### PR TITLE
v1.3.0 - within breakpoint method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ v1.3.0
 ------------------------------
 *October 5, 2018*
 
-- Added `withinBreakpoint` method to breakpoint helper for breakpoint queries that match our SCSS style
-- Added associated unit tests for `withinBreakpoint` method 
+- Added `isWithinBreakpoint` method to breakpoint helper for breakpoint queries that match our SCSS style
+- Added associated unit tests for `isWithinBreakpoint` method 
 
 
 v1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.3.0
+------------------------------
+*October 5, 2018*
+
+- Added `withinBreakpoint` method to breakpoint helper for breakpoint queries that match our SCSS style
+- Added associated unit tests for `withinBreakpoint` method 
+
+
 v1.2.0
 ------------------------------
 *October 3, 2018*
@@ -11,6 +19,7 @@ v1.2.0
 ### Fixed
 - Fixed spacing on `c-listing` component
 - Fixed display on `c-overflowCarousel` component
+
 
 v1.1.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,11 +1,11 @@
 import { stopFoit } from './modules/stopFoit';
 
 // All helper functions will be imported here, so that they can all be exported within one object.
-import { getBreakpoints, getCurrentScreenWidth, withinBreakpoint } from './modules/breakpointHelper';
+import { getBreakpoints, getCurrentScreenWidth, isWithinBreakpoint } from './modules/breakpointHelper';
 
 export {
     stopFoit,
     getBreakpoints,
     getCurrentScreenWidth,
-    withinBreakpoint
+    isWithinBreakpoint
 };

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,10 +1,11 @@
 import { stopFoit } from './modules/stopFoit';
 
 // All helper functions will be imported here, so that they can all be exported within one object.
-import { getBreakpoints, getCurrentScreenWidth } from './modules/breakpointHelper';
+import { getBreakpoints, getCurrentScreenWidth, withinBreakpoint } from './modules/breakpointHelper';
 
 export {
     stopFoit,
     getBreakpoints,
-    getCurrentScreenWidth
+    getCurrentScreenWidth,
+    withinBreakpoint
 };

--- a/src/js/modules/breakpointHelper.js
+++ b/src/js/modules/breakpointHelper.js
@@ -67,7 +67,7 @@ export const getCurrentScreenWidth = () => {
     return false;
 };
 
