### PR TITLE
v0.54.0 – Form reset module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v0.54.0
+------------------------------
+*August 9, 2018*
+
+### Added
+ - addition of form reset javascript module and associated unit tests
+
 v0.53.1
 ------------------------------
 *August 2, 2018*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.54.0
 ------------------------------
-*August 9, 2018*
+*August 13, 2018*
 
 ### Added
- - addition of form reset javascript module and associated unit tests
+ - Addition of form reset javascript module and associated unit tests
 
 v0.53.1
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.53.1",
+  "version": "0.54.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,7 +1,9 @@
 // All helper functions will be imported here, so that they can all be exported within one object.
 import { getBreakpoints, getCurrentScreenWidth } from './modules/breakpointHelper';
+import formReset from './modules/formReset';
 
 export {
+    formReset,
     getBreakpoints,
     getCurrentScreenWidth
 };

--- a/src/js/modules/formReset/index.js
+++ b/src/js/modules/formReset/index.js
@@ -1,0 +1,46 @@
+import $ from '@justeat/f-dom';
+
+
+/**
+ * @overview JS form / input reset
+ *
+ * @module formReset
+ */
+
+/**
+* Reset inputs loops through all inputs in js reset group [data-js-reset="RESETGROUP"] and sets checked to false or value to "".
+*
+* @param {event} event
+*
+*/
+export const resetInputs = event => {
+    const el = event.target;
+    const formInputGroup = el.getAttribute('data-js-reset');
+    const formInputs = $(`[data-js-reset-input="${formInputGroup}"]`);
+
+    formInputs.forEach(input => {
+        if (input.checked) {
+            input.checked = false;
+            return;
+        }
+        if (input.value.length > 0) {
+            input.value = '';
+        }
+    });
+};
+
+/**
+ * Bind event will check for form reset buttons on the page and add event listeners to each
+ *
+ */
+export const init = () => {
+    const resetAction = $('[data-js-reset]');
+
+    if (resetAction.length > 0) {
+        resetAction.forEach(button => {
+            button.addEventListener('click', event => resetInputs(event));
+        });
+    }
+};
+
+export default init;

--- a/src/js/modules/formReset/test/index.test.js
+++ b/src/js/modules/formReset/test/index.test.js
@@ -7,7 +7,7 @@ describe('module init', () => {
         expect(typeof init).toBe('function');
     });
 
-    it('will not error if no [data-js-reset] is available', () => {
+    it('will check if a [data-js-reset] is available', () => {
         // Arrange
         TestUtils.setBodyHtml('');
 
@@ -19,42 +19,57 @@ describe('module init', () => {
         expect(button.length).toBe(0);
     });
 
-    it('will uncheck a radio buttons from from button trigger bound on init()', () => {
-        // Arrange
-        TestUtils.setBodyHtml(`
-            <a data-js-reset="testGroup"></a>
-            <input type="radio" data-js-reset-input="testGroup" checked/>
-        `);
+    describe('When multiple form elements are cleared', () => {
+        it('should uncheck a radio form element from button trigger bound on init', () => {
+            // Arrange
+            TestUtils.setBodyHtml(`
+                <a data-js-reset="testGroup"></a>
+                <input type="radio" data-js-reset-input="testGroup" checked/>
+            `);
+    
+            // Act
+            init();
+            const [button] = document.querySelectorAll('[data-js-reset]');
+            TestUtils.click(button);
+    
+            // Assert
+            const [radio] = document.querySelectorAll('[data-js-reset-input]');
+            expect(radio.checked).toBe(false);
+        });
 
-        // Act
-        init();
-        const [button] = document.querySelectorAll('[data-js-reset]');
-        TestUtils.click(button);
+        it('should uncheck a checkbox form element from button trigger bound on init', () => {
+            // Arrange
+            TestUtils.setBodyHtml(`
+                <a data-js-reset="testGroup"></a>
+                <input type="checkbox" data-js-reset-input="testGroup" checked/>
+            `);
+    
+            // Act
+            init();
+            const [button] = document.querySelectorAll('[data-js-reset]');
+            TestUtils.click(button);
+    
+            // Assert
+            const [checkbox] = document.querySelectorAll('[data-js-reset-input]');
+            expect(checkbox.checked).toBe(false);
+        });
 
-        // Assert
-        const [radio] = document.querySelectorAll('[data-js-reset-input]');
-        expect(radio.checked).toBe(false);
-    });
-
-    it('will clear multiple form elements from button trigger bound on init()', () => {
-        // Arrange
-        TestUtils.setBodyHtml(`
-            <a data-js-reset="testGroup"></a>
-            <input type="radio" data-js-reset-input="testGroup" checked/>
-            <input type="checkbox" data-js-reset-input="testGroup" checked/>
-            <input type="text" data-js-reset-input="testGroup" value="testing is good for you" />
-        `);
-
-        // Act
-        init();
-        const [button] = document.querySelectorAll('[data-js-reset]');
-        TestUtils.click(button);
-
-        // Assert
-        const [radio, checkbox, input] = document.querySelectorAll('[data-js-reset-input]');
-        expect(radio.checked).toBe(false);
-        expect(checkbox.checked).toBe(false);
-        expect(input.value.length).toBe(0);
+        it('should uncheck a checkbox form element from button trigger bound on init', () => {
+            // Arrange
+            TestUtils.setBodyHtml(`
+                <a data-js-reset="testGroup"></a>
+                <input type="text" data-js-reset-input="testGroup" value="testing is good for you" />
+            `);
+    
+            // Act
+            init();
+            const [button] = document.querySelectorAll('[data-js-reset]');
+            TestUtils.click(button);
+    
+            // Assert
+            const [input] = document.querySelectorAll('[data-js-reset-input]');
+            expect(input.value.length).toBe(0);
+        });
     });
 });
 
@@ -123,27 +138,30 @@ describe('resetInputs', () => {
         expect(input.value.length).toBe(0);
     });
 
-    it('wont error if reset form button is clicked but no elements need resetting', () => {
-        // Arrange
-        TestUtils.setBodyHtml(`
-            <input type="text" data-js-reset-input="testGroup" value=""/>
-            <input type="radio" data-js-reset-input="testGroup" checked/>
-            <input type="checkbox" data-js-reset-input="testGroup" checked/>
-        `);
+    describe('When no form elements need to be reset and reset action is fired', () => {
 
-        const event = {
-            target: {
-                getAttribute:  () => 'testGroup'
-            }
-        };
+        it('should not adjust any form elements on the page', () => {
+            // Arrange
+            TestUtils.setBodyHtml(`
+                <input type="text" data-js-reset-input="testGroup" value=""/>
+                <input type="radio" data-js-reset-input="testGroup" checked/>
+                <input type="checkbox" data-js-reset-input="testGroup" checked/>
+            `);
 
-        // Act
-        resetInputs(event);
+            const event = {
+                target: {
+                    getAttribute:  () => 'testGroup'
+                }
+            };
 
-        // Assert
-        const [input, radio, checkbox] = document.querySelectorAll('[data-js-reset-input]');
-        expect(input.value.length).toBe(0);
-        expect(radio.checked).toBe(false);
-        expect(checkbox.checked).toBe(false);
+            // Act
+            resetInputs(event);
+
+            // Assert
+            const [input, radio, checkbox] = document.querySelectorAll('[data-js-reset-input]');
+            expect(input.value.length).toBe(0);
+            expect(radio.checked).toBe(false);
+            expect(checkbox.checked).toBe(false);
+        });
     });
 });

--- a/src/js/modules/formReset/test/index.test.js
+++ b/src/js/modules/formReset/test/index.test.js
@@ -9,13 +9,13 @@ describe('module init', () => {
 
     it('will not error if no [data-js-reset] is available', () => {
         // Arrange
-        TestUtils.setBodyHtml(``);
+        TestUtils.setBodyHtml('');
 
         // Act
         init();
         const button = $('[data-js-reset]');
-        
-        //Assert
+
+        // Assert
         expect(button.length).toBe(0);
     });
 

--- a/src/js/modules/formReset/test/index.test.js
+++ b/src/js/modules/formReset/test/index.test.js
@@ -1,0 +1,149 @@
+import $ from '@justeat/f-dom';
+import TestUtils from 'js-test-buddy';
+import { init, resetInputs } from '../index';
+
+describe('module init', () => {
+    it('is a function', () => {
+        expect(typeof init).toBe('function');
+    });
+
+    it('will not error if no [data-js-reset] is available', () => {
+        // Arrange
+        TestUtils.setBodyHtml(``);
+
+        // Act
+        init();
+        const button = $('[data-js-reset]');
+        
+        //Assert
+        expect(button.length).toBe(0);
+    });
+
+    it('will uncheck a radio buttons from from button trigger bound on init()', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+            <a data-js-reset="testGroup"></a>
+            <input type="radio" data-js-reset-input="testGroup" checked/>
+        `);
+
+        // Act
+        init();
+        const [button] = document.querySelectorAll('[data-js-reset]');
+        TestUtils.click(button);
+
+        // Assert
+        const [radio] = document.querySelectorAll('[data-js-reset-input]');
+        expect(radio.checked).toBe(false);
+    });
+
+    it('will clear multiple form elements from button trigger bound on init()', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+            <a data-js-reset="testGroup"></a>
+            <input type="radio" data-js-reset-input="testGroup" checked/>
+            <input type="checkbox" data-js-reset-input="testGroup" checked/>
+            <input type="text" data-js-reset-input="testGroup" value="testing is good for you" />
+        `);
+
+        // Act
+        init();
+        const [button] = document.querySelectorAll('[data-js-reset]');
+        TestUtils.click(button);
+
+        // Assert
+        const [radio, checkbox, input] = document.querySelectorAll('[data-js-reset-input]');
+        expect(radio.checked).toBe(false);
+        expect(checkbox.checked).toBe(false);
+        expect(input.value.length).toBe(0);
+    });
+});
+
+describe('resetInputs', () => {
+    it('is a function', () => {
+        expect(typeof resetInputs).toBe('function');
+    });
+
+    it('should uncheck a radio button', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+            <input type="radio" data-js-reset-input="testGroup" checked/>
+        `);
+
+        const event = {
+            target: {
+                getAttribute:  () => 'testGroup'
+            }
+        };
+
+        // Act
+        resetInputs(event);
+
+        // Assert
+        const [radio] = document.querySelectorAll('[data-js-reset-input]');
+        expect(radio.checked).toBe(false);
+    });
+
+    it('should uncheck a checkbox', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+            <input type="checkbox" data-js-reset-input="testGroup" checked/>
+        `);
+
+        const event = {
+            target: {
+                getAttribute:  () => 'testGroup'
+            }
+        };
+
+        // Act
+        resetInputs(event);
+
+        // Assert
+        const [checkbox] = document.querySelectorAll('[data-js-reset-input]');
+        expect(checkbox.checked).toBe(false);
+    });
+
+    it('should clear the value of a text input', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+            <input type="text" data-js-reset-input="testGroup" value="testing"/>
+        `);
+
+        const event = {
+            target: {
+                getAttribute:  () => 'testGroup'
+            }
+        };
+
+        // Act
+        resetInputs(event);
+
+        // Assert
+        const [input] = document.querySelectorAll('[data-js-reset-input]');
+        expect(input.value.length).toBe(0);
+    });
+
+    it('wont error if reset form button is clicked but no elements need resetting', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+            <input type="text" data-js-reset-input="testGroup" value=""/>
+            <input type="radio" data-js-reset-input="testGroup" checked/>
+            <input type="checkbox" data-js-reset-input="testGroup" checked/>
+        `);
+
+        const event = {
+            target: {
+                getAttribute:  () => 'testGroup'
+            }
+        };
+
+        // Act
+        resetInputs(event);
+
+        // Assert
+        const [input, radio, checkbox] = document.querySelectorAll('[data-js-reset-input]');
+        expect(input.value.length).toBe(0);
+        expect(radio.checked).toBe(false);
+        expect(checkbox.checked).toBe(false);
+    });
+});


### PR DESCRIPTION
_Fozzie form reset module (JS only)._


## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11


### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
