### PR TITLE
v0.10.0 – Content classes updated, jumbo text line-height, and custom bullets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.10.0
+------------------------------
+*August 25, 2017*
+
+### Added
+- Custom bullets on unordered lists.
+- `u-bordered` class for adding a border around a block.
+- Added narrow view type sizes for headings
+
+
+### Changed
+- Updated line-height for jumbo homepage text.
+- Updated the `l-content` class so that it can contain a `header` and `main` that are appropriately spaced for content pages.
+- Updated packages
+
+
 v0.9.0
 ------------------------------
 *August 24, 2017*

--- a/_build/config.js
+++ b/_build/config.js
@@ -4,6 +4,10 @@ const distDir = 'dist';
 
 module.exports = {
     js: {
-        srcFile: 'fozzie.js'
+        files: {
+            main: {
+                srcFile: 'fozzie.js'
+            }
+        }
     }
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "homepage": "https://github.com/justeat/fozzie",
   "contributors": [
     "Ashley Nolan <ashley.nolan@just-eat.com> (https://ashleynolan.co.uk)",
@@ -27,8 +27,8 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "@justeat/fozzie-colour-palette": "^0.4.0",
-    "@justeat/gulp-build-fozzie": "^4.2.0",
+    "@justeat/fozzie-colour-palette": "^0.6.0",
+    "@justeat/gulp-build-fozzie": "^5.5.2",
     "@kickoff/utils.scss": "^2.1.1",
     "babel-preset-es2015": "^6.24.1",
     "gulp": "^3.9.1",

--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -29,8 +29,38 @@ body {
 }
 
 /**
- * Modifier for page containers that contain solely content (such as T&cs and Privacy pages)
+ * Layout class for containers that contain content (such as T&cs and Privacy pages)
  */
-.l-container--content {
-    padding-top: spacing(x4);
+.l-content {
+    padding-top: spacing(x2);
+
+    @include media('>mid') {
+        padding-top: spacing(x4);
+    }
 }
+    .l-content-header {
+        margin: 0 0 spacing(x2);
+
+        @include media('>mid') {
+            margin: spacing(x2) 0 spacing(x4);
+        }
+
+        > h1 {
+            @include font-size(jumbo--scaleUp, true, narrow);
+
+            @include media('>mid') {
+                @include font-size(jumbo--scaleUp);
+            }
+        }
+    }
+        .l-content-header--centred {
+            text-align: center;
+        }
+        .l-content-header--highlight {
+            color: $color-headings--highlight;
+        }
+
+    .l-content-main {
+        @extend %u-bordered;
+    }
+

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -67,9 +67,13 @@ h6 {
 // For example: h3.h1 or h3.alpha
 h1,
 .alpha {
-    @include font-size(jumbo);
+    @include font-size(jumbo, true, narrow);
     margin-top: $baseline * 2;
     margin-bottom: $baseline;
+
+    @include media('>mid') {
+        @include font-size(jumbo);
+    }
 
     &:first-child {
         margin-top: 0;
@@ -78,7 +82,11 @@ h1,
 
 h2,
 .beta {
-    @include font-size(large);
+    @include font-size(large, true, narrow);
+
+    @include media('>mid') {
+        @include font-size(large);
+    }
 }
 
 h3,

--- a/src/scss/objects/_lists.scss
+++ b/src/scss/objects/_lists.scss
@@ -12,3 +12,18 @@ ol {
         margin-bottom: spacing();
     }
 }
+
+ul {
+    margin-left: 0;
+    list-style: none;
+
+    // Adds a coloured circle before list-items
+    li:before {
+        color: $red;
+        content: "\2022"; /* Unicode for circle character */
+        font-size: 1.8em;
+        padding-right: spacing();
+        position: relative;
+        top: 0.15em;
+    }
+}

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -42,8 +42,8 @@ $type: (
         narrow: (18, 24)
     ),
     jumbo--scaleUp: (
-        default: (64, 50),
-        narrow: (36, 42)
+        default: (64, 72),
+        narrow: (28, 32)
     )
 );
 

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -25,6 +25,13 @@
     background-color: $white;
 }
 
+.u-bordered,
+%u-bordered {
+    border: 1px solid $color-border;
+    padding: spacing(x3);
+    border-radius: $border-radius;
+}
+
 
 //
 // Display Utilities
@@ -131,5 +138,9 @@
 
     & > li {
         margin-bottom: 0;
+
+        &:before {
+            content: none;
+        }
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,17 +25,28 @@
   dependencies:
     eslint-config-airbnb-base "^11.2.0"
 
-"@justeat/fozzie-colour-palette@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-0.4.0.tgz#456501cb099c69b2c92a64c82ef68fbd07976fb0"
+"@justeat/f-copy-assets@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-copy-assets/-/f-copy-assets-0.3.0.tgz#dbdda754423874dea3b0c50776a1219518bd44e8"
   dependencies:
-    "@justeat/gulp-build-fozzie" "^4.2.0"
+    "@justeat/gulp-build-fozzie" "^5.4.0"
+    babel-preset-es2015 "^6.24.1"
+    fs "^0.0.1-security"
+    glob "^7.1.2"
+    mkdirp "^0.5.1"
 
-"@justeat/gulp-build-fozzie@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@justeat/gulp-build-fozzie/-/gulp-build-fozzie-4.2.0.tgz#b8d2cc7260aebe65b1193ea968fc1899c19f7c48"
+"@justeat/fozzie-colour-palette@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-0.6.0.tgz#ab4466ca0648a42a8903420a6ceb0643dbd1ff1b"
+  dependencies:
+    "@justeat/gulp-build-fozzie" "^5.3.1"
+
+"@justeat/gulp-build-fozzie@^5.3.1", "@justeat/gulp-build-fozzie@^5.4.0", "@justeat/gulp-build-fozzie@^5.5.2":
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/@justeat/gulp-build-fozzie/-/gulp-build-fozzie-5.5.2.tgz#a7b7f4a944d60fb00f272f3ba41bae82c46d8dcd"
   dependencies:
     "@justeat/eslint-config-fozzie" "^1.2.0"
+    "@justeat/f-copy-assets" "^0.3.0"
     "@justeat/stylelint-config-fozzie" "^1.1.0"
     assemble "^0.24.3"
     autoprefixer "^7.1.2"
@@ -47,16 +58,17 @@
     eslint "^4.3.0"
     eslint-plugin-import "^2.7.0"
     eslint-plugin-jest "^20.0.0"
+    event-stream "^3.3.4"
     exorcist "^0.4.0"
     eyeglass "^1.2.1"
     filesizegzip "^2.0.0"
     gulp "^3.9.1"
     gulp-cached "^1.1.1"
     gulp-changed "^3.1.0"
-    gulp-debug "^3.1.0"
     gulp-eslint "^4.0.0"
     gulp-extname "^0.2.2"
     gulp-filenames "^4.0.1"
+    gulp-gh-pages "^0.5.4"
     gulp-if "^2.0.2"
     gulp-imagemin "^3.2.0"
     gulp-newer "^1.3.0"
@@ -3500,6 +3512,10 @@ es6-iterator@2, es6-iterator@^2.0.1:
     es5-ext "^0.10.14"
     es6-symbol "^3.1"
 
+es6-promise@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-2.3.0.tgz#96edb9f2fdb01995822b263dd8aadab6748181bc"
+
 es6-promise@^4.0.5:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
@@ -3674,6 +3690,18 @@ event-emitter@^0.3.4:
   dependencies:
     d "1"
     es5-ext "~0.10.14"
+
+event-stream@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
+  dependencies:
+    duplexer "~0.1.1"
+    from "~0"
+    map-stream "~0.1.0"
+    pause-stream "0.0.11"
+    split "0.3"
+    stream-combiner "~0.0.4"
+    through "~2.3.1"
 
 eventemitter3@1.x.x:
   version "1.2.0"
@@ -4235,6 +4263,10 @@ fresh@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.3.0.tgz#651f838e22424e7566de161d8358caa199f83d4f"
 
+from@~0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
+
 fs-exists-sync@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
@@ -4260,6 +4292,10 @@ fs-extra@^0.30.0:
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+fs@^0.0.1-security:
+  version "0.0.1-security"
+  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
 
 fsevents@^1.0.0:
   version "1.1.2"
@@ -4329,10 +4365,6 @@ get-object@^0.2.0:
     is-number "^2.0.2"
     isobject "^0.2.0"
 
-get-own-enumerable-property-symbols@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-1.0.1.tgz#f1d4e3ad1402e039898e56d1e9b9aa924c26e484"
-
 get-proxy@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/get-proxy/-/get-proxy-1.1.0.tgz#894854491bc591b0f147d7ae570f5c678b7256eb"
@@ -4384,6 +4416,12 @@ gifsicle@^3.0.0:
     bin-build "^2.0.0"
     bin-wrapper "^3.0.0"
     logalot "^2.0.0"
+
+gift@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/gift/-/gift-0.6.1.tgz#c1698e6b6887164ed978a01095423cff65b8e79f"
+  dependencies:
+    underscore "1.x.x"
 
 git-config-path@^1.0.1:
   version "1.0.1"
@@ -4675,17 +4713,6 @@ gulp-changed@^3.1.0:
     pify "^2.3.0"
     through2 "^2.0.0"
 
-gulp-debug@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/gulp-debug/-/gulp-debug-3.1.0.tgz#4da91568b54915be803696caaac10c895b2c0a71"
-  dependencies:
-    chalk "^1.0.0"
-    gulp-util "^3.0.0"
-    plur "^2.0.0"
-    stringify-object "^3.0.0"
-    through2 "^2.0.0"
-    tildify "^1.1.2"
-
 gulp-decompress@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/gulp-decompress/-/gulp-decompress-1.2.0.tgz#8eeb65a5e015f8ed8532cafe28454960626f0dc7"
@@ -4715,6 +4742,17 @@ gulp-filenames@^4.0.1:
   dependencies:
     gulp-util ">=2.2.0"
     through2 "*"
+
+gulp-gh-pages@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/gulp-gh-pages/-/gulp-gh-pages-0.5.4.tgz#a6732ca475ab9b5a53253c1c24734c40c21b6546"
+  dependencies:
+    gift "^0.6.1"
+    gulp-util "^3.0.7"
+    readable-stream "^2.0.2"
+    rimraf "^2.4.3"
+    vinyl-fs "^2.2.1"
+    wrap-promise "^1.0.1"
 
 gulp-if@^2.0.2:
   version "2.0.2"
@@ -5694,7 +5732,7 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
-is-obj@^1.0.0, is-obj@^1.0.1:
+is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
@@ -7036,6 +7074,10 @@ map-schema@^0.2.3, map-schema@^0.2.4:
     sort-object-arrays "^0.1.1"
     union-value "^0.2.3"
 
+map-stream@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+
 map-visit@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-0.1.5.tgz#dbe43927ce5525b80dfc1573a44d68c51f26816b"
@@ -8059,6 +8101,12 @@ path-type@^2.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
   dependencies:
     pify "^2.0.0"
+
+pause-stream@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
+  dependencies:
+    through "~2.3"
 
 pbkdf2@^3.0.3:
   version "3.0.12"
@@ -9135,7 +9183,7 @@ right-align@^0.1.1, right-align@^0.1.3:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.6, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.2.6, rimraf@^2.2.8, rimraf@^2.4.3, rimraf@^2.5.1, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
@@ -9649,6 +9697,12 @@ split-string@^2.1.0:
   dependencies:
     extend-shallow "^2.0.1"
 
+split@0.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  dependencies:
+    through "2"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -9724,6 +9778,12 @@ stream-combiner@^0.2.2:
   dependencies:
     duplexer "~0.1.1"
     through "~2.3.4"
+
+stream-combiner@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
+  dependencies:
+    duplexer "~0.1.1"
 
 stream-consume@^0.1.0, stream-consume@~0.1.0:
   version "0.1.0"
@@ -9803,14 +9863,6 @@ string_decoder@~1.0.0, string_decoder@~1.0.3:
 stringify-author@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/stringify-author/-/stringify-author-0.1.3.tgz#d581e02ce0b55cda3c953e62add211fae4b0ef66"
-
-stringify-object@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.2.0.tgz#94370a135e41bc048358813bf99481f1315c6aa6"
-  dependencies:
-    get-own-enumerable-property-symbols "^1.0.1"
-    is-obj "^1.0.1"
-    is-regexp "^1.0.0"
 
 stringstream@~0.0.4:
   version "0.0.5"
@@ -10236,7 +10288,7 @@ through2@^0.6.0, through2@^0.6.1:
     readable-stream ">=1.0.33-1 <1.1.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
-"through@>=2.2.7 <3", through@^2.3.6, through@~2.3.4:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@~2.3, through@~2.3.1, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -10244,7 +10296,7 @@ through@~2.2.7:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/through/-/through-2.2.7.tgz#6e8e21200191d4eb6a99f6f010df46aa1c6eb2bd"
 
-tildify@^1.0.0, tildify@^1.1.2:
+tildify@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/tildify/-/tildify-1.2.0.tgz#dcec03f55dca9b7aa3e5b04f21817eb56e63588a"
   dependencies:
@@ -10473,7 +10525,7 @@ underscore.string@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.4.0.tgz#8cdd8fbac4e2d2ea1e7e2e8097c42f442280f85b"
 
-underscore@1.7.x, underscore@~1.7.0:
+underscore@1.7.x, underscore@1.x.x, underscore@~1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
 
@@ -10692,7 +10744,7 @@ vinyl-fs@^0.3.0:
     through2 "^0.6.1"
     vinyl "^0.4.0"
 
-vinyl-fs@^2.2.0, vinyl-fs@^2.4.4:
+vinyl-fs@^2.2.0, vinyl-fs@^2.2.1, vinyl-fs@^2.4.4:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/vinyl-fs/-/vinyl-fs-2.4.4.tgz#be6ff3270cb55dfd7d3063640de81f25d7532239"
   dependencies:
@@ -10916,6 +10968,12 @@ wrap-fn@^0.1.0:
   resolved "https://registry.yarnpkg.com/wrap-fn/-/wrap-fn-0.1.5.tgz#f21b6e41016ff4a7e31720dbc63a09016bdf9845"
   dependencies:
     co "3.1.0"
+
+wrap-promise@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wrap-promise/-/wrap-promise-1.0.1.tgz#b019f4236ccbf1fb560921b4b4870b7bda2f5255"
+  dependencies:
+    es6-promise "^2.3.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
### Added
- Custom bullets on unordered lists.
- `u-bordered` class for adding a border around a block.
- Added narrow view type sizes for headings


### Changed
- Updated line-height for jumbo homepage text.
- Updated the `l-content` class so that it can contain a `header` and `main` that are appropriately spaced for content pages.
- Updated packages