### PR TITLE
CPD-10667 Fixed o-btnLink's background-color for different statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.23.1
+------------------------------
+*January 31, 2018*
+
+### Changed
+- Fixed o-btnLink's background-color for different statuses
+
 v0.23.0
 ------------------------------
 *January 29, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "files": [
     "src"
   ],

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -567,10 +567,12 @@ input[type='button'] {
 
     &:hover {
         color: $color-link-hover;
+        background-color: transparent;
     }
     &:active,
     &:focus {
         color: $color-link-active;
+        background-color: transparent;
     }
 }
 


### PR DESCRIPTION
Fixed o-btnLink's background-color for different statuses

It was putting grey background on hover:
![image](https://user-images.githubusercontent.com/1676440/35623954-566370c4-0685-11e8-89ec-3e938e04d795.png)
