### PR TITLE
v0.53.4 form toggle icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v0.53.4
+------------------------------
+*August 15, 2018*
+
+### Changed
+ - Change formToggle from CSS based icon to SVG f-icon asset
+
 v0.53.3
 ------------------------------
 *August 15, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.53.3",
+  "version": "0.53.4",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -99,7 +99,7 @@ $formToggle-disabled-text           : $grey--lighter;
         display: block;
         transition: padding 200ms ease-in-out;
 
-        &:after{
+        &:after {
             content: '';
         }
 

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -99,45 +99,13 @@ $formToggle-disabled-text           : $grey--lighter;
         display: block;
         transition: padding 200ms ease-in-out;
 
-        &:after,
-        &:before {
+        &:after{
             content: '';
-        }
-
-        &:before {
-            top: 50%;
-            opacity: 0;
-            width: 12px;
-            height: 5px;
-            position: absolute;
-            margin-top: -4px;
-            left: spacing();
-            display: inline-block;
-            transform: rotate(-45deg) scale(0.5);
-            border-left: 1px solid $formToggle-icon-background;
-            border-bottom: 1px solid $formToggle-icon-background;
-            transition: transform 200ms ease, opacity 250ms ease;
-        }
-
-        .o-formToggle-input:not([disabled]):hover ~ &,
-        .o-formToggle-input:not(:checked):hover ~ & {
-
-            @include media('>=mid') {
-
-                &:before {
-                    border-color: $formToggle-icon-hover-background;
-                }
-            }
         }
 
         @mixin formToggleCheckedSpacing() {
             padding-left: 20px;
             font-weight: $font-weight-bold;
-
-            &:before {
-                opacity: 1;
-                transform: rotate(-45deg) scale(1);
-            }
         }
 
         .o-formToggle-input:checked ~ & {
@@ -194,6 +162,42 @@ $formToggle-disabled-text           : $grey--lighter;
         .o-formToggle--largeAboveMid & {
             @include media('>=mid') {
                 @include formToggleLargeInputSize();
+            }
+        }
+    }
+
+    .o-formToggle-icon {
+        top: 50%;
+        opacity: 0;
+        width: 16px;
+        height: 10px;
+        position: absolute;
+        margin-top: -4px;
+        left: spacing();
+        display: inline-block;
+        transform: rotate(-45deg) scale(0.5);
+        transition: transform 200ms ease, opacity 250ms ease;
+        fill: $formToggle-icon-background;
+
+        .o-formToggle-input:not([disabled]):hover ~ &,
+        .o-formToggle-input:not(:checked):hover ~ & {
+            @include media('>=mid') {
+                fill: $formToggle-icon-hover-background;
+            }
+        }
+
+        @mixin formToggleIconActive() {
+            opacity: 1;
+            transform: rotate(0) scale(1);
+        }
+
+        .o-formToggle-input:checked ~ & {
+            @include formToggleIconActive();
+        }
+
+        .o-formToggle-input:not(:disabled):hover ~ & {
+            @include media('>=mid') {
+                @include formToggleIconActive();
             }
         }
     }


### PR DESCRIPTION
__*Convert form toggle tick from CSS created tick to f-icon asset*__

Before:
<img width="159" alt="screen shot 2018-08-15 at 12 26 27" src="https://user-images.githubusercontent.com/5295718/44146210-89b5189c-a086-11e8-880d-882a4418b296.png">

After:
<img width="160" alt="screen shot 2018-08-15 at 12 26 08" src="https://user-images.githubusercontent.com/5295718/44146212-8df5fd4a-a086-11e8-8986-edf4bf4511b9.png">


---


## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Mobile