-export const withinBreakpoint = breakpointString => {
+export const isWithinBreakpoint = breakpointString => {
     const operatorRegex = /[<>=]+/;
     const operatorMatch = breakpointString.match(operatorRegex);
     const operator = operatorMatch ? operatorMatch[0] : '';

--- a/src/js/modules/breakpointHelper.js
+++ b/src/js/modules/breakpointHelper.js
@@ -4,8 +4,6 @@
  * @module breakpointHelper
  */
 
-let bps;
-
 export const getBreakpoints = () => {
     const output = {};
 
@@ -36,17 +34,23 @@ export const getBreakpoints = () => {
     }, output); // <- initial value
 };
 
+export const createBreakpointArray = breakpoints => {
+    // Order the breakpoints from widest to narrowest,
+    // takes the form [['narrow', '414px'], [...etc]]
+    const bps = [];
+    Object.keys(breakpoints).forEach(key => {
+        bps.unshift([key, breakpoints[key]]);
+    });
+
+    return bps;
+};
+
 export const getCurrentScreenWidth = () => {
     const currentWidth = window.innerWidth;
 
     const breakpoints = getBreakpoints();
 
-    // Order the breakpoints from widest to narrowest,
-    // takes the form [['narrow', '414px'], [...etc]]
-    bps = [];
-    Object.keys(breakpoints).forEach(key => {
-        bps.unshift([key, breakpoints[key]]);
-    });
+    const bps = createBreakpointArray(breakpoints);
 
     for (let i = 0; i < bps.length; i++) {
         // Loops through the breakpoints (in descending order)
@@ -70,24 +74,26 @@ export const withinBreakpoint = breakpointString => {
     const [, breakpoint] = breakpointString.split(operatorRegex);
     const currentScreenWidth = window.innerWidth;
 
-    // We fire getCurrentScreenWidth to set the bp array we loop through to get the PX values
-    getCurrentScreenWidth();
+    const breakpoints = getBreakpoints();
+    const bps = createBreakpointArray(breakpoints);
 
     // We loop through the breakpoint array until we get a match.
     // If we match we return the px value as an int. If we do not match we return false
-    const breakpointToPX = bp => {
-        for (let i = 0; i < bps.length; i++) {
-            if (bps[i][0] === bp) {
-                return parseInt(bps[i][1], 10);
+    const breakpointToPX = breakpointName => {
+        let match = false;
+
+        bps.forEach(bp => {
+            if (bp[0] === breakpointName) {
+                match = parseInt(bp[1], 10);
             }
-        }
-        return false;
+        });
+        return match;
     };
 
     const breakpointInPX = breakpointToPX(breakpoint);
 
-    // If the breakpoint passed in does not match any we return false;
-    if (breakpointInPX === false) {
+    // If the breakpoint passed in does not match any we;
+    if (!breakpointInPX) {
         return false;
     }
 

--- a/src/js/modules/breakpointHelper.js
+++ b/src/js/modules/breakpointHelper.js
@@ -4,6 +4,8 @@
  * @module breakpointHelper
  */
 
+let bps;
+
 export const getBreakpoints = () => {
     const output = {};
 
@@ -41,7 +43,7 @@ export const getCurrentScreenWidth = () => {
 
     // Order the breakpoints from widest to narrowest,
     // takes the form [['narrow', '414px'], [...etc]]
-    const bps = [];
+    bps = [];
     Object.keys(breakpoints).forEach(key => {
         bps.unshift([key, breakpoints[key]]);
     });
@@ -60,3 +62,57 @@ export const getCurrentScreenWidth = () => {
     // If no breakpoints have been set
     return false;
 };
+
+export const withinBreakpoint = breakpointString => {
+    const operatorMatch = breakpointString.match(/[<>=]+/);
+    const operator = operatorMatch ? operatorMatch[0] : '';
+    const [, breakpoint] = breakpointString.split(/[<>=]+/);
+    const currentScreenWidth = window.innerWidth;
+    let match;
+
+    // We fire getCurrentScreenWidth to set the bp array we loop through to get the PX values
+    getCurrentScreenWidth();
+
+    // We loop through the breakpoint array until we get a match.
+    // If we match we return the px value as an int. If we do not match we return false
+    const breakpointToPX = bp => {
+        for (let i = 0; i < bps.length; i++) {
+            if (bps[i][0] === bp) {
+                return parseInt(bps[i][1], 10);
+            }
+        }
+        return false;
+    };
+
+    const breakpointInPX = breakpointToPX(breakpoint);
+
+    // If the breakpoint passed in does not match any we return false;
+    if (breakpointInPX === false) {
+        return false;
+    }
+
+    // We match our passed in operator and execute a sum: current screen width [Passed operator] [Passed breakpoint in PX]
+    switch (operator) {
+        case '>':
+            match = currentScreenWidth > breakpointInPX;
+            break;
+        case '<':
+            match = currentScreenWidth < breakpointInPX;
+            break;
+        case '=':
+            match = currentScreenWidth === breakpointInPX;
+            break;
+        case '>=':
+            match = currentScreenWidth >= breakpointInPX;
+            break;
+        case '<=':
+            match = currentScreenWidth <= breakpointInPX;
+            break;
+        default:
+            return false;
+    }
+
+    // Return a bool on the breakpoint statement match
+    return match;
+};
+

--- a/src/js/modules/breakpointHelper.js
+++ b/src/js/modules/breakpointHelper.js
@@ -64,11 +64,11 @@ export const getCurrentScreenWidth = () => {
 };
 
 export const withinBreakpoint = breakpointString => {
-    const operatorMatch = breakpointString.match(/[<>=]+/);
+    const operatorRegex = /[<>=]+/;
+    const operatorMatch = breakpointString.match(operatorRegex);
     const operator = operatorMatch ? operatorMatch[0] : '';
-    const [, breakpoint] = breakpointString.split(/[<>=]+/);
+    const [, breakpoint] = breakpointString.split(operatorRegex);
     const currentScreenWidth = window.innerWidth;
-    let match;
 
     // We fire getCurrentScreenWidth to set the bp array we loop through to get the PX values
     getCurrentScreenWidth();
@@ -94,25 +94,17 @@ export const withinBreakpoint = breakpointString => {
     // We match our passed in operator and execute a sum: current screen width [Passed operator] [Passed breakpoint in PX]
     switch (operator) {
         case '>':
-            match = currentScreenWidth > breakpointInPX;
-            break;
+            return currentScreenWidth > breakpointInPX;
         case '<':
-            match = currentScreenWidth < breakpointInPX;
-            break;
+            return currentScreenWidth < breakpointInPX;
         case '=':
-            match = currentScreenWidth === breakpointInPX;
-            break;
+            return currentScreenWidth === breakpointInPX;
         case '>=':
-            match = currentScreenWidth >= breakpointInPX;
-            break;
+            return currentScreenWidth >= breakpointInPX;
         case '<=':
-            match = currentScreenWidth <= breakpointInPX;
-            break;
+            return currentScreenWidth <= breakpointInPX;
         default:
             return false;
     }
-
-    // Return a bool on the breakpoint statement match
-    return match;
 };
 

--- a/src/js/test/index.test.js
+++ b/src/js/test/index.test.js
@@ -1,5 +1,5 @@
 import TestUtils from 'js-test-buddy';
-import { getBreakpoints, getCurrentScreenWidth } from '..';
+import { getBreakpoints, getCurrentScreenWidth, withinBreakpoint } from '..';
 
 describe('getBreakpoints', () => {
     beforeEach(() => {
@@ -84,5 +84,146 @@ describe('currentScreenWidth', () => {
 
         // Assert
         expect(width).toBe(false);
+    });
+});
+
+describe('withinBreakpoint', () => {
+    it('should return true if I pass in `>narrow` when my screen width is larger than 414', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+        <style>
+            .c-screen-sizer {
+                content: 'narrow:414px,mid:768px,wide:1025px,huge:1280px';
+            }
+        </style>
+        `);
+        window.innerWidth = 415;
+
+        // Act
+        const breakpointMatch = withinBreakpoint('>narrow');
+
+        // Assert
+        expect(breakpointMatch).toBe(true);
+    });
+
+    it('should return true if I pass in `>=narrow` when my screen width is larger or equal to 414', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+        <style>
+            .c-screen-sizer {
+                content: 'narrow:414px,mid:768px,wide:1025px,huge:1280px';
+            }
+        </style>
+        `);
+        window.innerWidth = 414;
+
+        // Act
+        const breakpointMatch = withinBreakpoint('>=narrow');
+
+        window.innerWidth = 415;
+        const breakpointMatchTwo = withinBreakpoint('>=narrow');
+
+        // Assert
+        expect(breakpointMatch).toBe(true);
+        expect(breakpointMatchTwo).toBe(true);
+    });
+
+    it('should return true if I pass in `<=narrow` when my screen width is smaller or equal to 414', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+        <style>
+            .c-screen-sizer {
+                content: 'narrow:414px,mid:768px,wide:1025px,huge:1280px';
+            }
+        </style>
+        `);
+        window.innerWidth = 413;
+
+        // Act
+        const breakpointMatch = withinBreakpoint('<=narrow');
+
+        window.innerWidth = 414;
+        const breakpointMatchTwo = withinBreakpoint('<=narrow');
+
+        // Assert
+        expect(breakpointMatch).toBe(true);
+        expect(breakpointMatchTwo).toBe(true);
+    });
+
+    it('should return true if I pass in `<narrow` when my screen width is smaller than 414', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+        <style>
+            .c-screen-sizer {
+                content: 'narrow:414px,mid:768px,wide:1025px,huge:1280px';
+            }
+        </style>
+        `);
+        window.innerWidth = 413;
+
+
+        // Act
+        const breakpointMatch = withinBreakpoint('<narrow');
+
+        // Assert
+        expect(breakpointMatch).toBe(true);
+    });
+
+    it('should return true if I pass in `=narrow` when my screen width is 414', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+        <style>
+            .c-screen-sizer {
+                content: 'narrow:414px,mid:768px,wide:1025px,huge:1280px';
+            }
+        </style>
+        `);
+        window.innerWidth = 414;
+
+        // Act
+        const breakpointMatch = withinBreakpoint('=narrow');
+
+        // Assert
+        expect(breakpointMatch).toBe(true);
+    });
+
+    it('should return false if the passed operator is not accepted', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+        <style>
+            .c-screen-sizer {
+                content: 'narrow:414px,mid:768px,wide:1025px,huge:1280px';
+            }
+        </style>
+        `);
+        window.innerWidth = 414;
+
+        // Act
+        const breakpointMatch = withinBreakpoint('==>narrow');
+        const breakpointMatchTwo = withinBreakpoint('+narrow');
+
+
+        // Assert
+        expect(breakpointMatch).toBe(false);
+        expect(breakpointMatchTwo).toBe(false);
+    });
+
+    it('should return false if the passed breakpoint is not accepted', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+        <style>
+            .c-screen-sizer {
+                content: 'narrow:414px,mid:768px,wide:1025px,huge:1280px';
+            }
+        </style>
+        `);
+        window.innerWidth = 414;
+
+        // Act
+        const breakpointMatch = withinBreakpoint('>blah');
+
+
+        // Assert
+        expect(breakpointMatch).toBe(false);
     });
 });

--- a/src/js/test/index.test.js
+++ b/src/js/test/index.test.js
@@ -1,5 +1,5 @@
 import TestUtils from 'js-test-buddy';
-import { getBreakpoints, getCurrentScreenWidth, withinBreakpoint } from '..';
+import { getBreakpoints, getCurrentScreenWidth, isWithinBreakpoint } from '..';
 
 describe('getBreakpoints', () => {
     beforeEach(() => {
@@ -87,9 +87,9 @@ describe('currentScreenWidth', () => {
     });
 });
 
-describe('withinBreakpoint', () => {
+describe('isWithinBreakpoint', () => {
     it('should exist', () => {
-        expect(withinBreakpoint).toBeDefined();
+        expect(isWithinBreakpoint).toBeDefined();
     });
 
     beforeEach(() => {
@@ -107,7 +107,7 @@ describe('withinBreakpoint', () => {
         window.innerWidth = 415;
 
         // Act
-        const breakpointMatch = withinBreakpoint('>narrow');
+        const breakpointMatch = isWithinBreakpoint('>narrow');
 
         // Assert
         expect(breakpointMatch).toBe(true);
@@ -118,10 +118,10 @@ describe('withinBreakpoint', () => {
         window.innerWidth = 414;
 
         // Act
-        const breakpointMatch = withinBreakpoint('>=narrow');
+        const breakpointMatch = isWithinBreakpoint('>=narrow');
 
         window.innerWidth = 415;
-        const breakpointMatchTwo = withinBreakpoint('>=narrow');
+        const breakpointMatchTwo = isWithinBreakpoint('>=narrow');
 
         // Assert
         expect(breakpointMatch).toBe(true);
@@ -133,10 +133,10 @@ describe('withinBreakpoint', () => {
         window.innerWidth = 413;
 
         // Act
-        const breakpointMatch = withinBreakpoint('<=narrow');
+        const breakpointMatch = isWithinBreakpoint('<=narrow');
 
         window.innerWidth = 414;
-        const breakpointMatchTwo = withinBreakpoint('<=narrow');
+        const breakpointMatchTwo = isWithinBreakpoint('<=narrow');
 
         // Assert
         expect(breakpointMatch).toBe(true);
@@ -149,7 +149,7 @@ describe('withinBreakpoint', () => {
 
 
         // Act
-        const breakpointMatch = withinBreakpoint('<narrow');
+        const breakpointMatch = isWithinBreakpoint('<narrow');
 
         // Assert
         expect(breakpointMatch).toBe(true);
@@ -160,7 +160,7 @@ describe('withinBreakpoint', () => {
         window.innerWidth = 414;
 
         // Act
-        const breakpointMatch = withinBreakpoint('=narrow');
+        const breakpointMatch = isWithinBreakpoint('=narrow');
 
         // Assert
         expect(breakpointMatch).toBe(true);
@@ -171,8 +171,8 @@ describe('withinBreakpoint', () => {
         window.innerWidth = 414;
 
         // Act
-        const breakpointMatch = withinBreakpoint('==>narrow');
-        const breakpointMatchTwo = withinBreakpoint('+narrow');
+        const breakpointMatch = isWithinBreakpoint('==>narrow');
+        const breakpointMatchTwo = isWithinBreakpoint('+narrow');
 
 
         // Assert
@@ -185,7 +185,7 @@ describe('withinBreakpoint', () => {
         window.innerWidth = 414;
 
         // Act
-        const breakpointMatch = withinBreakpoint('>blah');
+        const breakpointMatch = isWithinBreakpoint('>blah');
 
 
         // Assert
@@ -197,7 +197,7 @@ describe('withinBreakpoint', () => {
         window.innerWidth = 414;
 
         // Act
-        const breakpointMatch = withinBreakpoint('narrow');
+        const breakpointMatch = isWithinBreakpoint('narrow');
 
 
         // Assert

--- a/src/js/test/index.test.js
+++ b/src/js/test/index.test.js
@@ -88,8 +88,7 @@ describe('currentScreenWidth', () => {
 });
 
 describe('withinBreakpoint', () => {
-    it('should return true if I pass in `>narrow` when my screen width is larger than 414', () => {
-        // Arrange
+    beforeEach(() => {
         TestUtils.setBodyHtml(`
         <style>
             .c-screen-sizer {
@@ -97,6 +96,10 @@ describe('withinBreakpoint', () => {
             }
         </style>
         `);
+    });
+
+    it('should return true if I pass in `>narrow` when my screen width is larger than 414', () => {
+        // Arrange
         window.innerWidth = 415;
 
         // Act
@@ -108,13 +111,6 @@ describe('withinBreakpoint', () => {
 
     it('should return true if I pass in `>=narrow` when my screen width is larger or equal to 414', () => {
         // Arrange
-        TestUtils.setBodyHtml(`
-        <style>
-            .c-screen-sizer {
-                content: 'narrow:414px,mid:768px,wide:1025px,huge:1280px';
-            }
-        </style>
-        `);
         window.innerWidth = 414;
 
         // Act
@@ -130,13 +126,6 @@ describe('withinBreakpoint', () => {
 
     it('should return true if I pass in `<=narrow` when my screen width is smaller or equal to 414', () => {
         // Arrange
-        TestUtils.setBodyHtml(`
-        <style>
-            .c-screen-sizer {
-                content: 'narrow:414px,mid:768px,wide:1025px,huge:1280px';
-            }
-        </style>
-        `);
         window.innerWidth = 413;
 
         // Act
@@ -152,13 +141,6 @@ describe('withinBreakpoint', () => {
 
     it('should return true if I pass in `<narrow` when my screen width is smaller than 414', () => {
         // Arrange
-        TestUtils.setBodyHtml(`
-        <style>
-            .c-screen-sizer {
-                content: 'narrow:414px,mid:768px,wide:1025px,huge:1280px';
-            }
-        </style>
-        `);
         window.innerWidth = 413;
 
 
@@ -171,13 +153,6 @@ describe('withinBreakpoint', () => {
 
     it('should return true if I pass in `=narrow` when my screen width is 414', () => {
         // Arrange
-        TestUtils.setBodyHtml(`
-        <style>
-            .c-screen-sizer {
-                content: 'narrow:414px,mid:768px,wide:1025px,huge:1280px';
-            }
-        </style>
-        `);
         window.innerWidth = 414;
 
         // Act
@@ -189,13 +164,6 @@ describe('withinBreakpoint', () => {
 
     it('should return false if the passed operator is not accepted', () => {
         // Arrange
-        TestUtils.setBodyHtml(`
-        <style>
-            .c-screen-sizer {
-                content: 'narrow:414px,mid:768px,wide:1025px,huge:1280px';
-            }
-        </style>
-        `);
         window.innerWidth = 414;
 
         // Act
@@ -210,13 +178,6 @@ describe('withinBreakpoint', () => {
 
     it('should return false if the passed breakpoint is not accepted', () => {
         // Arrange
-        TestUtils.setBodyHtml(`
-        <style>
-            .c-screen-sizer {
-                content: 'narrow:414px,mid:768px,wide:1025px,huge:1280px';
-            }
-        </style>
-        `);
         window.innerWidth = 414;
 
         // Act

--- a/src/js/test/index.test.js
+++ b/src/js/test/index.test.js
@@ -187,4 +187,16 @@ describe('withinBreakpoint', () => {
         // Assert
         expect(breakpointMatch).toBe(false);
     });
+
+    it('should return false if the passed breakpoint has no operator', () => {
+        // Arrange
+        window.innerWidth = 414;
+
+        // Act
+        const breakpointMatch = withinBreakpoint('narrow');
+
+
+        // Assert
+        expect(breakpointMatch).toBe(false);
+    });
 });

--- a/src/js/test/index.test.js
+++ b/src/js/test/index.test.js
@@ -88,6 +88,10 @@ describe('currentScreenWidth', () => {
 });
 
 describe('withinBreakpoint', () => {
+    it('should exist', () => {
+        expect(withinBreakpoint).toBeDefined();
+    });
+
     beforeEach(() => {
         TestUtils.setBodyHtml(`
         <style>


### PR DESCRIPTION
Extension of current breakpointHelper JS to include `withinBreakpoint`.

`withinBreakpoint` is build to mimic our current SCSS breakpoint media queries. 

`withinBreakpoint('>mid')` and will return true or false.

---

## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile