### PR TITLE
v0.74.1 - popOver content inside breakpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+
+v0.74.1
+------------------------------
+*September 5, 2018*
+
+### Fixed
+ - Fullscreen popover content styles to be within media breakpoint
+
+
 v0.74.0
 ------------------------------
 *September 4, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.74.0",
+  "version": "0.74.1",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_fullscreen-pop-over.scss
+++ b/src/scss/components/_fullscreen-pop-over.scss
@@ -81,9 +81,11 @@ $fullScreenPopOver-shadow-color      : rgba($black, 0.12);
     }
 
     .c-fullScreenPopOver-content {
-        height: 100%;
-        overflow-x: hidden;
-        overflow-y: scroll;
-        padding: spacing(x2) 0;
-        -webkit-overflow-scrolling: touch;
+        @include media('<mid') {
+            height: 100%;
+            overflow-x: hidden;
+            overflow-y: scroll;
+            padding: spacing(x2) 0;
+            -webkit-overflow-scrolling: touch;
+        }
     }


### PR DESCRIPTION
- Fixed  popOver content styles to media breakpoint to stop content being hidden by overflow

## UI Review Checks

Before:
<img width="301" alt="screen shot 2018-09-05 at 11 42 10" src="https://user-images.githubusercontent.com/5295718/45088407-cb13f800-b100-11e8-8b17-a7726162da5b.png">

After:
<img width="302" alt="screen shot 2018-09-05 at 11 42 15" src="https://user-images.githubusercontent.com/5295718/45088411-ce0ee880-b100-11e8-8cb3-207fcf1a2d68.png">

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile 

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
