### PR TITLE
v0.98.0 - update hover states on pop over action button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v0.98.0
+------------------------------
+*September 19, 2018*
+
+### Changed
+- Changed pop over action button text decoration from underlined to underlined on hover.
+
+
 v0.97.1
 ------------------------------
 *September 18, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.97.1",
+  "version": "0.98.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_fullscreen-pop-over.scss
+++ b/src/scss/components/_fullscreen-pop-over.scss
@@ -58,7 +58,13 @@ $fullScreenPopOver-shadow-color      : rgba($black, 0.12);
     .c-fullScreenPopOver-header-actionSecond {
         top: 50%;
         position: absolute;
+        text-decoration: none;
         transform: translateY(-50%);
+
+        &:hover,
+        &:focus {
+            text-decoration: underline;
+        }
     }
 
     .c-fullScreenPopOver-header-actionFirst {


### PR DESCRIPTION
- update hover states on pop over action button

Before:
<img width="332" alt="screen shot 2018-09-19 at 10 40 20" src="https://user-images.githubusercontent.com/5295718/45745489-dbe06580-bbf8-11e8-9690-8cd0d3b3059c.png">

After:
<img width="333" alt="screen shot 2018-09-19 at 10 40 04" src="https://user-images.githubusercontent.com/5295718/45745494-ddaa2900-bbf8-11e8-9d63-5cd34a1a6778.png">


## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines
- [x] This code has been checked with regard to our accessibility standards

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile