### PR TITLE
v0.88.0 - addition of c-badge--transparent modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v0.88.0
+------------------------------
+*September 12 2018*
+
+### Added
+- Addition of `c-badge--transparent`
+
 v0.87.0
 ------------------------------
 *September 12 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.87.0",
+  "version": "0.88.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_badges.scss
+++ b/src/scss/components/_badges.scss
@@ -54,6 +54,7 @@ $badge-angled-rounded-radius: 2px !default;
         }
 
         .c-badge--transparent {
+            background: none;
 
             span {
                 color: $grey--light;

--- a/src/scss/components/_badges.scss
+++ b/src/scss/components/_badges.scss
@@ -53,6 +53,13 @@ $badge-angled-rounded-radius: 2px !default;
             }
         }
 
+        .c-badge--transparent {
+
+            span {
+                color: $grey--light;
+            }
+        }
+
         .c-badge--info {
             color: $badge-info-color;
         }


### PR DESCRIPTION
 - addition of c-badge--transparent modifier

Addition of `c-badge--transparent` modifier to remove the background. I needed the badge BG removed as on some c-listings states (offline has a rgba .5 background and causes issues).

Before:
<img width="233" alt="screen shot 2018-09-12 at 16 55 48" src="https://user-images.githubusercontent.com/5295718/45437516-d9d44f00-b6ac-11e8-8af8-31556f0c6cf1.png">
After:
<img width="239" alt="screen shot 2018-09-12 at 16 55 36" src="https://user-images.githubusercontent.com/5295718/45437517-d9d44f00-b6ac-11e8-834b-e1480a70566b.png">

## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines
- [x] UI Documentation has been [updated]
    - Docs PR here:
    - https://github.com/justeat/global-component-library/pull/56

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile
