### PR TITLE
v1.20.0 - Updated vertical padding to button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v1.20.0
+------------------------------
+*December 17, 2018*
+
+### Changed
+- Updated button vert padding
+
 
 v1.19.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -19,7 +19,7 @@ $btn-default-font-family            : 'Ubuntu';
 $btn-default-bgColor--hover         : $grey--lighter;
 $btn-default-borderRadius           : 2px;
 $btn-default-hozPadding             : 1em;
-$btn-default-vertPadding            : 15px;
+$btn-default-vertPadding            : 11px;
 
 $btn-primary-bgColor                : $blue;
 $btn-primary-bgColor--hover         : $blue--dark;


### PR DESCRIPTION
The height of the button is currently 48px instead of the proposed 40px. This change decreases the vertical padding to fix this.

[Zeplin](https://app.zeplin.io/project/58e7554e0352f8ef2215f131/screen/5ab53161419dc1979f6d51de)

- [x] This PR has been checked with regard to our brand guidelines
- [X] UI Documentation has been [created|updated]
  
## Browsers Tested

- [X] Chrome
- [ ] Edge
- [ ] Internet Explorer 11
- [X] Mobile (i.e. iPhone/Android - please list device)