### PR TITLE
v0.54.0 - addition of has-no-match styling to c-listing component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v0.54.0
+------------------------------
+*August 16, 2018*
+
+### Added
+ - Addition of `has-no-match` class and styling to `.c-listing` item. (removes border).
+
 v0.53.4
 ------------------------------
 *August 15, 2018*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ v0.54.0
 *August 16, 2018*
 
 ### Added
- - Addition of `has-no-match` class and styling to `.c-listing` item. (removes border).
+ - Addition of `has-noItems` class and styling to `.c-listing` item. (removes border).
 
 v0.53.4
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.53.4",
+  "version": "0.54.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_listings.scss
+++ b/src/scss/components/_listings.scss
@@ -34,6 +34,9 @@ $listing-borderRadius       : 4px;
         }
     }
 
+    &.has-no-match {
+        border: 0;
+    }
 }
 
 .c-listing--offline {

--- a/src/scss/components/_listings.scss
+++ b/src/scss/components/_listings.scss
@@ -34,7 +34,7 @@ $listing-borderRadius       : 4px;
         }
     }
 
-    &.has-no-match {
+    &.has-noItems {
         border: 0;
     }
 }


### PR DESCRIPTION
__*addition of has-no-match styling to c-listing component*__

## UI Review Checks

Before:
<img width="926" alt="screen shot 2018-08-16 at 14 55 53" src="https://user-images.githubusercontent.com/5295718/44212920-8847ab80-a164-11e8-9ebe-cf1fcb2c68dd.png">

After:
<img width="924" alt="screen shot 2018-08-16 at 14 55 59" src="https://user-images.githubusercontent.com/5295718/44212923-8b429c00-a164-11e8-9dbf-874f1b997a46.png">


- [x] This PR has been checked with regard to our brand guidelines
- [x] UI Documentation has been [created|updated]
## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Internet Explorer 11
- [x] Mobile 