### PR TITLE
v0.99.0 - listing SVG fix and improved accessibility on popovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.99.0
 ------------------------------
-*September 20, 2018*
+*September 21, 2018*
 
 ### Changed
-- Changed target of listin component is-premier image.
+- Changed target of listing component is-premier image.
 
 ### Added
 - Added styles to `display: none` popover component content when not visible for accessible tabbing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v0.99.0
 
 ### Changed
 - Changed target of listing component is-premier image.
+- Removed redundant font weight from listing title.
 
 ### Added
 - Added styles to `display: none` popover component content when not visible for accessible tabbing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v0.99.0
+------------------------------
+*September 20, 2018*
+
+### Changed
+- Changed target of listin component is-premier image.
+
+### Added
+- Added styles to `display: none` popover component content when not visible for accessible tabbing.
+
+
 v0.98.0
 ------------------------------
 *September 19, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_fullscreen-pop-over.scss
+++ b/src/scss/components/_fullscreen-pop-over.scss
@@ -30,10 +30,24 @@ $fullScreenPopOver-shadow-color      : rgba($black, 0.12);
             opacity: 1;
             height: 100%;
             overflow: visible;
+            transition: top 200ms ease, opacity 150ms ease;
             padding: 56px $fullScreenPopOver-padding 80px $fullScreenPopOver-padding;
         }
     }
 }
+
+    // This style block is for accessibility - it's so the user can't get caught tabbing
+    // within a modal if it's not visible
+    .c-fullScreenPopOver-header,
+    .c-fullScreenPopOver-footer,
+    .c-fullScreenPopOver-content {
+        display: none;
+
+        .is-open & {
+            display: block;
+        }
+    }
+
 
     .c-fullScreenPopOver-header,
     .c-fullScreenPopOver-footer {

--- a/src/scss/components/_fullscreen-pop-over.scss
+++ b/src/scss/components/_fullscreen-pop-over.scss
@@ -38,16 +38,18 @@ $fullScreenPopOver-shadow-color      : rgba($black, 0.12);
 
     // This style block is for accessibility - it's so the user can't get caught tabbing
     // within a modal if it's not visible
-    .c-fullScreenPopOver-header,
-    .c-fullScreenPopOver-footer,
-    .c-fullScreenPopOver-content {
-        display: none;
+    .c-fullScreenPopOver {
+        & > * {
+          display: none;
+        }
 
-        .is-open & {
-            display: block;
+        &.is-open {
+            & > * {
+                display: block;
+
+            }
         }
     }
-
 
     .c-fullScreenPopOver-header,
     .c-fullScreenPopOver-footer {

--- a/src/scss/components/_listings.scss
+++ b/src/scss/components/_listings.scss
@@ -256,7 +256,6 @@ $listing-promoIconColor         : $orange;
         .c-listing-item-title {
             word-break: break-word;
             padding-right: spacing();
-            font-weight: $font-weight-base;
 
             @include media('>mid') {
                 margin: spacing(x0.5) 0;

--- a/src/scss/components/_listings.scss
+++ b/src/scss/components/_listings.scss
@@ -304,7 +304,9 @@ $listing-promoIconColor         : $orange;
         }
 
         .c-listing-item-premierImage {
-            height: 32px;
+            svg {
+                height: 32px;
+            }
         }
 
         .c-listing-item-text {


### PR DESCRIPTION
- Update listing premier image selector [need to target SVG due to f-icons issue]
- Display none popover content to stop the user getting tabs lost in the popovers when they are not shown

[No visible change]

- [x] This PR has been checked with regard to our brand guidelines
## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile (i.e. iPhone/Android - please list device)
