### PR TITLE
v0.93.0 - Focus states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v0.93.0
+------------------------------
+*September 14 2018*
+
+### Changed
+- Added addition focus states to improves accessibility of formToggles.
+- Moved the padding from c-listing-item to c-listing-item-link for a nicer focus border look.
+
 
 v0.92.0
 ------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ v0.93.0
 ------------------------------
 *September 14 2018*
 
+### Added
+- Added additional focus states to improves accessibility of formToggles.
+
 ### Changed
-- Added addition focus states to improves accessibility of formToggles.
 - Moved the padding from c-listing-item to c-listing-item-link for a nicer focus border look.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.93.0
 ------------------------------
-*September 14 2018*
+*September 17 2018*
 
 ### Added
 - Added additional focus states to improves accessibility of formToggles.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.92.0",
+  "version": "0.93.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_listings.scss
+++ b/src/scss/components/_listings.scss
@@ -58,7 +58,6 @@ $listing-promoIconColor         : $orange;
         margin: 0;
         display: block;
         position: relative;
-        padding: spacing(x2);
         background: $listing-background;
         border-bottom: 1px solid $listing-borderColor;
 
@@ -93,6 +92,7 @@ $listing-promoIconColor         : $orange;
         .c-listing-item-link {
             display: block;
             color: $color-text;
+            padding: spacing(x2);
             text-decoration: none;
 
             &:hover,

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -111,7 +111,7 @@ $formToggle-disabled-text           : $grey--lighter;
         display: block;
         transition: padding 200ms ease-in-out;
 
-        // This after is to increase the click area to the formToggle parent.
+        // This :before is to increase the click area to the formToggle parent.
         &:before {
             content: '';
             position: absolute;

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -112,7 +112,7 @@ $formToggle-disabled-text           : $grey--lighter;
         transition: padding 200ms ease-in-out;
 
         // This after is to increase the click area to the formToggle parent.
-        &:after {
+        &:before {
             content: '';
             position: absolute;
             top: 0;
@@ -131,7 +131,8 @@ $formToggle-disabled-text           : $grey--lighter;
             @include formToggleCheckedSpacing();
         }
 
-        .o-formToggle-input:not(:disabled):hover ~ & {
+        .o-formToggle-input:not(:disabled):hover ~ &,
+        .o-formToggle-input:not(:disabled):focus ~ & {
             @include media('>=mid') {
 
                 @include formToggleCheckedSpacing();
@@ -143,6 +144,7 @@ $formToggle-disabled-text           : $grey--lighter;
             //the &:after is to create a border that sits over the top of the parents,
             // it creates a visual state on the parent without the need for a JS class toggle
             &:after {
+                content: '';
                 top: -1px;
                 left: -1px;
                 display: block;
@@ -154,7 +156,8 @@ $formToggle-disabled-text           : $grey--lighter;
             }
         }
 
-        .o-formToggle-input:not([disabled]):checked ~ & {
+        .o-formToggle-input:not([disabled]):checked ~ &,
+        .o-formToggle-input:not([disabled]):focus ~ & {
             @include formToggleCheckedBorder();
         }
 
@@ -199,7 +202,9 @@ $formToggle-disabled-text           : $grey--lighter;
             fill: $formToggle-icon-background;
 
             .o-formToggle-input:not([disabled]):hover ~ &,
-            .o-formToggle-input:not(:checked):hover ~ & {
+            .o-formToggle-input:not(:checked):hover ~ &,
+            .o-formToggle-input:not([disabled]):focus ~ &,
+            .o-formToggle-input:not(:checked):focus ~ & {
                 @include media('>=mid') {
                     fill: $formToggle-icon-hover-background;
                 }
@@ -214,6 +219,7 @@ $formToggle-disabled-text           : $grey--lighter;
                 @include formToggleIconActive();
             }
 
+            .o-formToggle-input:not(:disabled):focus ~ &,
             .o-formToggle-input:not(:disabled):hover ~ & {
                 @include media('>=mid') {
                     @include formToggleIconActive();


### PR DESCRIPTION
- Added addition focus states to improves accessibility of formToggles.


- Moved the padding from c-listing-item to c-listing-item-link for a nicer focus border look.
Before:
<img width="884" alt="screen shot 2018-09-14 at 15 33 45" src="https://user-images.githubusercontent.com/5295718/45556962-6e1cee00-b834-11e8-8536-429798014886.png">
After:
<img width="903" alt="screen shot 2018-09-14 at 15 34 44" src="https://user-images.githubusercontent.com/5295718/45556974-7412cf00-b834-11e8-8de8-51ca305ae981.png">

- [x] This PR has been checked with regard to our brand guidelines
- [x] This code has been checked with regard to our accessibility standards
  
## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile
