### PR TITLE
v0.73.0 — Added Optional `c-menu` component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v0.73.0
+------------------------------
+*September 4, 2018*
+
+### Changed
+- Changed fullScreenPopOver JS to `is-open`
+- Optional `c-menu` component.
+
+### Changed
+- `l-inlined` extended so that it can be referenced as a placeholder.
+- `$truncation-boundary` parameter is now optional on the `truncate` mixin.
+
+
 v0.72.0
 ------------------------------
 *September 4, 2018*
@@ -24,8 +37,8 @@ v0.71.0
 
 ### Changed
 - Content title width
-- Changed listing content widths 
-- Changed positioning of listing meta block between mid and wide 
+- Changed listing content widths
+- Changed positioning of listing meta block between mid and wide
 
 
 v0.70.0

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.72.0",
+  "version": "0.73.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/_dependencies.scss
+++ b/src/scss/_dependencies.scss
@@ -14,8 +14,8 @@
 // but we should not need them if autoprefixer is being used
 // See mixins/css3.scss for the full list
 
-@import 'tools/functions/index'; // TODO: this will be separated into a separate utilities module
-@import 'tools/mixins/index'; // TODO: this will be separated into a separate utilities module
+@import 'tools/functions'; // TODO: this will be separated into a separate utilities module
+@import 'tools/mixins'; // TODO: this will be separated into a separate utilities module
 
 // Including helper modules
 @import 'kickoff-utils'; // imports a set of helper functions and mixins – https://github.com/TryKickoff/kickoff-utils.scss
@@ -81,6 +81,7 @@
 @import 'components/overflow-carousel';
 @import 'components/fullscreen-pop-over';
 @import 'components/page-banner';
+@import 'components/menu';
 
 
 

--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -78,6 +78,7 @@ body {
 }
 
 // utility that lets you align items side by side and vertically centered
+%l-inlined,
 .l-inlined {
     display: flex;
     align-items: center;

--- a/src/scss/components/_menu.scss
+++ b/src/scss/components/_menu.scss
@@ -1,0 +1,69 @@
+/**
+ * Menu Component
+ * =================================
+ * Example – Menu – Categories list.
+ *
+ * Used for styling small pieces of information.
+ *
+ * *The `c-menu` component is an optional mixin within Fozzie — if you'd like to use it in your project you can include it by adding `@include menu();` into your SCSS dependencies file.*
+ *
+ * Documentation:
+ * https://fozzie.just-eat.com/styleguide/ui-components/menus
+ */
+
+$menu-fontSize              : base--scaleUp !default;
+$menu-border-color          : $grey--lightest !default;
+$menu-border-color--active  : $grey--dark !default;
+$menu-link-color            : $color-text !default;
+$menu-link-padding          : spacing() spacing(x2) !default;
+
+@mixin menu() {
+
+    .c-menu {
+        @extend %u-unstyled;
+        @include font-size($menu-fontSize);
+    }
+
+        .c-menu--spacingTop--aboveMid {
+            @include media('>mid') {
+                margin-top: 125px;
+            }
+        }
+
+        .c-menu-item {
+            box-shadow: -1px 0 0 0 $menu-border-color;
+
+            &.has-icon {
+                @extend %l-inlined;
+
+                .c-menu-link {
+                    padding-right: spacing() / 2;
+                }
+            }
+        }
+            .c-menu-item:active,
+            .c-menu-item:focus,
+            .c-menu-item:hover,
+            .c-menu-item--active {
+                box-shadow: -2px 0 0 0 $menu-border-color--active;
+                font-weight: $font-weight-bold;
+            }
+
+        .c-menu-link {
+            @include truncate();
+            display: block;
+            padding: $menu-link-padding;
+            text-decoration: none;
+
+            &,
+            &:hover,
+            &:active,
+            &:focus {
+                color: $menu-link-color;
+            }
+        }
+
+        .c-menu-icon {
+            flex-shrink: 0;
+        }
+}

--- a/src/scss/tools/mixins/_truncate.scss
+++ b/src/scss/tools/mixins/_truncate.scss
@@ -5,7 +5,7 @@
 // ==========================================================================
 //
 // @include truncate(truncation-boundary);
-@mixin truncate($truncation-boundary) {
+@mixin truncate($truncation-boundary: null) {
   max-width: $truncation-boundary;
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
Queued behind #130.

### Added
- Optional `c-menu` component.

### Changed
- `l-inlined` extended so that it can be referenced as a placeholder.
- Applied `z-index` to `c-pageBanner` component.
- `$truncation-boundary` parameter is now optional on the `truncate` mixin.

![fozzie-menu-component](https://user-images.githubusercontent.com/89059/44993782-b9f9a880-af93-11e8-86ea-7846a2c0cbfb.gif)
