### PR TITLE
v0.53.0 – Addition of form toggle disabled state and touch area size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.53.0
 ------------------------------
-*August 1, 2018*
+*August 2, 2018*
 
 ### Added
  - addition of .o-formToggle--disabled state styles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ v0.53.0
 *August 1, 2018*
 
 ### Changed
- - height unit on fullScreenOverlay
  - addition of .o-formToggle--disabled state styles
  - addition of form toggle inline spacing to give 44px touch area
  - addition of cursor pointer of form toggle hover
+
+### Fixed
+ - height unit on fullScreenOverlay from vh to % as Android didnt take into account browser bars making 100vh larger than 100%
 
 
 v0.52.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ v0.53.0
 ------------------------------
 *August 1, 2018*
 
-### Changed
+### Added
  - addition of .o-formToggle--disabled state styles
  - addition of form toggle inline spacing to give 44px touch area
  - addition of cursor pointer of form toggle hover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ v0.53.0
 
 ### Changed
  - height unit on fullScreenOverlay
+ - addition of .o-formToggle--disabled state styles
+ - addition of form toggle inline spacing to give 44px touch area
 
 
 v0.52.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ v0.53.0
  - height unit on fullScreenOverlay
  - addition of .o-formToggle--disabled state styles
  - addition of form toggle inline spacing to give 44px touch area
+ - addition of cursor pointer of form toggle hover
 
 
 v0.52.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.53.0
 ------------------------------
-*July 31, 2018*
+*August 1, 2018*
 
 ### Changed
  - height unit on fullScreenOverlay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v0.53.0
+------------------------------
+*July 31, 2018*
+
+### Changed
+ - height unit on fullScreenOverlay
+
+
 v0.52.0
 ------------------------------
 *July 27, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_fullscreen-pop-over.scss
+++ b/src/scss/components/_fullscreen-pop-over.scss
@@ -27,7 +27,7 @@ $fullScreenPopOver-shadow-color     : rgba($black, 0.12);
         &.is-active {
             top: 0;
             opacity: 1;
-            height: 100vh;
+            height: 100%;
             overflow: visible;
             padding: 72px $fullScreenPopOver-padding 96px $fullScreenPopOver-padding;
         }

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -30,9 +30,6 @@ $formToggle-disabled-text           : $grey--lighter;
         background: $formToggle-background;
     }
 
