### PR TITLE
v0.80.0 — Card styles updated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v0.80.0
+------------------------------
+*September 10 2018*
+
+### Added
+- Card no padding modifier.
+- Card highlight modifier.
+- Card bottom section modifier.
+- Animation to card section chevron.
+- 0.5 spacing value.
+
+### Changed
+- Updated modules to use new 0.5 spacing value.
+
+### Fixed
+- Card section margin only applied on larger screens.
+
+
 v0.79.0
 ------------------------------
 *September 7 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.79.0",
+  "version": "0.80.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -19,6 +19,8 @@ $card-radius--large                             : 8px !default;
 $card-borderColor                               : $grey--lightest !default;
 $card-section-margin                            : spacing(x4) !default;
 $card-section-margin--large                     : spacing(x8) !default;
+$card-section-highlight-backgroundColor         : $orange;
+$card-section-highlight-color                   : $white;
 $card-section-collapsible-paddingRight          : 42px;
 $card-section-collapsible-paddingRight--aboveMid: 60px;
 
@@ -38,6 +40,10 @@ $card-section-collapsible-paddingRight--aboveMid: 60px;
         .c-card--noPad {
             padding: 0;
         }
+
+            .c-card--noPad--bottom {
+                padding-bottom: 0;
+            }
 
         .c-card--noPadVertical {
             padding-top: 0;
@@ -78,6 +84,26 @@ $card-section-collapsible-paddingRight--aboveMid: 60px;
             }
         }
 
+        // used to create a section at the end of a card which has a background colour applied
+        .c-card-section--bottom {
+            border-bottom-right-radius: $card-radius;
+            border-bottom-left-radius: $card-radius;
+
+            .c-card--rounded--large & {
+                border-bottom-right-radius: $card-radius--large;
+                border-bottom-left-radius: $card-radius--large;
+            }
+        }
+
+        // used to create a section at the end of a card which has a background colour applied
+        .c-card-section--highlight {
+            background-color: $card-section-highlight-backgroundColor;
+            border-top: none;
+            color: $card-section-highlight-color;
+            margin-top: spacing(x2);
+            padding: spacing(x0.5) spacing();
+        }
+
             .c-card-section--collapsible {
                 overflow: hidden;
                 padding-right: $card-section-collapsible-paddingRight;
@@ -109,7 +135,9 @@ $card-section-collapsible-paddingRight--aboveMid: 60px;
                 height: 50px;
 
                 &.c-card-section {
-                    margin-bottom: -#{spacing(x2)};
+                    @include media('>=mid') {
+                        margin-bottom: -#{spacing(x2)};
+                    }
                 }
 
                 p {
@@ -124,6 +152,7 @@ $card-section-collapsible-paddingRight--aboveMid: 60px;
                 right: spacing(x2);
                 top: 22px;
                 transform: rotate(180deg);
+                transition: transform 0.4s;
                 width: 10px;
 
                 @include media('>=mid') {

--- a/src/scss/components/_listings.scss
+++ b/src/scss/components/_listings.scss
@@ -164,7 +164,7 @@ $listing-promoIconColor         : $orange;
         .c-listing-item-detailsRow {
             display : flex;
             align-items : center;
-            margin-bottom: spacing() / 2;
+            margin-bottom: spacing(x0.5);
         }
 
         .c-listing-item-detailsRow-icon {
@@ -194,7 +194,7 @@ $listing-promoIconColor         : $orange;
             font-weight: $font-weight-base;
 
             @include media('>mid') {
-                margin: (spacing() / 2) 0;
+                margin: spacing(x0.5) 0;
                 padding-right: spacing(x2);
             }
         }
@@ -203,7 +203,7 @@ $listing-promoIconColor         : $orange;
             color: $green;
             top: -2px;
             position: relative;
-            margin-right: spacing() / 2;
+            margin-right: spacing(x0.5);
         }
 
         .c-listing-item-rating {
@@ -213,7 +213,7 @@ $listing-promoIconColor         : $orange;
         .c-listing-item-ratingText {
             top: -3px;
             position: relative;
-            margin-left: spacing() / 2;
+            margin-left: spacing(x0.5);
             @include font-size(small, true);
         }
 

--- a/src/scss/components/_media-element.scss
+++ b/src/scss/components/_media-element.scss
@@ -121,7 +121,7 @@ $mediaElement-spacing           : spacing(x2) !default;
 
         .c-mediaElement--fullstack & {
             flex: auto;
-            margin-top: spacing(base) / 2;
+            margin-top: spacing(x0.5);
         }
 
         // some content uses br for content shaping – get rid of it on mobile devices

--- a/src/scss/components/_menu.scss
+++ b/src/scss/components/_menu.scss
@@ -18,7 +18,7 @@ $menu-border-width              : 1px !default;
 $menu-border-width--active      : 2px !default;
 $menu-link-color                : $color-text !default;
 $menu-link-padding              : spacing() spacing(x2) !default;
-$menu--condensed-link-padding   : spacing() / 2 !default;
+$menu--condensed-link-padding   : spacing(x0.5) !default;
 
 @mixin menu() {
 
@@ -72,7 +72,7 @@ $menu--condensed-link-padding   : spacing() / 2 !default;
                 @extend %l-inlined;
 
                 .c-menu-link {
-                    padding-right: spacing() / 2;
+                    padding-right: spacing(x0.5);
                 }
             }
         }

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -50,7 +50,7 @@ $formToggle-disabled-text           : $grey--lighter;
     //Used alongside the default styles but for a larger tap area (min 44px) on narrow screens
     .o-formToggle--largeTouchArea {
         @include media('<mid') {
-            margin: spacing() 0 spacing() (spacing() / 2);
+            margin: spacing() 0 spacing() spacing(x0.5);
         }
     }
 

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -96,6 +96,7 @@ $spacing: 8px; // only for use in map below – not for in components
 // spacing map
 // Can access levels by using the spacing function > spacing() or spacing(x5) for example
 $spacing: (
+    x0.5 : $spacing / 2,
     base : $spacing,
     x1.5 : $spacing * 1.5,
     x2   : $spacing * 2,


### PR DESCRIPTION
### Added
- Card no padding modifier.
- Card highlight modifier.
- Card bottom section modifier.
- Animation to card section chevron.
- 0.5 spacing value.

### Changed
- Updated modules to use new 0.5 spacing value.

### Fixed
- Card section margin only applied on larger screens.

![screen shot 2018-09-10 at 13 00 35](https://user-images.githubusercontent.com/89059/45296312-8ff73780-b4f9-11e8-90c5-28b10152dc76.png)
