### PR TITLE
v0.94.0 - content header responsiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
-
 v0.94.0
 ------------------------------
-*September 14 2018*
+*September 17 2018*
 
 ### Changed
 - Made responsive breakpoints more consistent on `c-contentHeader`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+
+v0.94.0
+------------------------------
+*September 14 2018*
+
+### Changed
+- Made responsive breakpoints more consistent on `c-contentHeader`.
+
+
 v0.92.0
 ------------------------------
 *September 14, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.92.0",
+  "version": "0.94.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_content-header.scss
+++ b/src/scss/components/_content-header.scss
@@ -23,7 +23,7 @@
     margin-top: 4px;
     @include font-size(base, false);
 
-    @include media('>mid') {
+    @include media('>=mid') {
         display: inline-block;
     }
 }
@@ -45,7 +45,7 @@
         text-decoration: underline;
     }
 
-    @include media('>mid') {
+    @include media('>=mid') {
         display: inline-block;
     }
 }


### PR DESCRIPTION
 - Made responsive breakpoints more consistent on `c-contentHeader`

Before:
<img width="401" alt="screen shot 2018-09-14 at 16 21 55" src="https://user-images.githubusercontent.com/5295718/45559644-f0101580-b83a-11e8-8c88-78193a2432f0.png">

After:
<img width="399" alt="screen shot 2018-09-14 at 16 22 15" src="https://user-images.githubusercontent.com/5295718/45559652-f1d9d900-b83a-11e8-9d83-a468b06ada3a.png">


- [x] This PR has been checked with regard to our brand guidelines
- [x] UI Documentation has been [created|updated]
- [x] This code has been checked with regard to our accessibility standards
## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile