### PR TITLE
v0.100.0 - addition of stopFOIT module and unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v0.100.0
 ------------------------------
-*September 24, 2018*
+*September 26, 2018*
 
 ### Added
 - Stop FOIT JS module to reduce meaningful paint with webfonts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v0.100.0
+------------------------------
+*September 24, 2018*
+
+### Added
+- Stop FOIT JS module to reduce meaningful paint with webfonts
+
+### Changed
+- formToggle count text size
+
+
 v0.99.2
 ------------------------------
 *September 25, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.99.2",
+  "version": "0.100.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -33,10 +33,13 @@
   },
   "dependencies": {
     "@justeat/f-dom": "0.4.0",
+    "@justeat/f-logger": "^0.7.1",
     "@justeat/fozzie-colour-palette": "1.4.0",
     "@kickoff/utils.scss": "2.1.1",
+    "fontfaceobserver": "^2.0.13",
     "include-media": "1.4.9",
     "kickoff-grid.css": "1.1.2",
+    "lite-ready": "^1.0.4",
     "normalize-scss": "7.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "fontfaceobserver": "^2.0.13",
     "include-media": "1.4.9",
     "kickoff-grid.css": "1.1.2",
-    "lite-ready": "^1.0.4",
     "normalize-scss": "7.0.1"
   },
   "devDependencies": {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,7 +1,10 @@
+import { stopFoit } from './modules/stopFoit';
+
 // All helper functions will be imported here, so that they can all be exported within one object.
 import { getBreakpoints, getCurrentScreenWidth } from './modules/breakpointHelper';
 
 export {
+    stopFoit,
     getBreakpoints,
     getCurrentScreenWidth
 };

--- a/src/js/modules/stopFoit/index.js
+++ b/src/js/modules/stopFoit/index.js
@@ -14,18 +14,18 @@ import { logError } from '@justeat/f-logger';
 
 export const stopFoit = () => {
     // Create a new `FontFaceObserver` for each webfont
-    const baseFont = new FontFaceObserver('Hinds Vadodara');
+    const baseFont = new FontFaceObserver('Hind Vadodara');
     const headingFont = new FontFaceObserver('Ubuntu');
 
     // On load of each font we add `has-fontsLoaded` class with the font type modifier
     baseFont.load(null, 3000).then(() => {
-        document.body.classList.add('has-fontsLoaded--base');
+        document.body.classList.remove('is-fontsLoading--base');
     }).catch(() => {
         logError('Custom font is unable to load');
     });
 
     headingFont.load(null, 3000).then(() => {
-        document.body.classList.add('has-fontsLoaded--headings');
+        document.body.classList.remove('is-fontsLoading--heading');
     }).catch(() => {
         logError('Custom font is unable to load');
     });

--- a/src/js/modules/stopFoit/index.js
+++ b/src/js/modules/stopFoit/index.js
@@ -1,5 +1,5 @@
 import FontFaceObserver from 'fontfaceobserver';
-import logError from '@justeat/f-logger';
+import { logError } from '@justeat/f-logger';
 
 /**
  * @overview stopFOIT reduces the amount of time a user has invisible text when using webfonts.
@@ -11,22 +11,23 @@ import logError from '@justeat/f-logger';
 * Init method initialises the FontFaceObserver events
 *
 */
+
 export const stopFoit = () => {
     // Create a new `FontFaceObserver` for each webfont
     const baseFont = new FontFaceObserver('Hinds Vadodara');
     const headingFont = new FontFaceObserver('Ubuntu');
 
     // On load of each font we add `has-fontsLoaded` class with the font type modifier
-    baseFont.load(null, 5000).then(() => {
+    baseFont.load(null, 3000).then(() => {
         document.body.classList.add('has-fontsLoaded--base');
     }).catch(() => {
         logError('Custom font is unable to load');
     });
 
-    headingFont.load(null, 5000).then(() => {
+    headingFont.load(null, 3000).then(() => {
         document.body.classList.add('has-fontsLoaded--headings');
     }).catch(() => {
-        logError('Custom fonts is unable to load');
+        logError('Custom font is unable to load');
     });
 };
 

--- a/src/js/modules/stopFoit/index.js
+++ b/src/js/modules/stopFoit/index.js
@@ -1,0 +1,35 @@
+import FontFaceObserver from 'fontfaceobserver';
+import logError from '@justeat/f-logger';
+
+/**
+ * @overview stopFOIT reduces the amount of time a user has invisible text when using webfonts.
+ *
+ * @module stopFOIT
+ */
+
+/**
+* Init method initialises the FontFaceObserver events
+*
+*/
+export const stopFoit = () => {
+    // Create a new `FontFaceObserver` for each webfont
+    const baseFont = new FontFaceObserver('Hisssssnds Vadodara');
+    const headingFont = new FontFaceObserver('Usbussssntu');
+
+    // On load of each font we add `has-fontsLoaded` class with the font type modifier
+    baseFont.load(null, 5000).then(() => {
+        document.body.classList.add('has-fontsLoaded--base');
+    }).catch(() => {
+        console.log('canne load');
+        logError('Custom font is unable to load');
+    });
+
+    headingFont.load(null, 5000).then(() => {
+        document.body.classList.add('has-fontsLoaded--headings');
+    }).catch(() => {
+        console.log('canne load');
+        logError('Custom fonts is unable to load');
+    });
+};
+
+export default stopFoit;

--- a/src/js/modules/stopFoit/index.js
+++ b/src/js/modules/stopFoit/index.js
@@ -13,21 +13,19 @@ import logError from '@justeat/f-logger';
 */
 export const stopFoit = () => {
     // Create a new `FontFaceObserver` for each webfont
-    const baseFont = new FontFaceObserver('Hisssssnds Vadodara');
-    const headingFont = new FontFaceObserver('Usbussssntu');
+    const baseFont = new FontFaceObserver('Hinds Vadodara');
+    const headingFont = new FontFaceObserver('Ubuntu');
 
     // On load of each font we add `has-fontsLoaded` class with the font type modifier
     baseFont.load(null, 5000).then(() => {
         document.body.classList.add('has-fontsLoaded--base');
     }).catch(() => {
-        console.log('canne load');
         logError('Custom font is unable to load');
     });
 
     headingFont.load(null, 5000).then(() => {
         document.body.classList.add('has-fontsLoaded--headings');
     }).catch(() => {
-        console.log('canne load');
         logError('Custom fonts is unable to load');
     });
 };

--- a/src/js/modules/stopFoit/test/index.test.js
+++ b/src/js/modules/stopFoit/test/index.test.js
@@ -2,7 +2,17 @@ import FontFaceObserver from 'fontfaceobserver';
 import TestUtils from 'js-test-buddy';
 import { stopFoit } from '../index';
 
+jest.mock('fontfaceobserver');
+
 describe('module stopFoit', () => {
+    beforeAll(() => {
+        FontFaceObserver.mockImplementation(() => ({
+            load: () => new Promise(resolve => {
+                resolve();
+            })
+        }));
+    });
+
     it('adds `has-fontsLoaded--headings` to the body when Ubunto webfont has loaded', () => {
         // Arrange
         TestUtils.setBodyHtml(`
@@ -13,13 +23,13 @@ describe('module stopFoit', () => {
         stopFoit();
 
         // Assert
-        const headingFont = new FontFaceObserver('Ubuntu');
-        headingFont.load().then(() => {
+        setTimeout(() => {
+            expect(FontFaceObserver).toBeCalled();
             expect(document.body.classList.contains('has-fontsLoaded--headings')).toBe(true);
-        });
+        }, 100);
     });
 
-    it('adds `has-fontsLoaded--base` to the body when Ubunto webfont has loaded', () => {
+    it('adds `has-fontsLoaded--base` to the body when Hind Vadodara webfont has loaded', async () => {
         // Arrange
         TestUtils.setBodyHtml(`
             <link href="https://fonts.googleapis.com/css?family=Hind+Vadodara" rel="stylesheet">
@@ -29,9 +39,32 @@ describe('module stopFoit', () => {
         stopFoit();
 
         // Assert
-        const baseFont = new FontFaceObserver('Hind Vadodara');
-        baseFont.load().then(() => {
+        setTimeout(() => {
+            expect(FontFaceObserver).toBeCalled();
             expect(document.body.classList.contains('has-fontsLoaded--base')).toBe(true);
-        });
+        }, 100);
+    });
+});
+
+describe('module stopFoit catches Errors', () => {
+    beforeAll(() => {
+        FontFaceObserver.mockImplementation(() => ({
+            load: () => new Promise((...reject) => {
+                reject();
+            })
+        }));
+    });
+
+    it('rejects if fonts do not load', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+            <link href="https://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet">
+        `);
+
+        // Act
+        stopFoit();
+
+        // Assert
+        expect(FontFaceObserver.rejects);
     });
 });

--- a/src/js/modules/stopFoit/test/index.test.js
+++ b/src/js/modules/stopFoit/test/index.test.js
@@ -14,10 +14,11 @@ describe('module stopFoit', () => {
             }));
         });
 
-        it('adds `has-fontsLoaded--headings` to the body when Ubunto webfont has loaded', () => {
+        it('removes `is-fontsLoading--headings` from the body when Ubunto webfont has loaded', () => {
             // Arrange
             TestUtils.setBodyHtml(`
                 <link href="https://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet">
+                <body class="is-fontsLoading--headings"></body>
             `);
 
             // Act
@@ -26,14 +27,15 @@ describe('module stopFoit', () => {
             // Assert
             setTimeout(() => {
                 expect(FontFaceObserver).toBeCalled();
-                expect(document.body.classList.contains('has-fontsLoaded--headings')).toBe(true);
+                expect(document.body.classList.contains('has-fontsLoaded--headings')).toBe(false);
             }, 100);
         });
 
-        it('adds `has-fontsLoaded--base` to the body when Hind Vadodara webfont has loaded', async () => {
+        it('removes `is-fontsLoading--base` from the body when Hind Vadodara webfont has loaded', async () => {
             // Arrange
             TestUtils.setBodyHtml(`
                 <link href="https://fonts.googleapis.com/css?family=Hind+Vadodara" rel="stylesheet">
+                <body class="is-fontsLoading--base"></body>
             `);
 
             // Act
@@ -42,7 +44,7 @@ describe('module stopFoit', () => {
             // Assert
             setTimeout(() => {
                 expect(FontFaceObserver).toBeCalled();
-                expect(document.body.classList.contains('has-fontsLoaded--base')).toBe(true);
+                expect(document.body.classList.contains('is-fontsLoading--base')).toBe(false);
             }, 100);
         });
     });
@@ -64,13 +66,17 @@ describe('module stopFoit', () => {
             stopFoit();
 
             // Assert
-            expect(FontFaceObserver.rejects);
+            setTimeout(() => {
+                expect(FontFaceObserver.rejects).toHaveBeenCalled();
+            }, 100);
         });
 
         it('does not add any font loaded classes to the body', () => {
             // Arrange
             TestUtils.setBodyHtml(`
                 <link href="https://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet">
+                <body class="is-fontsLoading--base is-fontsLoading--headings"></body>
+
             `);
 
             // Act
@@ -78,8 +84,8 @@ describe('module stopFoit', () => {
 
             // Assert
             setTimeout(() => {
-                expect(document.body.classList.contains('has-fontsLoaded--base')).toBe(false);
-                expect(document.body.classList.contains('has-fontsLoaded--headings')).toBe(false);
+                expect(document.body.classList.contains('is-fontsLoading--base')).toBe(true);
+                expect(document.body.classList.contains('is-fontsLoading--headings')).toBe(true);
             }, 100);
         });
     });

--- a/src/js/modules/stopFoit/test/index.test.js
+++ b/src/js/modules/stopFoit/test/index.test.js
@@ -5,66 +5,82 @@ import { stopFoit } from '../index';
 jest.mock('fontfaceobserver');
 
 describe('module stopFoit', () => {
-    beforeAll(() => {
-        FontFaceObserver.mockImplementation(() => ({
-            load: () => new Promise(resolve => {
-                resolve();
-            })
-        }));
+    describe('when the fonts load correctly', () => {
+        beforeAll(() => {
+            FontFaceObserver.mockImplementation(() => ({
+                load: () => new Promise(resolve => {
+                    resolve();
+                })
+            }));
+        });
+
+        it('adds `has-fontsLoaded--headings` to the body when Ubunto webfont has loaded', () => {
+            // Arrange
+            TestUtils.setBodyHtml(`
+                <link href="https://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet">
+            `);
+
+            // Act
+            stopFoit();
+
+            // Assert
+            setTimeout(() => {
+                expect(FontFaceObserver).toBeCalled();
+                expect(document.body.classList.contains('has-fontsLoaded--headings')).toBe(true);
+            }, 100);
+        });
+
+        it('adds `has-fontsLoaded--base` to the body when Hind Vadodara webfont has loaded', async () => {
+            // Arrange
+            TestUtils.setBodyHtml(`
+                <link href="https://fonts.googleapis.com/css?family=Hind+Vadodara" rel="stylesheet">
+            `);
+
+            // Act
+            stopFoit();
+
+            // Assert
+            setTimeout(() => {
+                expect(FontFaceObserver).toBeCalled();
+                expect(document.body.classList.contains('has-fontsLoaded--base')).toBe(true);
+            }, 100);
+        });
     });
 
-    it('adds `has-fontsLoaded--headings` to the body when Ubunto webfont has loaded', () => {
-        // Arrange
-        TestUtils.setBodyHtml(`
-            <link href="https://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet">
-        `);
+    describe('when the fonts do not load correctly', () => {
+        beforeAll(() => {
+            FontFaceObserver.mockImplementation(() => ({
+                load: () => new Promise((...reject) => {
+                    reject();
+                })
+            }));
+        });
 
-        // Act
-        stopFoit();
+        it('causes FontFaceObserver to reject', () => {
+            // Arrange
+            TestUtils.setBodyHtml('');
 
-        // Assert
-        setTimeout(() => {
-            expect(FontFaceObserver).toBeCalled();
-            expect(document.body.classList.contains('has-fontsLoaded--headings')).toBe(true);
-        }, 100);
-    });
+            // Act
+            stopFoit();
 
-    it('adds `has-fontsLoaded--base` to the body when Hind Vadodara webfont has loaded', async () => {
-        // Arrange
-        TestUtils.setBodyHtml(`
-            <link href="https://fonts.googleapis.com/css?family=Hind+Vadodara" rel="stylesheet">
-        `);
+            // Assert
+            expect(FontFaceObserver.rejects);
+        });
 
-        // Act
-        stopFoit();
+        it('does not add any font loaded classes to the body', () => {
+            // Arrange
+            TestUtils.setBodyHtml(`
+                <link href="https://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet">
+            `);
 
-        // Assert
-        setTimeout(() => {
-            expect(FontFaceObserver).toBeCalled();
-            expect(document.body.classList.contains('has-fontsLoaded--base')).toBe(true);
-        }, 100);
-    });
-});
+            // Act
+            stopFoit();
 
-describe('module stopFoit catches Errors', () => {
-    beforeAll(() => {
-        FontFaceObserver.mockImplementation(() => ({
-            load: () => new Promise((...reject) => {
-                reject();
-            })
-        }));
-    });
-
-    it('rejects if fonts do not load', () => {
-        // Arrange
-        TestUtils.setBodyHtml(`
-            <link href="https://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet">
-        `);
-
-        // Act
-        stopFoit();
-
-        // Assert
-        expect(FontFaceObserver.rejects);
+            // Assert
+            setTimeout(() => {
+                expect(document.body.classList.contains('has-fontsLoaded--base')).toBe(false);
+                expect(document.body.classList.contains('has-fontsLoaded--headings')).toBe(false);
+            }, 100);
+        });
     });
 });

--- a/src/js/modules/stopFoit/test/index.test.js
+++ b/src/js/modules/stopFoit/test/index.test.js
@@ -1,0 +1,37 @@
+import FontFaceObserver from 'fontfaceobserver';
+import TestUtils from 'js-test-buddy';
+import { stopFoit } from '../index';
+
+describe('module stopFoit', () => {
+    it('adds `has-fontsLoaded--headings` to the body when Ubunto webfont has loaded', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+            <link href="https://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet">
+        `);
+
+        // Act
+        stopFoit();
+
+        // Assert
+        const headingFont = new FontFaceObserver('Ubuntu');
+        headingFont.load().then(() => {
+            expect(document.body.classList.contains('has-fontsLoaded--headings')).toBe(true);
+        });
+    });
+
+    it('adds `has-fontsLoaded--base` to the body when Ubunto webfont has loaded', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+            <link href="https://fonts.googleapis.com/css?family=Hind+Vadodara" rel="stylesheet">
+        `);
+
+        // Act
+        stopFoit();
+
+        // Assert
+        const baseFont = new FontFaceObserver('Hind Vadodara');
+        baseFont.load().then(() => {
+            expect(document.body.classList.contains('has-fontsLoaded--base')).toBe(true);
+        });
+    });
+});

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -18,13 +18,43 @@
 //
 // ******
 
+/**
+ * Typography preloading styles
+ */
+
+.is-fontsLoading--base {
+
+    body,
+    p {
+        font-family: $font-family-preload !important;
+    }
+}
+
+.is-fontsLoading--heading {
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    .alpha,
+    .beta,
+    .gamma,
+    .delta,
+    .epsilon {
+        font-family: $font-family-preload !important;
+        font-weight: $font-weight-bold;
+    }
+}
+
 html {
     font-size: $font-size-base-px;
     text-size-adjust: 100%;
 }
 
 body {
-    font-family: $font-family-preload;
+    font-family: $font-family-base;
     @include font-size(base);
     color: $color-text;
     font-weight: $font-weight-base;
@@ -32,24 +62,16 @@ body {
     text-rendering: optimizelegibility;
     -webkit-font-smoothing: antialiased;
     -moz-font-smoothing: antialiased;
-
-    .has-fontsLoaded--base & {
-        font-family: $font-family-base;
-    }
 }
 
 /**
  * Paragraphs
  */
 p {
-    font-family: $font-family-preload;
+    font-family: $font-family-base;
     @include font-size(base);
     margin-top: $baseline;
     margin-bottom: 0;
-
-    .has-fontsLoaded--base & {
-        font-family: $font-family-base;
-    }
 }
 
 /**
@@ -69,16 +91,11 @@ h6,
     color: $color-headings;
     margin: 0;
     margin-bottom: 0;
-    font-family: $font-family-preload;
-    font-weight: $font-weight-bold;
+    font-family: $font-family-headings;
+    font-weight: $font-weight-base;
 
     small {
         font-weight: normal;
-    }
-
-    .has-fontsLoaded--headings & {
-        font-family: $font-family-headings;
-        font-weight: $font-weight-base;
     }
 }
 

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -24,7 +24,7 @@ html {
 }
 
 body {
-    font-family: $font-family-base;
+    font-family: $font-family-preload;
     @include font-size(base);
     color: $color-text;
     font-weight: $font-weight-base;
@@ -32,16 +32,24 @@ body {
     text-rendering: optimizelegibility;
     -webkit-font-smoothing: antialiased;
     -moz-font-smoothing: antialiased;
+
+    .has-fontsLoaded--base & {
+        font-family: $font-family-base;
+    }
 }
 
 /**
  * Paragraphs
  */
 p {
-    font-family: $font-family-base;
+    font-family: $font-family-preload;
     @include font-size(base);
     margin-top: $baseline;
     margin-bottom: 0;
+
+    .has-fontsLoaded--base & {
+        font-family: $font-family-base;
+    }
 }
 
 /**
@@ -60,12 +68,17 @@ h6,
 .epsilon {
     color: $color-headings;
     margin: 0;
-    font-family: $font-family-headings;
-    font-weight: $font-weight-headings;
     margin-bottom: 0;
+    font-family: $font-family-preload;
+    font-weight: $font-weight-bold;
 
     small {
         font-weight: normal;
+    }
+
+    .has-fontsLoaded--headings & {
+        font-family: $font-family-headings;
+        font-weight: $font-weight-base;
     }
 }
 

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -22,32 +22,6 @@
  * Typography preloading styles
  */
 
-.is-fontsLoading--base {
-
-    body,
-    p {
-        font-family: $font-family-preload !important;
-    }
-}
-
-.is-fontsLoading--heading {
-
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6,
-    .alpha,
-    .beta,
-    .gamma,
-    .delta,
-    .epsilon {
-        font-family: $font-family-preload !important;
-        font-weight: $font-weight-bold;
-    }
-}
-
 html {
     font-size: $font-size-base-px;
     text-size-adjust: 100%;
@@ -62,6 +36,10 @@ body {
     text-rendering: optimizelegibility;
     -webkit-font-smoothing: antialiased;
     -moz-font-smoothing: antialiased;
+
+    .is-fontsLoading--base & {
+        font-family: $font-family-preload !important;
+    }
 }
 
 /**
@@ -72,6 +50,10 @@ p {
     @include font-size(base);
     margin-top: $baseline;
     margin-bottom: 0;
+
+    .is-fontsLoading--base & {
+        font-family: $font-family-preload !important;
+    }
 }
 
 /**
@@ -96,6 +78,11 @@ h6,
 
     small {
         font-weight: normal;
+    }
+
+    .is-fontsLoading--heading & {
+        font-family: $font-family-preload !important;
+        font-weight: $font-weight-bold;
     }
 }
 

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -61,6 +61,12 @@ $font-family-base           : 'Hind Vadodara', 'Helvetica Neue', Helvetica, sans
 $font-family-headings       : 'Ubuntu'; // we need to define some fallbacks here!
 $font-family-mono           : Menlo, Monaco, 'Courier New', monospace;
 
+// Fonts for preload
+// ==========================================================================
+// base fonts and headings have a preload system font, when the webfonts are loaded we style with JustEat fonts.
+
+$font-family-preload: Helvetica, sans-serif;
+
 
 //  Global Breakpoints
 // ==========================================================================

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -65,7 +65,7 @@ $font-family-mono           : Menlo, Monaco, 'Courier New', monospace;
 // ==========================================================================
 // base fonts and headings have a preload system font, when the webfonts are loaded we style with JustEat fonts.
 
-$font-family-preload: Helvetica, sans-serif;
+$font-family-preload: 'Helvetica Neue', Helvetica, sans-serif;
 
 
 //  Global Breakpoints

--- a/yarn.lock
+++ b/yarn.lock
@@ -8001,10 +8001,6 @@ limiter@^1.0.5:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/limiter/-/limiter-1.1.3.tgz#32e2eb55b2324076943e5d04c1185ffb387968ef"
 
-lite-ready@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/lite-ready/-/lite-ready-1.0.4.tgz#6dfe50f45a5a2840c87c8406a7abf3088bfd255e"
-
 load-helpers@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/load-helpers/-/load-helpers-0.3.1.tgz#99a8ba07362901827c8e62c95b0b0b1fe9830549"

--- a/yarn.lock
+++ b/yarn.lock
@@ -237,6 +237,10 @@
   dependencies:
     qwery "^4.0.0"
 
+"@justeat/f-logger@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@justeat/f-logger/-/f-logger-0.7.1.tgz#06e728d3c65733cab7c9bbfc813b401fa68ba82b"
+
 "@justeat/f-templates-loader@0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-templates-loader/-/f-templates-loader-0.1.0.tgz#5b4138b949ae99f070b215ba4add917d6a082d92"
@@ -5050,6 +5054,10 @@ follow-redirects@^1.2.5:
   dependencies:
     debug "^3.1.0"
 
+fontfaceobserver@^2.0.13:
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/fontfaceobserver/-/fontfaceobserver-2.0.13.tgz#47adbb343261eda98cb44db2152196ff124d3221"
+
 for-in@^0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
@@ -7992,6 +8000,10 @@ liftoff@^2.1.0:
 limiter@^1.0.5:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/limiter/-/limiter-1.1.3.tgz#32e2eb55b2324076943e5d04c1185ffb387968ef"
+
+lite-ready@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/lite-ready/-/lite-ready-1.0.4.tgz#6dfe50f45a5a2840c87c8406a7abf3088bfd255e"
 
 load-helpers@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
### Added
- Stop FOIT JS module to reduce meaningful paint with webfonts

**Before (slow 3g):**
![without-preload](https://user-images.githubusercontent.com/5295718/45963632-7981cd80-c01b-11e8-9238-2eb9ee82b442.gif)

**After (slow 3g):**
![with-preload-font](https://user-images.githubusercontent.com/5295718/45963639-7be42780-c01b-11e8-8a51-5d02832fac3e.gif)

### Changed
- formToggle count text size


- [x] This PR has been checked with regard to our brand guidelines
- [x] This code has been checked with regard to our accessibility standards
  - [x] HTML is valid

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile