### PR TITLE
v0.85.0 - formtoggle click area - overflow carousel display type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v0.85.0
+------------------------------
+*September 11 2018*
+
+### Changed
+- Updated formToggle click area.
+- Removed formToggle count pointer events.
+- Updated overflowCarousel display to `inline-flex`.
+
+
 v0.84.0
 ------------------------------
 *September 11 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.84.0",
+  "version": "0.85.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_overflow-carousel.scss
+++ b/src/scss/components/_overflow-carousel.scss
@@ -28,7 +28,7 @@
     .c-overflowCarousel-content {
 
         @include media('<mid') {
-            display: inline-block;
+            display: inline-flex;
             white-space: nowrap;
             padding-left: spacing(x2);
             padding-right: spacing(x2);

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -107,11 +107,18 @@ $formToggle-disabled-text           : $grey--lighter;
     }
 
     .o-formToggle-text {
+        width: 100%;
         display: block;
         transition: padding 200ms ease-in-out;
 
         &:after {
             content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            display: block;
         }
 
         @mixin formToggleCheckedSpacing() {
@@ -151,9 +158,7 @@ $formToggle-disabled-text           : $grey--lighter;
         }
 
         .o-formToggle:not(.o-formToggle--disabled):hover &,
-        .o-formToggle:not(.o-formToggle--disabled):focus &,
-        .o-formToggle-input:not([disabled]):hover ~ &,
-        .o-formToggle-input:not([disabled]):focus ~ & {
+        .o-formToggle:not(.o-formToggle--disabled):focus & {
             @include media('>=mid') {
                 @include formToggleCheckedBorder();
             }
@@ -217,11 +222,12 @@ $formToggle-disabled-text           : $grey--lighter;
     }
 
     .o-formToggle--hasCount {
-        display: inline-flex;
+        display: flex;
         vertical-align: middle;
     }
 
     .o-formToggle-count {
+        pointer-events: none;
         padding-left: spacing();
 
         @include media('>mid') {

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -111,6 +111,7 @@ $formToggle-disabled-text           : $grey--lighter;
         display: block;
         transition: padding 200ms ease-in-out;
 
+        // This after is to increase the click area to the formToggle parent.
         &:after {
             content: '';
             position: absolute;


### PR DESCRIPTION
- Updated formToggle click area.
- Removed formToggle count pointer events.

![click-anywhere](https://user-images.githubusercontent.com/5295718/45365328-2f88f880-b5d4-11e8-9ccb-2806f9f50334.gif)

- Updated overflowCarousel display to `inline-flex`.


- [x] This PR has been checked with regard to our brand guidelines

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile

