### PR TITLE
v1.38.0 - Fix app component padding and image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.37.0
+------------------------------
+*March 20, 2019*
+
+### Fixed
+- Styling for `c-cookieWarning-inner` to prevent text flowing under the close button.
+
+
 v1.36.0
 ------------------------------
 *March 12, 2019*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.38.0
+------------------------------
+*March 20, 2019*
+
+### Changed
+- Alignment and image size of app component.
+
+
 v1.37.0
 ------------------------------
 *March 20, 2019*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_apps-banner.scss
+++ b/src/scss/components/optional/_apps-banner.scss
@@ -14,7 +14,8 @@
         .c-appsBanner {
             text-align: left;
             position: relative;
-            padding-top: 40px;
+            padding-top: spacing(x5);
+            padding-left: spacing(x3);
             display: flex;
             flex-flow: row nowrap;
             justify-content: center;
@@ -37,6 +38,7 @@
             left: 0;
             width: 100%;
             text-align: center;
+            padding-left: spacing(x3);
 
 
             @include media('>=mid') {
@@ -47,7 +49,11 @@
 
         .c-appsBanner-image {
             overflow: hidden;
-            flex: 0 1 84px;
+            flex: 0 1 120px;
+
+            @include media('>=narrow') {
+                flex: 0 1 104px;
+            }
 
             @include media('>=narrow-mid') {
                 flex: 0 1 324px;
@@ -86,10 +92,6 @@
 
         .c-appsBanner-appBtn {
             display: block;
-
-            &:first-child {
-                margin-right: spacing(x1.5);
-            }
 
             @include media('>=mid') {
                 display: inline-block;

--- a/src/scss/components/optional/_cookie-warning.scss
+++ b/src/scss/components/optional/_cookie-warning.scss
@@ -1,51 +1,51 @@
 @mixin cookieWarning() {
-	.c-cookieWarning {
-	    background-color: $grey--darkest;
-	    position: fixed;
-	    bottom: 0;
-		width: 100%;
-		z-index: zIndex(high);
+    .c-cookieWarning {
+        background-color: $grey--darkest;
+        position: fixed;
+        bottom: 0;
+        width: 100%;
+        z-index: zIndex(high);
 
-		& p {
-			@include font-size(small, false);
-			color: $white;
-			text-align: center;
-			margin: 0 auto;
-		}
-	}
+        & p {
+            @include font-size(small, false);
+            color: $white;
+            text-align: center;
+            margin: 0 auto;
+        }
+    }
 
-	.c-cookieWarning-inner {
-	    margin: 0 auto;
-		padding: spacing();
-		padding-right: spacing(x3);
-	    overflow: hidden;
-	}
+    .c-cookieWarning-inner {
+        margin: 0 auto;
+        padding: spacing();
+        padding-right: spacing(x3);
+        overflow: hidden;
+    }
 
-	.c-cookieWarning-btn {
-	    display: block;
-	    position: absolute;
-	    top: 8px;
-	    right: 8px;
-	    width: 10px;
-	    height: 10px;
-		background: url('//dy3erx8o0a6nh.cloudfront.net/images/icon-close-banner.png') no-repeat center center;
-		background-size: 10px 10px;
-		border: none;
+    .c-cookieWarning-btn {
+        display: block;
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        width: 10px;
+        height: 10px;
+        background: url('//dy3erx8o0a6nh.cloudfront.net/images/icon-close-banner.png') no-repeat center center;
+        background-size: 10px 10px;
+        border: none;
 
-		&:hover,
-		&:active,
-		&:focus {
-			background-color: $grey--mid;
-			cursor: pointer;
-		}
-	}
+        &:hover,
+        &:active,
+        &:focus {
+            background-color: $grey--mid;
+            cursor: pointer;
+        }
+    }
 
-	.c-cookieWarning-link {
-		color: $white;
-		&:hover,
-		&:active,
-		&:focus {
-			color: $white;
-		}
-	}
+    .c-cookieWarning-link {
+        color: $white;
+        &:hover,
+        &:active,
+        &:focus {
+            color: $white;
+        }
+    }
 }

--- a/src/scss/components/optional/_cookie-warning.scss
+++ b/src/scss/components/optional/_cookie-warning.scss
@@ -5,34 +5,20 @@
 	    bottom: 0;
 		width: 100%;
 		z-index: zIndex(high);
+
+		& p {
+			@include font-size(small, false);
+			color: $white;
+			text-align: center;
+			margin: 0 auto;
+		}
 	}
 
 	.c-cookieWarning-inner {
-	    width: 940px;
 	    margin: 0 auto;
-	    padding: spacing() 0;
+		padding: spacing();
+		padding-right: spacing(x3);
 	    overflow: hidden;
-
-	    @include media('<wide') {
-	    	width: 830px;
-	    }
-    	@include media('<mid') {
-	        width: 414px;
-		}
-		@include media('<narrow') {
-	        width: 375px;
-		}
-		@include media('<tiny') {
-			margin-top: 12px;
-			width: 100%;
-		}
-	}
-
-	.c-cookieWarning p {
-		@include font-size(small, false);
-		color: $white;
-		text-align: center;
-		margin: 0 auto;
 	}
 
 	.c-cookieWarning-btn {


### PR DESCRIPTION
The app component that is shown when a user is not logged in was a bit unbalanced on mobile. I've added some left padding and adjusted the image size to match.

## UI Review Checks

![a46c4640896b2d5a4f6dd52a95035824](https://user-images.githubusercontent.com/26894168/54694128-a244d480-4b1f-11e9-94d6-57f720e1f370.gif)

CSS change only, no HTML.

## Browsers Tested

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile (emulated various devices on Chrome)