### PR TITLE
v1.30.0 - Rewrite c-cuisinesWidget to use css grid instead of flex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ v1.30.0
 ### Changed
 - Rewrite `c-cuisinesWidget` to use css grid instead of flex
 
+Now the component has grid modifier class `c-cuisinesWidget-grid--gridOfThree` instead of widget modifier class `c-cuisinesWidget--gridOfThree`
+
 
 v1.29.1
 ------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.30.0
+------------------------------
+*February 11, 2019*
+
+### Changed
+- Rewrite `c-cuisinesWidget` to use css grid instead of flex
+
+
 v1.29.1
 ------------------------------
 *February 6, 2019*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.29.1",
+  "version": "1.30.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_cuisines-widget.scss
+++ b/src/scss/components/optional/_cuisines-widget.scss
@@ -13,6 +13,7 @@
 
 //TODO: Improvement of this solution: WH-682 as suggested in https://github.com/justeat/fozzie/pull/188#issuecomment-442138750
 
+
 $cuisinesWidget-titleColour: $white;
 $cuisinesWidget-defaultBackground: $brand--red;
 $cuisinesWidget-boxShadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
@@ -23,113 +24,69 @@ $cuisinesWidget-gradient: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0,
     @include media-context(('narrow-mid': 570px, 'mid-wide': 1240px)) {
 
        .c-cuisinesWidget {
-           display: block;
-           border-radius: 8px;
-           overflow: hidden;
-           position: relative;
-           background-color: $cuisinesWidget-defaultBackground;
-           box-shadow: $cuisinesWidget-boxShadow;
+            min-height: 96px;
+            display: block;
+            border-radius: 8px;
+            overflow: hidden;
+            position: relative;
+            background-color: $cuisinesWidget-defaultBackground;
+            box-shadow: $cuisinesWidget-boxShadow;
 
            &:hover {
-               box-shadow: $cuisinesWidget-hoverBoxShadow;
-           }
-       }
-
-       .c-cuisinesWidget-name {
-           position: absolute;
-           bottom: 0;
-           left: 0;
-           width: 100%;
-           padding: spacing(x2);
-           color: $cuisinesWidget-titleColour;
-           text-align: center;
-           background-image: $cuisinesWidget-gradient;
-
-           @include media('>=mid-wide') {
-               @include font-size(large, false);
-               padding: spacing(x3);
-           }
-       }
-
-       .c-cuisinesWidget-img {
-           vertical-align: bottom;
-           width: 100%;
-       }
-
-      // grid of three elements for wide viewports, two for mid and one for narrow
-       .c-cuisinesWidget--gridOfThree {
-           min-height: 96px;
-           width: 100%;
-           max-width: 360px;
-           margin: auto;
-           margin-bottom: spacing(x2);
-
-           &:last-child {
-               margin-bottom: 0;
-           }
+                box-shadow: $cuisinesWidget-hoverBoxShadow;
+            }
 
            @include media('>=mid') {
-               min-height: 133px;
-               max-width: none;
-           }
+                min-height: 133px;
+            }
 
-           @include media('>=narrow-mid') {
-               width: calc(50% - 8px);
-               margin-right: spacing(x2);
-               margin-left: 0;
-               margin-top: 0;
+            @include media('>=mid-wide') {
+                min-height: 145px;
+            }
+        }
 
-               //for the grid of 2 elements for every second element not to have right margin
-               &:nth-child(even) {
-                   margin-right: 0;
-               }
+        .c-cuisinesWidget-name {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            padding: spacing(x2);
+            color: $cuisinesWidget-titleColour;
+            text-align: center;
+            background-image: $cuisinesWidget-gradient;
 
-               //for the grid of 2 elements last row of elements not to have bottom margin
-               //(last child 0 margin is in initial styles above)
-               &:nth-last-child(2) {
-                   margin-bottom: 0;
-               }
-           }
+            @include media('>=mid-wide') {
+                @include font-size(large, false);
+                padding: spacing(x3);
+            }
+        }
 
+        .c-cuisinesWidget-img {
+            vertical-align: bottom;
+            width: 100%;
+        }
 
-           @include media('>=mid-wide') {
-               min-height: 145px;
-               width: calc((100% - 32px) / 3);
+        /* autoprefixer grid: autoplace */
+        //for IE it should be explicit grid
+        .c-cuisinesWidget-grid {
+            max-width: 360px;
+            margin: auto;
+            display: grid;
+            grid-template-columns: auto;
+            grid-template-rows: auto auto auto auto auto auto;
+            grid-gap: spacing(x2);
 
-               &:nth-child(even) {
-                   margin-right: spacing(x2);
-               }
+            @include media('>=narrow-mid') {
+                max-width: 800px;
+                grid-template-columns: auto auto;
+                grid-template-rows: auto auto auto;
+            }
 
-               //Every third element will not have right margin + the last one
-               //(if the amount of items is not divisible by 3)
-               &:nth-child(3n+3),
-               &:last-child {
-                   margin-right: 0;
-               }
-
-               //for the grid of 3 elements last row of elements not to have bottom margin
-               //(last and second to last childs 0 margin are in styles above)
-               &:nth-last-child(3) {
-                   margin-bottom: 0;
-               }
-           }
-       }
-
-       .c-cuisinesWidget-grid {
-           display: flex;
-           flex-flow: row wrap;
-           justify-content: flex-start;
-           align-items: flex-start;
-
-           @include media('>=mid') {
-               max-width: 800px;
-               margin-left: auto;
-               margin-right: auto;
-           }
-
-           @include media('>=mid-wide') {
-               max-width: 1208px;
-           }
-       }
-   }
+            @include media('>=mid-wide') {
+                grid-template-columns: auto auto auto;
+                grid-template-rows: auto auto;
+                max-width: none;
+            }
+        }
+    }
 }

--- a/src/scss/components/optional/_cuisines-widget.scss
+++ b/src/scss/components/optional/_cuisines-widget.scss
@@ -67,17 +67,27 @@ $cuisinesWidget-gradient: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0,
         }
 
         /* autoprefixer grid: autoplace */
-        //for IE it should be explicit grid
         .c-cuisinesWidget-grid {
             max-width: 360px;
             margin: auto;
             display: grid;
+
+            @include media('>=narrow-mid') {
+                max-width: 800px;
+            }
+
+            @include media('>=mid-wide') {
+                max-width: none;
+            }
+        }
+
+        //for IE it should be explicit grid
+        .c-cuisinesWidget-grid--gridOfThree {
             grid-template-columns: auto;
             grid-template-rows: auto auto auto auto auto auto;
             grid-gap: spacing(x2);
 
             @include media('>=narrow-mid') {
-                max-width: 800px;
                 grid-template-columns: auto auto;
                 grid-template-rows: auto auto auto;
             }
@@ -85,7 +95,6 @@ $cuisinesWidget-gradient: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0,
             @include media('>=mid-wide') {
                 grid-template-columns: auto auto auto;
                 grid-template-rows: auto auto;
-                max-width: none;
             }
         }
     }


### PR DESCRIPTION
### Changed
- Rewrite `c-cuisinesWidget` to use css grid instead of flex

The block looks the same as with flexboxes, just fixed the Edge width calculation problem and reduce a little bit amount of styles

[![Gif from Gyazo](https://i.gyazo.com/c0df29a69863fb93c97fe8c405c2000e.gif)](https://gyazo.com/c0df29a69863fb93c97fe8c405c2000e)

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Firefox
- [x] Safari
- [x] Mobile (via browser simulator)

