### PR TITLE
v0.100.1 - Update font weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v0.100.1
+------------------------------
+*September 26, 2018*
+
+### Changed
+- preload font-weight to 400 to stop large visible jump in weight once webfonts have loaded
+- set headings to use headings font-weight
+
+
 v0.100.0
 ------------------------------
 *September 26, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.100.0",
+  "version": "0.100.1",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -74,7 +74,7 @@ h6,
     margin: 0;
     margin-bottom: 0;
     font-family: $font-family-headings;
-    font-weight: $font-weight-base;
+    font-weight: $font-weight-headings;
 
     small {
         font-weight: normal;
@@ -82,7 +82,7 @@ h6,
 
     .is-fontsLoading--heading & {
         font-family: $font-family-preload !important;
-        font-weight: $font-weight-bold;
+        font-weight: $font-weight-headings-preload;
     }
 }
 

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -66,6 +66,7 @@ $font-family-mono           : Menlo, Monaco, 'Courier New', monospace;
 // base fonts and headings have a preload system font, when the webfonts are loaded we style with JustEat fonts.
 
 $font-family-preload: 'Helvetica Neue', Helvetica, sans-serif;
+$font-weight-headings-preload: 400;
 
 
 //  Global Breakpoints


### PR DESCRIPTION
- update headings to use heading font weight variable.
- change preload font to use a preload font weight variable to reduce difference in fonts causing a less intrusive font change.

Before (preload and loaded font difference):
<img width="608" alt="screen shot 2018-09-26 at 12 53 11" src="https://user-images.githubusercontent.com/5295718/46078134-32b2e580-c18b-11e8-8416-381e15d5d35c.png">
<img width="589" alt="screen shot 2018-09-26 at 12 50 15" src="https://user-images.githubusercontent.com/5295718/46078138-35153f80-c18b-11e8-902f-60ea089949ff.png">


After (preload and loaded font difference):
<img width="582" alt="screen shot 2018-09-26 at 12 50 11" src="https://user-images.githubusercontent.com/5295718/46078088-144cea00-c18b-11e8-8b98-195bc239f5be.png">
<img width="589" alt="screen shot 2018-09-26 at 12 50 15" src="https://user-images.githubusercontent.com/5295718/46078092-16af4400-c18b-11e8-9569-9b0f901a5ea0.png">


## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile
