### PR TITLE
v1.37.0 - Fix cookie banner text flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.37.0
+------------------------------
+*March 20, 2019*
+
+### Fixed
+- Styling for `c-cookieWarning-inner` to prevent text flowing under the close button.
+
+
 v1.36.0
 ------------------------------
 *March 12, 2019*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_cookie-warning.scss
+++ b/src/scss/components/optional/_cookie-warning.scss
@@ -1,51 +1,51 @@
 @mixin cookieWarning() {
-	.c-cookieWarning {
-	    background-color: $grey--darkest;
-	    position: fixed;
-	    bottom: 0;
-		width: 100%;
-		z-index: zIndex(high);
+    .c-cookieWarning {
+        background-color: $grey--darkest;
+        position: fixed;
+        bottom: 0;
+        width: 100%;
+        z-index: zIndex(high);
 
-		& p {
-			@include font-size(small, false);
-			color: $white;
-			text-align: center;
-			margin: 0 auto;
-		}
-	}
+        & p {
+            @include font-size(small, false);
+            color: $white;
+            text-align: center;
+            margin: 0 auto;
+        }
+    }
 
-	.c-cookieWarning-inner {
-	    margin: 0 auto;
-		padding: spacing();
-		padding-right: spacing(x3);
-	    overflow: hidden;
-	}
+    .c-cookieWarning-inner {
+        margin: 0 auto;
+        padding: spacing();
+        padding-right: spacing(x3);
+        overflow: hidden;
+    }
 
-	.c-cookieWarning-btn {
-	    display: block;
-	    position: absolute;
-	    top: 8px;
-	    right: 8px;
-	    width: 10px;
-	    height: 10px;
-		background: url('//dy3erx8o0a6nh.cloudfront.net/images/icon-close-banner.png') no-repeat center center;
-		background-size: 10px 10px;
-		border: none;
+    .c-cookieWarning-btn {
+        display: block;
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        width: 10px;
+        height: 10px;
+        background: url('//dy3erx8o0a6nh.cloudfront.net/images/icon-close-banner.png') no-repeat center center;
+        background-size: 10px 10px;
+        border: none;
 
-		&:hover,
-		&:active,
-		&:focus {
-			background-color: $grey--mid;
-			cursor: pointer;
-		}
-	}
+        &:hover,
+        &:active,
+        &:focus {
+            background-color: $grey--mid;
+            cursor: pointer;
+        }
+    }
 
-	.c-cookieWarning-link {
-		color: $white;
-		&:hover,
-		&:active,
-		&:focus {
-			color: $white;
-		}
-	}
+    .c-cookieWarning-link {
+        color: $white;
+        &:hover,
+        &:active,
+        &:focus {
+            color: $white;
+        }
+    }
 }

--- a/src/scss/components/optional/_cookie-warning.scss
+++ b/src/scss/components/optional/_cookie-warning.scss
@@ -5,34 +5,20 @@
 	    bottom: 0;
 		width: 100%;
 		z-index: zIndex(high);
+
+		& p {
+			@include font-size(small, false);
+			color: $white;
+			text-align: center;
+			margin: 0 auto;
+		}
 	}
 
 	.c-cookieWarning-inner {
-	    width: 940px;
 	    margin: 0 auto;
-	    padding: spacing() 0;
+		padding: spacing();
+		padding-right: spacing(x3);
 	    overflow: hidden;
-
-	    @include media('<wide') {
-	    	width: 830px;
-	    }
-    	@include media('<mid') {
-	        width: 414px;
-		}
-		@include media('<narrow') {
-	        width: 375px;
-		}
-		@include media('<tiny') {
-			margin-top: 12px;
-			width: 100%;
-		}
-	}
-
-	.c-cookieWarning p {
-		@include font-size(small, false);
-		color: $white;
-		text-align: center;
-		margin: 0 auto;
 	}
 
 	.c-cookieWarning-btn {


### PR DESCRIPTION
Fix cookie banner text flow, remove unnecessary CSS and simplify using scss syntax

## UI Review Checks

![911bd8281b046575ff264c647d599e2c](https://user-images.githubusercontent.com/26894168/54684951-87696480-4b0d-11e9-8d9d-d1199d9ed0f2.gif)

CSS change only, no HTML.

## Browsers Tested

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile (emulated mobile in Chrome for Galaxy S5, iPhone 6, iPad, etc)
- [ ] Safari
