### PR TITLE
v1.33.0 add more media breakpoints to c-pageBanner--tall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
-v1.32.1
+v1.33.0
 ------------------------------
 *February 19, 2019*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v1.33.0
 ------------------------------
-*February 19, 2019*
+*February 20, 2019*
 
 ### Changed
 - Add more media breakpoints to `c-pageBanner--tall`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.32.1
+------------------------------
+*February 19, 2019*
+
+### Changed
+- Add more media breakpoints to `c-pageBanner--tall`
+
+
 v1.32.0
 ------------------------------
 *February 14, 2019*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.32.1",
+  "version": "1.33.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_page-banner.scss
+++ b/src/scss/components/optional/_page-banner.scss
@@ -18,6 +18,7 @@ $pageBanner-bg: $white;
 $rays--coloured-spacing: 60px;
 $rays--coloured-spacing--mid: 164px;
 $rays--coloured-spacing--wide: 148px;
+$rays--coloured-spacing--huge: 230px;
 
 
 @mixin pageBanner() {
@@ -117,7 +118,6 @@ $rays--coloured-spacing--wide: 148px;
             bottom: -$rays--coloured-spacing;
 
             @include media('>=mid') {
-                background: url('#{$img-path-url}/decoration/rays--coloured--mid.svg') no-repeat bottom left;
                 bottom: -$rays--coloured-spacing--mid;
             }
 
@@ -126,8 +126,18 @@ $rays--coloured-spacing--wide: 148px;
                 bottom: -$rays--coloured-spacing--wide;
             }
 
+            @include media('>=huge') {
+                bottom: -$rays--coloured-spacing--huge;
+            }
+
+            // Prevents IE from applying these styles as IE11 doesn't support the @supports rule
             @supports (position: absolute) {
                 bottom: 0;
+
+                @include media('>=mid') {
+                    // removed this image call from IE because of the svg wrong scaling bug. SVG for smaller screens looks much better in IE
+                    background: url('#{$img-path-url}/decoration/rays--coloured--mid.svg') no-repeat bottom left;
+                }
             }
         }
     }

--- a/src/scss/components/optional/_page-banner.scss
+++ b/src/scss/components/optional/_page-banner.scss
@@ -134,7 +134,7 @@ $rays--coloured-spacing--huge: 230px;
             @supports (position: absolute) {
                 bottom: 0;
 
-                @include media('>=mid') {
+                @include media('>=mid', '<wide') {
                     // removed this image call from IE because of the svg wrong scaling bug. SVG for smaller screens looks much better in IE
                     background: url('#{$img-path-url}/decoration/rays--coloured--mid.svg') no-repeat bottom left;
                 }

--- a/src/scss/components/optional/_page-banner.scss
+++ b/src/scss/components/optional/_page-banner.scss
@@ -36,12 +36,24 @@ $rays--coloured-spacing--wide: 148px;
     .c-pageBanner--tall {
         max-height: 221px;
 
+        @include media('>=tiny') {
+            max-height: 318px;
+        }
+
         @include media('>=narrow') {
-            max-height: 460px;
+            max-height: 370px;
+        }
+
+        @include media('>=mid') {
+            max-height: 626px;
         }
 
         @include media('>=wide') {
-            max-height: 600px;
+            max-height: 703px;
+        }
+
+        @include media('>=huge') {
+            max-height: 780px;
         }
 
         &.c-pageBanner--withRays--coloured {


### PR DESCRIPTION
### Changed
- Add more media breakpoints to `c-pageBanner--tall`

![screen shot 2019-02-19 at 14 17 20](https://user-images.githubusercontent.com/19548183/53021503-4409d080-3451-11e9-8882-50f3118da293.png)
![screen shot 2019-02-19 at 14 17 28](https://user-images.githubusercontent.com/19548183/53021507-45d39400-3451-11e9-879f-2b5846e64d5e.png)
![screen shot 2019-02-19 at 14 17 39](https://user-images.githubusercontent.com/19548183/53021514-48ce8480-3451-11e9-81bc-d0472cedccae.png)
![screen shot 2019-02-19 at 14 17 47](https://user-images.githubusercontent.com/19548183/53021519-4b30de80-3451-11e9-90e5-a4be1ef04522.png)
![screen shot 2019-02-19 at 14 17 56](https://user-images.githubusercontent.com/19548183/53021521-4cfaa200-3451-11e9-9c29-dc295d372574.png)
![screen shot 2019-02-19 at 14 18 14](https://user-images.githubusercontent.com/19548183/53021526-4ec46580-3451-11e9-8089-c060453f314e.png)
