### PR TITLE
Update to replace css inlined svgs that are breaking build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v0.27.0
+v0.28.0
 ------------------------------
 *February 14, 2018*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.27.0
 ------------------------------
+*February 14, 2018*
+
+### Fixed
+- Inline svg for breadcrumbs breaking build. Now uses separate svg icon.
+
+
+v0.27.0
+------------------------------
 *February 9, 2018*
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "files": [
     "src"
   ],

--- a/src/scss/components/_breadcrumbs.scss
+++ b/src/scss/components/_breadcrumbs.scss
@@ -7,11 +7,6 @@
 
 $breadcrumb-font-weight : $font-weight-bold !default;
 
-//pixel size of the breadcrumb chevron
-$breadcrumb-chevron-height : 6px;
-$breadcrumb-chevron-width : 10px;
-$breadcrumb-chevron-point-right : -90deg;
-
 .c-breadcrumb {
     width: 100%;
     @include font-size(mid, false);
@@ -32,23 +27,12 @@ $breadcrumb-chevron-point-right : -90deg;
     color: $grey--darkest;
     font-weight: $breadcrumb-font-weight;
 
-    //positioning for rotated chevron in :after
-    position: relative;
-    margin-right: $breadcrumb-chevron-height * 4;
-
-    &:after {
-        content: ' ';
-        position: absolute;
-        top: 50%;
-        right: -$breadcrumb-chevron-height * 3;
-        width: $breadcrumb-chevron-width;
-        height: $breadcrumb-chevron-height;
-        background: inline('#{$icon-path}/arrows/chevron.svg') no-repeat;
-        transform: translateY(-2px) rotate($breadcrumb-chevron-point-right); // -2px is an aesthetic alignment for the chevron icon  
-    }
-
     &:hover {
         text-decoration: underline;
         color: $grey--dark;
     }
+}
+
+.c-breadcrumb-item-icon {
+    margin: 0 spacing(base);
 }


### PR DESCRIPTION
Update to replace css 'inlined' svgs with svg icons for the breadcrumb component.