### PR TITLE
v0.52.0 - addition of subtitle styles to content header. update of fo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
-v0.51.3
+v0.52.0
 ------------------------------
 *July 27, 2018*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v0.51.3
+------------------------------
+*July 25, 2018*
+
+### Changed
+ - Update of font styles to content header
+ - Addition of subTitle styles to content header
+
+
 v0.51.2
 ------------------------------
 *July 25, 2018*
@@ -10,12 +19,14 @@ v0.51.2
 ### Changed
  - Remove of margin top on listing item meta block to change to a <p> for better screen reader experience
 
+
 v0.51.1
 ------------------------------
 *July 23, 2018*
 
 ### Fixed
  - A minor layout fix for the form toggle control
+
 
 v0.51.0
 ------------------------------
@@ -29,6 +40,7 @@ v0.51.0
 
 ### Changed
 - Addition of JS toggle classes (`active`, `inactive`) to listing component
+
 
 v0.50.1
 ------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.51.3
 ------------------------------
-*July 25, 2018*
+*July 27, 2018*
 
 ### Changed
  - Update of font styles to content header

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.51.2",
+  "version": "0.51.3",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_content-header.scss
+++ b/src/scss/components/_content-header.scss
@@ -7,19 +7,39 @@
 
 .c-contentHeader {
     padding-top: spacing(x2);
-    padding-bottom: spacing(x2);
+    padding-bottom: spacing();
 }
 
 .c-contentHeader-title {
     padding: 0;
     display: inline-block;
     margin: 0 spacing(x2) 0 0;
+    font-weight: $font-weight-base;
+    font-family: $font-family-headings;
+    @include font-size(base--scaleUp, false);
+}
+
+.c-contentHeader-subTitle {
+    display: block;
+    margin-top: 4px;
+    @include font-size(base, false);
+
+    @include media('>mid') {
+        display: inline-block;
+    }
+}
+
+.c-contentHeader-title,
+.c-contentHeader-subTitle {
+    @include media('>=mid') {
+        @include font-size(jumbo, false);
+    }
 }
 
 .c-contentHeader-link {
     display: block;
     text-decoration: none;
-    font-weight: $font-weight-bold;
+    font-weight: $font-weight-base;
 
     &:hover,
     &:focus {

--- a/src/scss/components/_content-header.scss
+++ b/src/scss/components/_content-header.scss
@@ -15,7 +15,6 @@
     display: inline-block;
     margin: 0 spacing(x2) 0 0;
     font-weight: $font-weight-base;
-    font-family: $font-family-headings;
     @include font-size(base--scaleUp, false);
 }
 


### PR DESCRIPTION
_Content header style updates._

![screen shot 2018-07-26 at 16 27 54](https://user-images.githubusercontent.com/5295718/43272024-ea715d62-90f0-11e8-8f13-d01cb97bba24.png)
![screen shot 2018-07-26 at 16 28 01](https://user-images.githubusercontent.com/5295718/43272025-ea878b28-90f0-11e8-9914-60c471c4e7c7.png)

- Addition of content header subTitle styles
- Update to content header font styles

## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines

## Browsers Tested

- [x] Chrome
- [x] Mobile (i.e. iPhone/Android - please list device)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
