### PR TITLE
v0.37.0 - Fix applied to table border style.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.37.0
+------------------------------
+*March 16, 2018*
+
+### Fixed
+- Table border style flipped to fix rowspan columns.
+
 v0.36.0
 ------------------------------
 *March 12, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/objects/_tables.scss
+++ b/src/scss/objects/_tables.scss
@@ -44,7 +44,7 @@ table,
             padding: $table-cell-padding;
             line-height: $line-height-base;
             vertical-align: top;
-            border-left: 1px solid $table-verticalBorder--color;
+            border-right: 1px solid $table-verticalBorder--color;
         }
         th {
             text-align: left;
@@ -60,8 +60,8 @@ table,
             }
         }
         td {
-            &:first-child {
-                border-left: none;
+            &:last-child {
+                border-right: none;
             }
         }
     }


### PR DESCRIPTION
The problem happens when the first TD contains something like `<td rowspan="8">` which then causes the border to be missing on the rows below it because it treats the remaining TDs as a first-child. I've reversed the border to fix this issue.

### Before:

![screen shot 2018-03-16 at 11 15 56 am](https://user-images.githubusercontent.com/2299779/37517871-c3f7761a-290a-11e8-8998-f8f41403088a.png)

### After:

![screen shot 2018-03-16 at 11 15 40 am](https://user-images.githubusercontent.com/2299779/37517875-c8d5a486-290a-11e8-8af2-30f865d9e4b0.png)
