### PR TITLE
v0.59.1 - Content Title Action hover state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v0.59.1
+------------------------------
+*August 22, 2018*
+
+### Changed
+ - Change content header action hover state from no decoration normal and underline when hovered.
+
 v0.59.0
 ------------------------------
 *August 22, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_content-title.scss
+++ b/src/scss/components/_content-title.scss
@@ -26,4 +26,9 @@
 
     .c-contentTitle-action {
         font-weight: $font-weight-bold;
+        text-decoration: none;
+
+        &:hover {
+            text-decoration: underline;
+        }
     }

--- a/src/scss/components/_content-title.scss
+++ b/src/scss/components/_content-title.scss
@@ -28,7 +28,8 @@
         font-weight: $font-weight-bold;
         text-decoration: none;
 
-        &:hover {
+        &:hover,
+        &:focus {
             text-decoration: underline;
         }
     }

--- a/src/scss/components/_content-title.scss
+++ b/src/scss/components/_content-title.scss
@@ -25,8 +25,9 @@
     }
 
     .c-contentTitle-action {
-        font-weight: $font-weight-bold;
         text-decoration: none;
+        font-weight: $font-weight-bold;
+        font-family: $font-family-base;
 
         &:hover,
         &:focus {


### PR DESCRIPTION
__*Content Title Action hover state*__

- change text decoration of content header from none to underlined on hover

Before:
<img width="281" alt="screen shot 2018-08-15 at 15 21 40" src="https://user-images.githubusercontent.com/5295718/44153079-1e7f6fe6-a09f-11e8-873b-818c50b67648.png">

After:
<img width="323" alt="screen shot 2018-08-17 at 11 19 08" src="https://user-images.githubusercontent.com/5295718/44261377-62c3ac00-a20f-11e8-81ca-9e6d67ea20b0.png">



---

## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines

## Browsers Tested

- [x] Chrome
- [x] Mobile
