### PR TITLE
V0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "homepage": "https://github.com/justeat/fozzie",
   "contributors": [
     "Ashley Nolan <ashley.nolan@just-eat.com> (https://ashleynolan.co.uk)",
@@ -27,7 +27,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "@justeat/fozzie-colour-palette": "^0.1.0",
+    "@justeat/fozzie-colour-palette": "^0.2.0",
     "@justeat/gulp-build-fozzie": "^2.0.0",
     "@kickoff/utils.scss": "^2.1.1",
     "babel-preset-es2015": "^6.24.1",

--- a/src/scss/_dependencies.scss
+++ b/src/scss/_dependencies.scss
@@ -53,8 +53,10 @@
  *
  * Object styles should be prefixed with `.o-`
  */
-// @import 'objects/…';
+@import 'objects/images';
 @import 'objects/links';
+@import 'objects/lists';
+@import 'objects/tables';
 
 /**
  * Components:
@@ -63,7 +65,7 @@
  *
  * This is where the majority of our day-to-day styling will take place.  Component styles should be prefixed with `.c-`
  */
-// @import 'components/…';
+@import 'components/cards.scss';
 
 
 // Global layout definitions & helpers

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -28,6 +28,7 @@ body {
     @include font-size(base, false);
     line-height: $leading-base;
     color: $color-text;
+    font-weight: $font-weight-base;
 
     text-rendering: optimizelegibility;
     -webkit-font-smoothing: antialiased;

--- a/src/scss/components/cards.scss
+++ b/src/scss/components/cards.scss
@@ -4,7 +4,7 @@
  * Used for content listing cards
  *
  * Documentation:
- * https://pages.github.je-labs.com/ICP/app_consumerweb/styleguide/js-components/address-lookup
+ * TBC
  */
 
 $card-bgColor--active           : $white !default;

--- a/src/scss/components/cards.scss
+++ b/src/scss/components/cards.scss
@@ -1,0 +1,37 @@
+/**
+ * Card Component
+ * =================================
+ * Used for content listing cards
+ *
+ * Documentation:
+ * https://pages.github.je-labs.com/ICP/app_consumerweb/styleguide/js-components/address-lookup
+ */
+
+$card-bgColor--active           : $white !default;
+$card-tooltip-width             : 10px !default;
+$card-arrow-bottom-position     : 0 !default;
+$card-padding                   : spacing(x2) !default;
+$card-radius                    : 4px !default;
+
+@mixin card() {
+
+    .card {
+        background-color: $card-bgColor--active;
+        margin-bottom: spacing();
+        padding: $card-padding;
+
+        @include media('>=mid') {
+            margin-bottom: 0;
+        }
+    }
+
+        .card--noPad {
+            padding: 0;
+        }
+
+        .card--rounded {
+            border-radius: $card-radius;
+        }
+
+}
+

--- a/src/scss/objects/_lists.scss
+++ b/src/scss/objects/_lists.scss
@@ -2,3 +2,9 @@
  * Objects > Lists
  * =================================
  */
+
+ul,
+ol {
+    padding: 0;
+    margin: spacing(x2) 0 0 spacing(x2);
+}

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -49,6 +49,7 @@ $type: (
     )
 );
 
+$font-weight-base           : 300;
 $font-weight-bold           : 500;
 $font-weight-headings       : 500; // instead of browser default, bold
 $line-height-headings       : 1.2;

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,9 +25,9 @@
   dependencies:
     eslint-config-airbnb-base "^11.2.0"
 
-"@justeat/fozzie-colour-palette@^0.1.0":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-0.1.1.tgz#3bffa3f1e86faba69b921c10d00d2e97bbf8cf37"
+"@justeat/fozzie-colour-palette@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-0.2.0.tgz#1f06bea8c7bb5ce82467fa690d2e93e2c933cc66"
   dependencies:
     "@justeat/gulp-build-fozzie" "^1.4.0"
 


### PR DESCRIPTION
- Updating body copy to #535353 as in brand, and lighter font variant
- Lists now have proper spacing by default added to them
- Optional base component `cards.scss` added