### PR TITLE
v1.30.1 - Add pointer cursor for cookie banner close button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.30.1
+------------------------------
+*February 11, 2019*
+
+### Fixed
+- Update the cursor type for the cookie banner close button
+
+
 v1.30.0
 ------------------------------
 *February 11, 2019*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_cookie-warning.scss
+++ b/src/scss/components/optional/_cookie-warning.scss
@@ -45,12 +45,12 @@
 		background: url('//dy3erx8o0a6nh.cloudfront.net/images/icon-close-banner.png') no-repeat center center;
 		background-size: 10px 10px;
 		border: none;
-		cursor: pointer;
 
 		&:hover,
 		&:active,
 		&:focus {
 			background-color: $grey--mid;
+			cursor: pointer;
 		}
 	}
 

--- a/src/scss/components/optional/_cookie-warning.scss
+++ b/src/scss/components/optional/_cookie-warning.scss
@@ -45,6 +45,7 @@
 		background: url('//dy3erx8o0a6nh.cloudfront.net/images/icon-close-banner.png') no-repeat center center;
 		background-size: 10px 10px;
 		border: none;
+		cursor: pointer;
 
 		&:hover,
 		&:active,


### PR DESCRIPTION
The cursor type for the button to close the cookie banner did not change on mouseover, but it should be `pointer` to "feel right" to users.

## UI Review Checks

- [ ] UI Documentation has been updated

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Opera
