### PR TITLE
v0.53.2 - Fix formToggle states on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v0.53.2
+------------------------------
+*August 14, 2018*
+
+### Fixed
+ - Fixed formToggle hover state - Only checked state is applied to < mid. >=mid has hover and checked states.
+
 v0.53.1
 ------------------------------
 *August 2, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.53.1",
+  "version": "0.53.2",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -122,13 +122,15 @@ $formToggle-disabled-text           : $grey--lighter;
         .o-formToggle-input:not([disabled]):hover ~ &,
         .o-formToggle-input:not(:checked):hover ~ & {
 
-            &:before {
-                border-color: $formToggle-icon-hover-background;
+            @include media('>=mid') {
+
+                &:before {
+                    border-color: $formToggle-icon-hover-background;
+                }
             }
         }
 
-        .o-formToggle-input:checked ~ &,
-        .o-formToggle-input:not(:disabled):hover ~ & {
+        @mixin formToggleCheckedSpacing() {
             padding-left: 20px;
             font-weight: $font-weight-bold;
 
@@ -138,13 +140,19 @@ $formToggle-disabled-text           : $grey--lighter;
             }
         }
 
-        .o-formToggle:not(.o-formToggle--disabled):hover &,
-        .o-formToggle:not(.o-formToggle--disabled):focus &,
-        .o-formToggle-input:not([disabled]):hover ~ &,
-        .o-formToggle-input:not([disabled]):focus ~ &,
-        .o-formToggle-input:not([disabled]):checked ~ & {
-            cursor: pointer;
+        .o-formToggle-input:checked ~ & {
+            @include formToggleCheckedSpacing();
+        }
 
+        .o-formToggle-input:not(:disabled):hover ~ & {
+            @include media('>=mid') {
+
+                @include formToggleCheckedSpacing();
+            }
+        }
+
+        @mixin formToggleCheckedBoder() {
+            cursor: pointer;
             //the &:after is to create a border that sits over the top of the parents,
             // it creates a visual state on the parent without the need for a JS class toggle
             &:after {
@@ -156,6 +164,19 @@ $formToggle-disabled-text           : $grey--lighter;
                 height: calc(100% + 2px);
                 border-radius: $formToggle-border-radius;
                 border: $formToggle-border-width solid $formToggle-border-color-checked;
+            }
+        }
+
+        .o-formToggle-input:not([disabled]):checked ~ & {
+            @include formToggleCheckedBoder();
+        }
+
+        .o-formToggle:not(.o-formToggle--disabled):hover &,
+        .o-formToggle:not(.o-formToggle--disabled):focus &,
+        .o-formToggle-input:not([disabled]):hover ~ &,
+        .o-formToggle-input:not([disabled]):focus ~ & {
+            @include media('>=mid') {
+                @include formToggleCheckedBoder();
             }
         }
 

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -151,7 +151,7 @@ $formToggle-disabled-text           : $grey--lighter;
             }
         }
 
-        @mixin formToggleCheckedBoder() {
+        @mixin formToggleCheckedBorder() {
             cursor: pointer;
             //the &:after is to create a border that sits over the top of the parents,
             // it creates a visual state on the parent without the need for a JS class toggle
@@ -168,7 +168,7 @@ $formToggle-disabled-text           : $grey--lighter;
         }
 
         .o-formToggle-input:not([disabled]):checked ~ & {
-            @include formToggleCheckedBoder();
+            @include formToggleCheckedBorder();
         }
 
         .o-formToggle:not(.o-formToggle--disabled):hover &,
@@ -176,7 +176,7 @@ $formToggle-disabled-text           : $grey--lighter;
         .o-formToggle-input:not([disabled]):hover ~ &,
         .o-formToggle-input:not([disabled]):focus ~ & {
             @include media('>=mid') {
-                @include formToggleCheckedBoder();
+                @include formToggleCheckedBorder();
             }
         }
 


### PR DESCRIPTION
_Fix formToggle hover states._

On mobile hover state would hang when checking a checkbox. Design asked for hover state to only apply when >=mid.

before (Hover/checked mobile):
<img width="92" alt="screen shot 2018-08-14 at 16 24 21" src="https://user-images.githubusercontent.com/5295718/44101160-b4dc3616-9fde-11e8-97c0-d9d94957312e.png">

After checked:
<img width="100" alt="screen shot 2018-08-14 at 16 26 12" src="https://user-images.githubusercontent.com/5295718/44101198-c97a3ce4-9fde-11e8-9c22-c1b7b66066a3.png">

## UI Review Checks


- [x] This PR has been checked with regard to our brand guidelines
- [x] UI Documentation has been [created|updated]
## Browsers Tested

- [x] Chrome
- [x] Mobile