### PR TITLE
v1.8.0 - form toggle a11y and states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ v1.8.0
 *October 29, 2018*
 
 ### Added
-- Improved a11y focus states on `.o-formToggle`
+- Improved a11y focus states on `.o-formToggle`.
 
 ### Changed
-- Updated `.o-formToggle` checked state to reflect new design
+- Updated `.o-formToggle` checked state to reflect new design.
+
+### Fixed
+- Fixed icon showing on hover.
+- Fixed border updating when checked (missing content in pseudo).
 
 
 v1.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+
+v1.8.0
+------------------------------
+*October 29, 2018*
+
+### Added
+- Improved a11y focus states on `.o-formToggle`
+
+### Changed
+- Updated `.o-formToggle` checked state to reflect new design
+
+
 v1.7.0
 ------------------------------
 *October 22, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_toast.scss
+++ b/src/scss/components/optional/_toast.scss
@@ -17,7 +17,7 @@ $toast-animation-duration               : 0.5s;
 $toast-height                           : 95px;
 $toast-translateY                       : -#{$toast-height - 5px};
 $toast-height--aboveNarrow              : 125px;
-$toast-translateY--aboveNarrow          : -#{$toast-height--aboveNarrow - 5px};;
+$toast-translateY--aboveNarrow          : -#{$toast-height--aboveNarrow - 5px};
 $toast-height--aboveMid                 : $toast-height;
 $toast-translateY--aboveMid             : $toast-translateY;
 

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -62,7 +62,7 @@ $formToggle-checked-text            : $green;
     }
 }
 
-// `formToggle-hoverState` is used only when a formToggle has a user interaction: :hover
+// `formToggle-hoverState` is used only when a formToggle has a user interaction :hover
 @mixin formToggle-hoverState() {
     @include formToggle-border();
     &:after {
@@ -73,16 +73,7 @@ $formToggle-checked-text            : $green;
     }
 }
 
-@mixin formToggle-hoverState() {
-    @include formToggle-border();
-    &:after {
-        width: calc(100% + 2px);
-        height: calc(100% + 2px);
-        border-radius: $formToggle-border-radius;
-        border: $formToggle-border-width solid $formToggle-border-color-interact;
-    }
-}
-
+// `formToggle-hoverState` is used only when a formToggle has a user interaction: :focus
 @mixin formToggle-focusState() {
     @include formToggle-border();
     &:after {
@@ -210,7 +201,7 @@ $formToggle-checked-text            : $green;
             }
 
             .o-formToggle-input:checked ~ & {
-                font-weight: 500;
+                font-weight: $font-weight-bold;
                 color: $formToggle-checked-text;
                 @include formToggle-checkedSpacing();
             }
@@ -290,8 +281,7 @@ $formToggle-checked-text            : $green;
 
                     &:hover,
                     &:focus {
-                    fill: $formToggle-icon-background;
-                        
+                        fill: $formToggle-icon-background;
                     }
                 }
 

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -52,7 +52,6 @@ $formToggle-checked-text            : $green;
     cursor: pointer;
     //the &:after is to create a border that sits over the top of the parents,
     // it creates a visual state on the parent without the need for a JS class toggle
-    // 
     &:after {
         content: '';
         top: -1px;

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -14,7 +14,8 @@
 
 $formToggle-padding                 : spacing() !default;
 $formToggle-border-color            : $grey--lightest;
-$formToggle-border-color-checked    : $grey--lighter;
+$formToggle-border-color-interact   : $grey--lighter;
+$formToggle-border-color-checked    : $green;
 $formToggle-border-width            : 1px;
 $formToggle-border-radius           : 8px;
 $formToggle-icon-background         : $green;
@@ -24,6 +25,7 @@ $formToggle-large-size              : 48px;
 $formToggle-button-color            : $blue;
 $formToggle-button-background       : $blue--offWhite;
 $formToggle-disabled-text           : $grey--lighter;
+$formToggle-checked-text            : $green;
 
 // associated form toggle mixins
 @mixin formToggle-large() {
@@ -46,19 +48,64 @@ $formToggle-disabled-text           : $grey--lighter;
     font-weight: $font-weight-bold;
 }
 
-@mixin formToggle-checkedBorder() {
+@mixin formToggle-border() {
     cursor: pointer;
     //the &:after is to create a border that sits over the top of the parents,
     // it creates a visual state on the parent without the need for a JS class toggle
+    // 
     &:after {
+        content: '';
         top: -1px;
         left: -1px;
         display: block;
         position: absolute;
+    }
+}
+
+// `formToggle-hoverState` is used only when a formToggle has a user interaction: :hover
+@mixin formToggle-hoverState() {
+    @include formToggle-border();
+    &:after {
         width: calc(100% + 2px);
         height: calc(100% + 2px);
         border-radius: $formToggle-border-radius;
+        border: $formToggle-border-width solid $formToggle-border-color-interact;
+    }
+}
+
+@mixin formToggle-hoverState() {
+    @include formToggle-border();
+    &:after {
+        width: calc(100% + 2px);
+        height: calc(100% + 2px);
+        border-radius: $formToggle-border-radius;
+        border: $formToggle-border-width solid $formToggle-border-color-interact;
+    }
+}
+
+@mixin formToggle-focusState() {
+    @include formToggle-border();
+    &:after {
+        @extend %u-elementFocus;
+        left: 1px;
+        top: 1px;
+        width: calc(100% - 2px);
+        height: calc(100% - 2px);
+        border-radius: $formToggle-border-radius;
+        border: $formToggle-border-width solid $formToggle-border-color-interact;
+    }
+}
+
+@mixin formToggle-checkedState() {
+    @include formToggle-border();
+    // for `formToggle-checkedState` we double the size of the element and scale by
+    // 0.5 to make a 0.5px border render for the checked state
+    &:after {
+        width: calc(200% + 4px);
+        height: calc(200% + 4px);
+        border-radius: ($formToggle-border-radius * 2);
         border: $formToggle-border-width solid $formToggle-border-color-checked;
+        transform: scale(0.5) translate(-50%, -50%);
     }
 }
 
@@ -163,6 +210,8 @@ $formToggle-disabled-text           : $grey--lighter;
             }
 
             .o-formToggle-input:checked ~ & {
+                font-weight: 500;
+                color: $formToggle-checked-text;
                 @include formToggle-checkedSpacing();
             }
 
@@ -173,25 +222,32 @@ $formToggle-disabled-text           : $grey--lighter;
                 }
             }
 
-            .o-formToggle-input:not([disabled]):checked ~ & {
-                @include formToggle-checkedBorder();
-            }
-
-            .o-formToggle:not(.o-formToggle--disabled):hover &,
-            .o-formToggle:not(.o-formToggle--disabled):focus & {
+            .o-formToggle:not(.o-formToggle--disabled):hover & {
                 @include media('>=mid') {
-                    @include formToggle-checkedBorder();
+                    @include formToggle-hoverState();
                 }
             }
 
-            .o-formToggle-input:not([disabled]):checked ~ &,
-            .o-formToggle-input:not([disabled]):focus ~ & {
-                @include formToggle-checkedBorder();
+            .o-formToggle:not(.o-formToggle--disabled):focus & {
+                @include media('>=mid') {
+                    @include formToggle-focusState();
+                }
             }
 
-            .o-formToggle-input:not(:disabled):focus ~ &,
+            .o-formToggle-input:not([disabled]):hover ~ &,
             .o-formToggle-input:not(:disabled):hover ~ & {
-                @include formToggle-checkedBorder();
+                @include formToggle-hoverState();
+            }
+            
+            .o-formToggle-input:not([disabled]):focus ~ &,
+            .o-formToggle-input:not(:disabled):focus ~ & {
+                @include formToggle-focusState();
+            }
+
+
+            .o-formToggle-input:not([disabled]):checked ~ &,
+            .o-formToggle-input:not(:disabled):checked ~ & {
+                @include formToggle-checkedState();
             }
 
             .o-formToggle--largeSized & {
@@ -221,9 +277,9 @@ $formToggle-disabled-text           : $grey--lighter;
                 fill: $formToggle-icon-background;
 
                 .o-formToggle-input:not([disabled]):hover ~ &,
-                .o-formToggle-input:not(:checked):hover ~ &,
+                .o-formToggle-input:not([checked]):hover ~ &,
                 .o-formToggle-input:not([disabled]):focus ~ &,
-                .o-formToggle-input:not(:checked):focus ~ & {
+                .o-formToggle-input:not([checked]):focus ~ & {
                     @include media('>=mid') {
                         fill: $formToggle-icon-hover-background;
                     }
@@ -231,8 +287,15 @@ $formToggle-disabled-text           : $grey--lighter;
 
                 .o-formToggle-input:checked ~ & {
                     @include formToggle-iconActive();
+
+                    &:hover,
+                    &:focus {
+                    fill: $formToggle-icon-background;
+                        
+                    }
                 }
 
+                .o-formToggle-input:not(:disabled):focus ~ &,
                 .o-formToggle-input:not(:disabled):hover ~ & {
                     @include media('>=mid') {
                         @include formToggle-iconActive();


### PR DESCRIPTION
### Added
- Improved a11y focus states on `.o-formToggle`.

### Changed
- Updated `.o-formToggle` checked state to reflect new design.

### Fixed
- Fixed icon showing on hover.
- Fixed border updating when checked (missing content in pseudo).


Before:
<img width="304" alt="screen shot 2018-10-29 at 14 38 08" src="https://user-images.githubusercontent.com/5295718/47657176-77fe7480-db88-11e8-9726-20b471e543f4.png">


After:
<img width="303" alt="screen shot 2018-10-29 at 14 11 26" src="https://user-images.githubusercontent.com/5295718/47657019-34a40600-db88-11e8-8bac-89e17c64607f.png">

- [x] This PR has been checked with regard to our brand guidelines
- [x] This code has been checked with regard to our accessibility standards

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile