### PR TITLE
v1.24.1 - Alignment tweeks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v1.24.1
 ------------------------------
-*January 23, 2019*
+*January 24, 2019*
 
 ### Fixed
 - Adjusted dates in changelog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.24.1
+------------------------------
+*January 23, 2019*
+
+### Fixed
+- Adjusted dates in changelog.
+- Removed height on `c-contentTitle-icon` to fix icon alignment.
+
+### Added
+- `white-space: initial` to `.c-listing-item-detailsRow-text` to adjust line wrapping.
+
+
 v1.24.0
 ------------------------------
-*January 15, 2018*
+*January 15, 2019*
 
 ### Added
 - `l-innerContainer--verticalSpacing` for base spacing between sections.
@@ -14,7 +26,7 @@ v1.24.0
 
 v1.23.0
 ------------------------------
-*January 11, 2018*
+*January 11, 2019*
 
 ### Changed
 - Adjusted collapsible card padding and heights for different device widths.
@@ -22,7 +34,7 @@ v1.23.0
 
 v1.22.0
 ------------------------------
-*January 10, 2018*
+*January 10, 2019*
 
 ### Added
 - LGTM badge on readme.
@@ -36,7 +48,7 @@ v1.22.0
 
 v1.21.0
 ------------------------------
-*January 9, 2018*
+*January 9, 2019*
 
 ### Changed
 - Hide all but the paragraph element in a collapsed card section.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_content-title.scss
+++ b/src/scss/components/optional/_content-title.scss
@@ -23,7 +23,6 @@
 
         .c-contentTitle-icon {
             width: 24px;
-            height: 24px;
             margin-right: spacing();
         }
 

--- a/src/scss/components/optional/_listings.scss
+++ b/src/scss/components/optional/_listings.scss
@@ -244,6 +244,7 @@ $listing--inactive-bg           : rgba($listing-bg, 0.5);
             }
 
             .c-listing-item-detailsRow-text {
+                white-space: initial;
                 margin-left: spacing();
             }
 


### PR DESCRIPTION
### Fixed
- Adjusted dates in changelog.
- Removed height on `c-contentTitle-icon` to fix icon alignment.

### Added
- `white-space: initial` to `.c-listing-item-detailsRow-text` to adjust line wrapping.

## UI Review Checks

## Before
<img width="340" alt="small icon" src="https://user-images.githubusercontent.com/43729056/51617618-7ee91900-1f24-11e9-8edb-867068d69698.png">

## After
![big icon](https://user-images.githubusercontent.com/43729056/51617656-96c09d00-1f24-11e9-8eca-6f3d1eb02101.PNG)
## Before 
<img width="314" alt="broken1" src="https://user-images.githubusercontent.com/43729056/51617691-a9d36d00-1f24-11e9-9f2d-759cff99c972.png">

## After 

![broken2](https://user-images.githubusercontent.com/43729056/51617704-afc94e00-1f24-11e9-855e-f91c585d0963.PNG)

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile (i.e. iPhone/Android - please list device)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
