### PR TITLE
Focus outline emulation using box-shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.18.4
+  ------------------------------
+ *November 6, 2017*
+ 
+ ### Added
+ - `u-elementFocus--boxShadow` utility class is added.
+
 
 v0.18.3
   ------------------------------

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "files": [
     "src"
   ],

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -160,3 +160,10 @@
 .u-elementFocus {
     outline: 2px solid $color-focus-outline;
 }
+
+/* Custom visual outline emulation for better appearance on elements with rounded corners */
+%u-elementFocus--boxShadow,
+.u-elementFocus--boxShadow {
+  outline: none;
+  box-shadow: 0 0 0 2px $color-focus-outline;
+}


### PR DESCRIPTION
Looks better than default outline on elements with rounded corners