### PR TITLE
v1.31.0 Css class names fix for cuisines block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.31.0
+------------------------------
+*February 12, 2019*
+
+### Changed
+- Change class names from `c-cuisinesWidget-grid` and `c-cuisinesWidget-grid--gridOfThree` to `c-cuisinesGrid` and `c-cuisinesGrid--gridOfThree`
+
+
 v1.30.1
 ------------------------------
 *February 11, 2019*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.30.1",
+  "version": "1.31.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_cuisines-widget.scss
+++ b/src/scss/components/optional/_cuisines-widget.scss
@@ -67,7 +67,7 @@ $cuisinesWidget-gradient: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0,
         }
 
         /* autoprefixer grid: autoplace */
-        .c-cuisinesWidget-grid {
+        .c-cuisinesGrid {
             max-width: 360px;
             margin: auto;
             display: grid;
@@ -82,7 +82,7 @@ $cuisinesWidget-gradient: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0,
         }
 
         //for IE it should be explicit grid
-        .c-cuisinesWidget-grid--gridOfThree {
+        .c-cuisinesGrid--gridOfThree {
             grid-template-columns: auto;
             grid-template-rows: auto auto auto auto auto auto;
             grid-gap: spacing(x2);


### PR DESCRIPTION
### Changed
- Change class names from `c-cuisinesWidget-grid` and `c-cuisinesWidget-grid--gridOfThree` to `c-cuisinesGrid` and `c-cuisinesGrid--gridOfThree`