### PR TITLE
v0.90.0 - remove margin from span within `c-badge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v0.90.0
+------------------------------
+*September 13 2018*
+
+### Changed
+- Removed margin from the span within `c-badge`.
+
+
 v0.89.0
 ------------------------------
 *September 13 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_badges.scss
+++ b/src/scss/components/_badges.scss
@@ -34,10 +34,6 @@ $badge-angled-rounded-radius: 2px !default;
         padding: $badge-padding;
         position: relative;
         white-space: nowrap;
-
-        span {
-            margin: 0 4px;
-        }
     }
 
         .c-badge--rounded {


### PR DESCRIPTION
- remove margin from span within `c-badge`

*The changes have been approved by menu designers*

## UI Review Checks

Before:
<img width="104" alt="screen shot 2018-09-13 at 15 19 19" src="https://user-images.githubusercontent.com/5295718/45494315-a951eb00-b768-11e8-83ca-5e9a90739c1f.png">

After:
<img width="93" alt="screen shot 2018-09-13 at 15 19 28" src="https://user-images.githubusercontent.com/5295718/45494321-abb44500-b768-11e8-8673-519f92c59b5d.png">


- [x] This PR has been checked with regard to our brand guidelines
- [x] UI Documentation has been 

## Browsers Tested
- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile
