### PR TITLE
v1.14.0 - IE11 star rating rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v1.14.0
+------------------------------
+### Fixed
+- Fixed star rating SVG rendering on IE11 by setting the background size to the set size of the SVG.
+
 v1.13.0
 ------------------------------
 *November 14, 2018*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v1.14.0
 ------------------------------
+*November 16, 2018*
+
 ### Fixed
 - Fixed star rating SVG rendering on IE11 by setting the background size to the set size of the SVG.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_ratings.scss
+++ b/src/scss/components/optional/_ratings.scss
@@ -41,10 +41,6 @@ $star-size--large       : 42px;
         .c-rating--fill {
             background-size: $star-size--small $star-size--small;
         }
-
-        @include media('retina3x') {
-            width: ($star-size--small * $star-count);
-        }
     }
 
     .c-rating--medium {

--- a/src/scss/components/optional/_ratings.scss
+++ b/src/scss/components/optional/_ratings.scss
@@ -15,7 +15,6 @@ $star-size--small       : 12px;
 $star-size--default     : 16px;
 $star-size--medium      : 28px;
 $star-size--large       : 42px;
-$star-spacing           : $star-count;
 
 
 @mixin rating() {
@@ -23,38 +22,55 @@ $star-spacing           : $star-count;
     .c-rating {
         @extend %c-icon--star--empty !optional;
         background-repeat: repeat-x;
-        background-size: contain;
         display: inline-block;
         height: $star-size--default;
-        width: ($star-size--default * $star-count) + $star-spacing;
+        width: ($star-size--default * $star-count);
+
+        &,
+        .c-rating--fill {
+            background-size: $star-size--default $star-size--default;
+        }
     }
 
     .c-rating--small {
 
         height: $star-size--small;
-        width: ($star-size--small * $star-count) + $star-spacing;
+        width: ($star-size--small * $star-count);
+
+        &,
+        .c-rating--fill {
+            background-size: $star-size--small $star-size--small;
+        }
 
         @include media('retina3x') {
-            $star-spacing: 4;
-            width: ($star-size--small * $star-count) + $star-spacing;
+            width: ($star-size--small * $star-count);
         }
     }
 
     .c-rating--medium {
         height: $star-size--medium;
-        width: ($star-size--medium * $star-count) + ($star-spacing * 2);
+        width: ($star-size--medium * $star-count);
+
+        &,
+        .c-rating--fill {
+            background-size: $star-size--medium $star-size--medium;
+        }
     }
 
     .c-rating--large {
         height: $star-size--large;
-        width: ($star-size--large * $star-count) + ($star-spacing * 3);
+        width: ($star-size--large * $star-count);
+
+        &,
+        .c-rating--fill {
+            background-size: $star-size--large $star-size--large;
+        }
     }
 
     .c-rating--fill {
         @extend %c-icon--star--fill !optional;
         vertical-align: top;
         background-repeat: repeat-x;
-        background-size: contain;
         display: inline-block;
         height: 100%;
         width: 100%;


### PR DESCRIPTION
- Fixed star rating SVG rendering on IE11 by setting the background size to the set size of the SVG.

background SVG's in IE11 don't like a background size of contain 

Before:

After:


## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines
## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile