### PR TITLE
v0.99.2 - no tab popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ v0.99.2
 *September 25, 2018*
 
 ### Fixed
-- Addition of modifier to display block on `c-fullScreenPopOver` to stop non tabable functionality affecting other devices >mid
+- Addition of modifier on `c-fullScreenPopOver` to stop non tabable functionality affecting other devices >mid
 
 
 v0.99.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v0.99.2
+------------------------------
+*September 25, 2018*
+
+### Fixed
+- Addition of modifier to display block on `c-fullScreenPopOver` to stop non tabable functionality affecting other devices >mid
+
+
 v0.99.1
 ------------------------------
 *September 25, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.99.1",
+  "version": "0.99.2",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_fullscreen-pop-over.scss
+++ b/src/scss/components/_fullscreen-pop-over.scss
@@ -37,10 +37,12 @@ $fullScreenPopOver-shadow-color      : rgba($black, 0.12);
 }
 
     // This style block is for accessibility - it's so the user can't get caught tabbing
-    // within a modal if it's not visible
-    .c-fullScreenPopOver {
+    // within a modal if it's not visible on mid and below
+    .c-fullScreenPopOver--midNoTab {
         & > * {
-          display: none;
+            @include media('<=mid') {
+                display: none;
+            }
         }
 
         &.is-open {

--- a/src/scss/components/_fullscreen-pop-over.scss
+++ b/src/scss/components/_fullscreen-pop-over.scss
@@ -38,7 +38,7 @@ $fullScreenPopOver-shadow-color      : rgba($black, 0.12);
 
     // This style block is for accessibility - it's so the user can't get caught tabbing
     // within a modal if it's not visible on mid and below
-    .c-fullScreenPopOver--midNoTab {
+    .c-fullScreenPopOver--noTab--mid {
         & > * {
             @include media('<=mid') {
                 display: none;

--- a/src/scss/components/_fullscreen-pop-over.scss
+++ b/src/scss/components/_fullscreen-pop-over.scss
@@ -47,8 +47,9 @@ $fullScreenPopOver-shadow-color      : rgba($black, 0.12);
 
         &.is-open {
             & > * {
-                display: block;
-
+                @include media('<=mid') {
+                    display: block;
+                }
             }
         }
     }


### PR DESCRIPTION
- Addition of modifier on `c-fullScreenPopOver` to stop non tabable functionality affecting other devices >mid

## UI Review Checks



- [x] This PR has been checked with regard to our brand guidelines
- [x] This code has been checked with regard to our accessibility standards

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile
