### PR TITLE
v0.17.1 - Updating focus styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.17.1
+------------------------------
+*October 24, 2017*
+
+### Changed
+- `:focus` state updated to be `2px solid` rather than `3px auto` by default.
+
+
 v0.17.0
 ------------------------------
 *October 20, 2017*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "files": [
     "src"
   ],

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -152,5 +152,5 @@
 /* Custom outline styling for elements that have a focus state */
 %u-elementFocus,
 .u-elementFocus {
-    outline: 3px auto $color-focus-outline;
+    outline: 2px solid $color-focus-outline;
 }


### PR DESCRIPTION
### Changed
- `:focus` state updated to be `2px solid` rather than `3px auto` by default.