### PR TITLE
v1.9.0 - Star rating size issue on high DPR devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.9.0
+------------------------------
+*October 30, 2018*
+
+### Fixed
+- Fixed small star rating widths on devices with pixel density ratio of +3.
+
 
 v1.8.0
 ------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v1.9.0
 ------------------------------
-*October 30, 2018*
+*November 2, 2018*
 
 ### Fixed
 - Fixed small star rating widths on devices with pixel density ratio of +3.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_ratings.scss
+++ b/src/scss/components/optional/_ratings.scss
@@ -17,6 +17,11 @@ $star-size--medium      : 28px;
 $star-size--large       : 42px;
 $star-spacing           : $star-count;
 
+@mixin smallStarSizing() {
+    height: $star-size--small;
+    width: ($star-size--small * $star-count) + $star-spacing;
+}
+
 @mixin rating() {
 
     .c-rating {
@@ -29,8 +34,14 @@ $star-spacing           : $star-count;
     }
 
     .c-rating--small {
-        height: $star-size--small;
-        width: ($star-size--small * $star-count) + $star-spacing;
+
+        @include smallStarSizing();
+
+        @media only screen and (-webkit-device-pixel-ratio : 3) {
+            $star-spacing: 4;
+            
+            @include smallStarSizing();
+        }
     }
 
     .c-rating--medium {

--- a/src/scss/components/optional/_ratings.scss
+++ b/src/scss/components/optional/_ratings.scss
@@ -17,10 +17,6 @@ $star-size--medium      : 28px;
 $star-size--large       : 42px;
 $star-spacing           : $star-count;
 
-@mixin smallStarSizing() {
-    height: $star-size--small;
-    width: ($star-size--small * $star-count) + $star-spacing;
-}
 
 @mixin rating() {
 
@@ -35,12 +31,12 @@ $star-spacing           : $star-count;
 
     .c-rating--small {
 
-        @include smallStarSizing();
+        height: $star-size--small;
+        width: ($star-size--small * $star-count) + $star-spacing;
 
         @include media('retina3x') {
             $star-spacing: 4;
-
-            @include smallStarSizing();
+            width: ($star-size--small * $star-count) + $star-spacing;
         }
     }
 

--- a/src/scss/components/optional/_ratings.scss
+++ b/src/scss/components/optional/_ratings.scss
@@ -37,9 +37,9 @@ $star-spacing           : $star-count;
 
         @include smallStarSizing();
 
-        @media only screen and (-webkit-device-pixel-ratio : 3) {
+        @include media('retina3x') {
             $star-spacing: 4;
-            
+
             @include smallStarSizing();
         }
     }


### PR DESCRIPTION
- Move small star rating styles into mixin to reduce duplication
- Addition of pixel density ratio media query and override of spacing var within

On high (3+) pixel density ratio devices the small sized ratings would render ~ 6.1 stars

Before:
<img width="86" alt="screen shot 2018-10-30 at 15 42 57" src="https://user-images.githubusercontent.com/5295718/47730963-1fe47280-dc5b-11e8-96c6-6efde7ed1592.png">

After:
<img width="93" alt="screen shot 2018-10-30 at 15 48 12" src="https://user-images.githubusercontent.com/5295718/47731040-3e4a6e00-dc5b-11e8-90e4-6c2eb3c4462d.png">

- [x] This PR has been checked with regard to our brand guidelines

## Browsers Tested

- [x] Mobile