### PR TITLE
v0.53.3 - fullscreen popover background colour fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,21 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v0.53.3
+------------------------------
+*August 15, 2018*
+
+### Fixed
+ - Fullscreen popover background to grey--offWhite instead of white.
+ - Fullscreen popover header/footer background colour set to white due to popover background colour change
+
 v0.53.2
 ------------------------------
 *August 14, 2018*
 
 ### Fixed
  - Fixed formToggle hover state - Only checked state is applied to < mid. >=mid has hover and checked states.
+
 
 v0.53.1
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.53.2",
+  "version": "0.53.3",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_fullscreen-pop-over.scss
+++ b/src/scss/components/_fullscreen-pop-over.scss
@@ -5,10 +5,11 @@
  *
  * ================================= */
 
-$fullScreenPopOver-background       : $white;
-$fullScreenPopOver-padding          : spacing(x2);
-$fullScreenPopOver-border-color     : $grey--lightest;
-$fullScreenPopOver-shadow-color     : rgba($black, 0.12);
+$fullScreenPopOver-background        : $grey--offWhite;
+$fullScreenPopOver-action-background : $white;
+$fullScreenPopOver-padding           : spacing(x2);
+$fullScreenPopOver-border-color      : $grey--lightest;
+$fullScreenPopOver-shadow-color      : rgba($black, 0.12);
 
 .c-fullScreenPopOver {
 
@@ -40,6 +41,7 @@ $fullScreenPopOver-shadow-color     : rgba($black, 0.12);
         width: 100vw;
         position: absolute;
         padding: $fullScreenPopOver-padding;
+        background: $fullScreenPopOver-action-background;
 
         @include media('>=mid') {
             display: none;


### PR DESCRIPTION
_Fix of fullscreen popover background colour._

Background colour has changed to grey-offWhite instead of white. 

background colour of parent and header/footer updated.

<img width="389" alt="screen shot 2018-08-14 at 16 37 24" src="https://user-images.githubusercontent.com/5295718/44101944-7e85dfac-9fe0-11e8-88e7-bb816e79c5e5.png">

## UI Review Checks


- [x] This PR has been checked with regard to our brand guidelines


## Browsers Tested

- [x] Mobile (i.e. iPhone/Android - please list device)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