-    &:hover {
-        cursor: pointer;
-    }
 }
 
     .o-formToggle--button {
@@ -144,6 +141,7 @@ $formToggle-disabled-text           : $grey--lighter;
         .o-formToggle-input:not([disabled]):hover ~ &,
         .o-formToggle-input:not([disabled]):focus ~ &,
         .o-formToggle-input:not([disabled]):checked ~ & {
+            cursor: pointer;
 
             //the &:after is to create a border that sits over the top of the parents,
             // it creates a visual state on the parent without the need for a JS class toggle

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -48,7 +48,7 @@ $formToggle-disabled-text           : $grey--lighter;
     }
 
     .o-formToggle--inline {
-        margin: spacing() 0 spacing() (spacing() / 2) ;
+        margin: spacing() 0 spacing() (spacing() / 2);
     }
 
     .o-formToggle--fullWidth {
@@ -118,7 +118,8 @@ $formToggle-disabled-text           : $grey--lighter;
             transition: transform 200ms ease, opacity 250ms ease;
         }
 
-        .o-formToggle-input:not([disabled]):not(:checked):hover ~ & {
+        .o-formToggle-input:not([disabled]):hover ~ &,
+        .o-formToggle-input:not(:checked):hover ~ & {
 
             &:before {
                 border-color: $formToggle-tick-hover-background;

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -19,10 +19,14 @@ $formToggle-button-background       : $blue--offWhite;
 .o-formToggle {
     position: relative;
     display: inline-block;
-    margin-bottom: spacing();
+    margin: 0 0 spacing() (spacing() / 2);
     border-radius: $formToggle-border-radius;
     padding: ($formToggle-padding / 2) $formToggle-padding;
     border: $formToggle-border-width solid $formToggle-border-color;
+
+    &:first-child {
+        margin-left: 0;
+    }
 
     @include media('>=mid') {
         background: $formToggle-background;

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -11,25 +11,27 @@ $formToggle-border-color-checked    : $grey--lighter;
 $formToggle-border-width            : 1px;
 $formToggle-border-radius           : 8px;
 $formToggle-tick-background         : $green;
+$formToggle-tick-hover-background   : $grey--lighter;
 $formToggle-background              : $white;
 $formToggle-large-size              : 48px;
 $formToggle-button-color            : $blue;
 $formToggle-button-background       : $blue--offWhite;
+$formToggle-disabled-text           : $grey--lighter;
 
 .o-formToggle {
     position: relative;
     display: inline-block;
-    margin: 0 0 spacing() (spacing() / 2);
+    margin-bottom: spacing();
     border-radius: $formToggle-border-radius;
     padding: ($formToggle-padding / 2) $formToggle-padding;
     border: $formToggle-border-width solid $formToggle-border-color;
 
-    &:first-child {
-        margin-left: 0;
-    }
-
     @include media('>=mid') {
         background: $formToggle-background;
+    }
+
+    &:hover {
+        cursor: pointer;
     }
 }
 
@@ -46,6 +48,10 @@ $formToggle-button-background       : $blue--offWhite;
         left: $formToggle-padding;
         transform: translateY(-50%);
         fill: $formToggle-button-color;
+    }
+
+    .o-formToggle--inline {
+        margin: spacing() 0 spacing() (spacing() / 2) ;
     }
 
     .o-formToggle--fullWidth {
@@ -86,6 +92,7 @@ $formToggle-button-background       : $blue--offWhite;
 
         @include media('>=mid') {
             float: left;
+            margin: 0 0 spacing();
             @include formToggleLarge();
         }
     }
@@ -114,7 +121,15 @@ $formToggle-button-background       : $blue--offWhite;
             transition: transform 200ms ease, opacity 250ms ease;
         }
 
-        .o-formToggle-input:checked ~ & {
+        .o-formToggle-input:not([disabled]):not(:checked):hover ~ & {
+
+            &:before {
+                border-color: $formToggle-tick-hover-background;
+            }
+        }
+
+        .o-formToggle-input:checked ~ &,
+        .o-formToggle-input:not(:disabled):hover ~ & {
             padding-left: 20px;
             font-weight: $font-weight-bold;
 
@@ -124,11 +139,11 @@ $formToggle-button-background       : $blue--offWhite;
             }
         }
 
-        .o-formToggle:hover &,
-        .o-formToggle:focus &,
-        .o-formToggle-input:hover ~ &,
-        .o-formToggle-input:focus ~ &,
-        .o-formToggle-input:checked ~ & {
+        .o-formToggle:not(.o-formToggle--disabled):hover &,
+        .o-formToggle:not(.o-formToggle--disabled):focus &,
+        .o-formToggle-input:not([disabled]):hover ~ &,
+        .o-formToggle-input:not([disabled]):focus ~ &,
+        .o-formToggle-input:not([disabled]):checked ~ & {
 
             //the &:after is to create a border that sits over the top of the parents,
             // it creates a visual state on the parent without the need for a JS class toggle
@@ -167,4 +182,9 @@ $formToggle-button-background       : $blue--offWhite;
         position: absolute;
         right: spacing();
         transform: translateY(-50%);
+    }
+
+    .o-formToggle--disabled {
+        background: none;
+        color: $formToggle-disabled-text;
     }

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -10,8 +10,8 @@ $formToggle-border-color            : $grey--lightest;
 $formToggle-border-color-checked    : $grey--lighter;
 $formToggle-border-width            : 1px;
 $formToggle-border-radius           : 8px;
-$formToggle-tick-background         : $green;
-$formToggle-tick-hover-background   : $grey--lighter;
+$formToggle-icon-background         : $green;
+$formToggle-icon-hover-background   : $grey--lighter;
 $formToggle-background              : $white;
 $formToggle-large-size              : 48px;
 $formToggle-button-color            : $blue;
@@ -47,7 +47,8 @@ $formToggle-disabled-text           : $grey--lighter;
         fill: $formToggle-button-color;
     }
 
-    .o-formToggle--inline {
+    //Used alongside the default styles but for a larger tap area (min 44px)
+    .o-formToggle--largeTouchArea {
         margin: spacing() 0 spacing() (spacing() / 2);
     }
 
@@ -113,8 +114,8 @@ $formToggle-disabled-text           : $grey--lighter;
             left: spacing();
             display: inline-block;
             transform: rotate(-45deg) scale(0.5);
-            border-left: 1px solid $formToggle-tick-background;
-            border-bottom: 1px solid $formToggle-tick-background;
+            border-left: 1px solid $formToggle-icon-background;
+            border-bottom: 1px solid $formToggle-icon-background;
             transition: transform 200ms ease, opacity 250ms ease;
         }
 
@@ -122,7 +123,7 @@ $formToggle-disabled-text           : $grey--lighter;
         .o-formToggle-input:not(:checked):hover ~ & {
 
             &:before {
-                border-color: $formToggle-tick-hover-background;
+                border-color: $formToggle-icon-hover-background;
             }
         }
 


### PR DESCRIPTION
_Addition of form toggle disabled state and touch area size._

 - height unit on fullScreenOverlay
 - addition of .o-formToggle--disabled state styles
 - addition of form toggle inline spacing to give 44px touch area
 - addition of cursor pointer of form toggle hover

<img width="314" alt="screen shot 2018-08-01 at 15 03 08" src="https://user-images.githubusercontent.com/5295718/43526392-0b97f7ee-959c-11e8-8435-e5b5ae4d57b8.png">



- [x] This PR has been checked with regard to our brand guidelines
- [x] UI Documentation has been [created|updated]