### PR TITLE
v0.17.0 - focus state added to fozzie defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.17.0
+------------------------------
+*October 20, 2017*
+
+### Changed
+- `:focus` state added (controlled via colour palette variable).
+
+
 v0.16.0
 ------------------------------
 *October 18, 2017*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "files": [
     "src"
   ],
@@ -30,7 +30,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "@justeat/fozzie-colour-palette": "^0.7.0",
+    "@justeat/fozzie-colour-palette": "^0.8.0",
     "@kickoff/utils.scss": "^2.1.1",
     "include-media": "^1.4.9",
     "kickoff-grid.css": "^1.1.2",

--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -7,6 +7,13 @@ body {
     background-color: $color-bg;
 }
 
+/*
+* By default we want to give focus styling to all elements that are focusable.
+*/
+:focus {
+    @extend %u-elementFocus;
+}
+
 /**
  * Default layout container
  */

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -144,3 +144,13 @@
         }
     }
 }
+
+//
+// Helper classes for focus accessibility
+// =================================================================================
+
+/* Custom outline styling for elements that have a focus state */
+%u-elementFocus,
+.u-elementFocus {
+    outline: 3px auto $color-focus-outline;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,9 +32,9 @@
     glob "^7.1.2"
     mkdirp "^0.5.1"
 
-"@justeat/fozzie-colour-palette@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-0.7.0.tgz#c05d85f4bc9602db7f322191871ad52119652c53"
+"@justeat/fozzie-colour-palette@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-0.8.0.tgz#76471f1ea0357ac8515620433b0dd06c90815b26"
 
 "@justeat/gulp-build-fozzie@^6.3.0":
   version "6.3.0"


### PR DESCRIPTION
### Changed
- `:focus` state added (controlled via colour palette variable).