### PR TITLE
v1.18.0 add styles for c-appsBanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.18.0
+------------------------------
+*December 4, 2018*
+
+### Added
+- Styles for `c-appsBanner`.
+
+
 v1.17.0
 ------------------------------
 *December 4, 2018*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/_dependencies.scss
+++ b/src/scss/_dependencies.scss
@@ -94,7 +94,7 @@
 @import 'components/optional/ratings';
 @import 'components/optional/toast';
 @import 'components/optional/cuisines-widget';
-
+@import 'components/optional/apps-banner';
 
 
 // Global layout definitions & helpers

--- a/src/scss/components/optional/_apps-banner.scss
+++ b/src/scss/components/optional/_apps-banner.scss
@@ -1,0 +1,102 @@
+/**
+ * Apps Banner Component
+ * =================================
+ * Used to display app promo banner on the page.
+ *
+ * *The `c-appBaner` component is an optional mixin within Fozzie — if you'd like to use it in your project you can include it by adding `@include appsBanner();` into your SCSS dependencies file.*
+ *
+ * Documentation:
+ * https://fozzie.just-eat.com/styleguide/ui-components/apps-banner
+ */
+
+@mixin appsBanner() {
+    @include media-context(('narrow-mid': 600px)) {
+        .c-appsBanner {
+            margin: spacing(x4) auto;
+            text-align: left;
+            position: relative;
+            padding-top: 40px;
+            display: flex;
+            flex-flow: row nowrap;
+            justify-content: center;
+            align-items: flex-start;
+
+            @include media('>=mid') {
+                padding-top: 0;
+                margin: spacing(x5) auto spacing(x6);
+                text-align: center;
+                align-items: center;
+            }
+
+            @include media('>=wide') {
+                margin: spacing(x8) auto;
+                justify-content: flex-start;
+            }
+        }
+
+        .c-appsBanner-heading {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            text-align: center;
+
+
+            @include media('>=mid') {
+                position: relative;
+                @include font-size('jumbo', false);
+            }
+        }
+
+        .c-appsBanner-image {
+            overflow: hidden;
+            flex: 0 1 84px;
+
+            @include media('>=narrow-mid') {
+                flex: 0 1 324px;
+            }
+
+            @include media('>=wide') {
+                flex: 0 1 492px;
+            }
+
+            img {
+                width: 100%;
+            }
+        }
+
+        .c-appsBanner-content {
+            margin-left: spacing(x2);
+            flex: 0 1 300px;
+
+            @include media('>=mid') {
+                text-align: center;
+                flex: 1 1 auto;
+            }
+
+            p {
+                margin-top: 0;
+
+                @include media('>=mid') {
+                    margin-top: spacing();
+                }
+            }
+        }
+
+        .c-appsBanner-buttons {
+            margin-top: spacing(x3);
+        }
+
+        .c-appsBanner-appBtn {
+            display: block;
+
+            &:first-child {
+                margin-right: spacing(x1.5);
+            }
+
+            @include media('>=mid') {
+                display: inline-block;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Added
- Styles for `c-appsBanner`.

In future for mobile there will be only one "download the app" button depending on what device you are + image will be different.

[![Image from Gyazo](https://i.gyazo.com/8457d05568fa6110f1bc089e589283a8.gif)](https://gyazo.com/8457d05568fa6110f1bc089e589283a8)


- [ + ] This PR has been checked with regard to our brand guidelines
- [ + ] UI Documentation has been [created|updated]
- [ + ] This code has been checked with regard to our accessibility standards

## Browsers Tested

- [ + ] Chrome
- [ + ] Firefox
- [ + ] Safari
- [ + ] Edge
- [ + ] Internet Explorer 11
- [ + ] Mobile (iPhone/Android - via responsive browser mode)
