### PR TITLE
v0.51.2 - update to item listing meta margin for better screen reader…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v0.51.2
+------------------------------
+*July 25, 2018*
+
+### Changed
+ - Remove of margin top on listing item meta block to change to a <p> for better screen reader experience
+
 v0.51.1
 ------------------------------
 *July 23, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.51.1",
+  "version": "0.51.2",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_listings.scss
+++ b/src/scss/components/_listings.scss
@@ -152,6 +152,7 @@ $listing-borderRadius       : 4px;
         .c-listing-item-meta {
             top: -3px;
             float: right;
+            margin-top: 0;
             position: relative;
 
             @include media('>wide') {


### PR DESCRIPTION
_update to item listing meta margin for better screen reader experience_

<img width="300" alt="screen shot 2018-07-25 at 09 39 41" src="https://user-images.githubusercontent.com/5295718/43189598-d6242c66-8fee-11e8-90c8-9df363f50d11.png">

- [x] This PR has been checked with regard to our brand guidelines
- [x] UI Documentation has been [created|updated]

