### PR TITLE
v1.6.0 - Added `overflow-y: hidden` to overflow carousel to stop X an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.6.0
+------------------------------
+*October 9, 2018*
+
+### Fixed
+- Added `overflow-y: hidden` to overflow carousel to stop X and Y scrolling.
+
 v1.5.0
 ------------------------------
 *October 8, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_overflow-carousel.scss
+++ b/src/scss/components/optional/_overflow-carousel.scss
@@ -22,7 +22,8 @@
 
         .c-overflowCarousel-inner {
             @include media('<mid') {
-                overflow: scroll;
+                overflow-x: scroll;
+                overflow-y: hidden;
                 -webkit-overflow-scrolling: touch;
                 width: 100%;
                 &.is-active {


### PR DESCRIPTION
- Added `overflow-y: hidden` to overflow carousel to stop X and Y scrolling.

## UI Review Checks


- [x] This PR has been checked with regard to our brand guidelines

Before:
![scroll-fix-before](https://user-images.githubusercontent.com/5295718/46674485-28a1d580-cbd4-11e8-9bb2-4446aead73c9.gif)

After:
![scroll-fiz-after](https://user-images.githubusercontent.com/5295718/46674492-2e97b680-cbd4-11e8-927c-bf8524acf320.gif)


## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile