### PR TITLE
v1.11.0 - listing `has-noItems` style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v1.11.0
 ### Added
 - Added `display: none` to `has-noItems` within the listing component.
 
+
 v1.10.0
 ------------------------------
 *November 5, 2018*
@@ -17,12 +18,14 @@ v1.10.0
 ### Added
 - Added `.c-breadcrumb--transparent` class to use breadcrumbs with the transparent header.
 
+
 v1.9.0
 ------------------------------
 *October 30, 2018*
 
 ### Fixed
 - Fixed small star rating widths on devices with pixel density ratio of +3.
+
 
 v1.9.0
 ------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v1.11.0
+------------------------------
+*November 6, 2018*
+
+### Added
+- Added `display: none` to `has-noItems` within the listing component.
+
 v1.10.0
 ------------------------------
 *November 5, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_listings.scss
+++ b/src/scss/components/optional/_listings.scss
@@ -63,7 +63,6 @@ $listing--inactive-bg           : rgba($listing-bg, 0.5);
         }
 
         &.has-noItems {
-            border: 0;
             display: none;
         }
     }

--- a/src/scss/components/optional/_listings.scss
+++ b/src/scss/components/optional/_listings.scss
@@ -64,6 +64,7 @@ $listing--inactive-bg           : rgba($listing-bg, 0.5);
 
         &.has-noItems {
             border: 0;
+            display: none;
         }
     }
 

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -228,7 +228,7 @@ $formToggle-checked-text            : $green;
             .o-formToggle-input:not(:disabled):hover ~ & {
                 @include formToggle-hoverState();
             }
-            
+
             .o-formToggle-input:not([disabled]):focus ~ &,
             .o-formToggle-input:not(:disabled):focus ~ & {
                 @include formToggle-focusState();


### PR DESCRIPTION
- addition of display none to has-noItems class within listing component

Before (when `has-noItems` applied to an elm with bg colour):

<img width="916" alt="screen shot 2018-11-06 at 11 56 27" src="https://user-images.githubusercontent.com/5295718/48062874-35a5ea80-e1bb-11e8-9dbc-5b22d1e120f9.png">

## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines
## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile