### PR TITLE
v0.99.1 - fix content header link display property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v0.99.1
+------------------------------
+*September 25, 2018*
+
+### Fixed
+- Content header link mobile display property
+
+
 v0.99.0
 ------------------------------
 *September 21, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.99.0",
+  "version": "0.99.1",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_content-header.scss
+++ b/src/scss/components/_content-header.scss
@@ -36,16 +36,12 @@
 }
 
 .c-contentHeader-link {
-    display: block;
+    display: inline-block;
     text-decoration: none;
     font-weight: $font-weight-base;
 
     &:hover,
     &:focus {
         text-decoration: underline;
-    }
-
-    @include media('>=mid') {
-        display: inline-block;
     }
 }


### PR DESCRIPTION
- fix content header link display property

Before:
<img width="244" alt="screen shot 2018-09-25 at 12 10 54" src="https://user-images.githubusercontent.com/5295718/46010895-1a27ca00-c0bc-11e8-8a0a-77396d76df65.png">

After:
<img width="279" alt="screen shot 2018-09-25 at 12 10 40" src="https://user-images.githubusercontent.com/5295718/46010899-1c8a2400-c0bc-11e8-8f81-9a8f10243e1c.png">

---

## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile