### PR TITLE
v0.101.0 - change badge divider to be a pseudo elm to improve a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v0.101.0
+------------------------------
+*September 26, 2018*
+
+### Changed
+- Changed `c-badge--transparent` and `c-badge--light` divider to be a pseudo element to improve accessibility 
+
+
 v0.100.1
 ------------------------------
 *September 26, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "0.100.1",
+  "version": "0.101.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/_badges.scss
+++ b/src/scss/components/_badges.scss
@@ -43,17 +43,23 @@ $badge-angled-rounded-radius: 2px !default;
 
         .c-badge--light {
             background-color: $badge-light-bgColor;
-
-            span {
-                color: $grey--light;
-            }
         }
 
         .c-badge--transparent {
             background: none;
+        }
+
+        //Both c-badge--light and c-badge--transparent share the same divider styles,
+        //The content '\2022' will output a bullet: •
+        .c-badge--light,
+        .c-badge--transparent {
 
             span {
-                color: $grey--light;
+                &:after {
+                    content: '\2022';
+                    display: block;
+                    color: $grey--light;
+                }
             }
         }
 


### PR DESCRIPTION
- change badge divider to be a pseudo element to improve accessibility warning (Background and foreground colors do not have a sufficient contrast ratio.).

## UI Review Checks

**No visual change**

- [x] This PR has been checked with regard to our brand guidelines
- [x] UI Documentation has been [updated] 
    - **link:**https://github.com/justeat/global-component-library/pull/60/files
- [x] This code has been checked with regard to our accessibility standards

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile