### PR TITLE
v0.41.1 - Bring back the focus outline for the footer country selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v0.41.1
+------------------------------
+*April 25, 2018*
+
+### Added
+- Focus outline to buttons with the class `o-btnLink`.
+
+
 v0.41.0
 ------------------------------
 *April 20, 2018*
@@ -10,12 +19,14 @@ v0.41.0
 ### Fixed
 - Button font size rendered larger due to v0.38.0 release so fix applied here.
 
+
 v0.40.0
 ------------------------------
 *April 19, 2018*
 
 ### Added
 - Enhanced `c-alert` component styling
+
 
 v0.39.0
 ------------------------------
@@ -26,12 +37,14 @@ v0.39.0
 - Non selectable star ratings
 - Mixin to generate fill classes for ratings
 
+
 v0.38.0
 ------------------------------
 *April 10, 2018*
 
 ### Changed
 - Font size variable map updated.
+
 
 v0.37.0
 ------------------------------
@@ -40,12 +53,14 @@ v0.37.0
 ### Fixed
 - Table border style flipped to fix rowspan columns.
 
+
 v0.36.0
 ------------------------------
 *March 12, 2018*
 
 ### Fixed
 - Removed unnecessary *$* infront of zIndex variable.
+
 
 v0.35.0
 ------------------------------
@@ -322,7 +337,6 @@ v0.15.0
 
 ### Removed
 - Removed icons SCSS partial — now using SCSS from `f-icons` module.
-
 
 
 v0.14.0

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -99,8 +99,10 @@ $btn-rounded-width: 38px !default;
     &:hover,
     &:active,
     &:focus {
-        background-color: $btn-default-bgColor--highlight;
-        outline: none; // no need as already has a focus/active state
+        &:not(.o-btnLink) {
+            background-color: $btn-default-bgColor--highlight;
+            outline: none; // no need as already has a focus/active state
+        }
     }
 
     &,


### PR DESCRIPTION
Changing the country selector from a link to a button disabled the outline on focus. This adds is back to make it more obvious, rather than just the hard-to-spot grey -> blue text colour change.

(And fix whitespace in changelog)