### PR TITLE
v1.39.0 c-order-card styles amends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ v1.39.0
 *March 21, 2019*
 
 ### Changed
-- `c-order-card` style amends.
+- `c-order-card` style amendments.
 - `c-cuisinesWidget` underline text on hover state.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.39.0
+------------------------------
+*March 21, 2019*
+
+### Changed
+- `c-order-card` style amends.
+
+
 v1.38.0
 ------------------------------
 *March 20, 2019*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v1.39.0
 
 ### Changed
 - `c-order-card` style amends.
+- `c-cuisinesWidget` underline text on hover state.
 
 
 v1.38.0

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_cuisines-widget.scss
+++ b/src/scss/components/optional/_cuisines-widget.scss
@@ -34,8 +34,13 @@ $cuisinesWidget-gradient: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0,
             box-shadow: $cuisinesWidget-boxShadow;
             margin-bottom: spacing(x2);
 
-            &:hover {
+            &:hover,
+            &:focus {
                 box-shadow: $cuisinesWidget-hoverBoxShadow;
+
+                .c-cuisinesWidget-name {
+                    text-decoration: underline;
+                }
             }
 
             @include media('>=narrow-mid') {

--- a/src/scss/components/optional/_order-card.scss
+++ b/src/scss/components/optional/_order-card.scss
@@ -16,13 +16,13 @@ $previousOrder-hoverBoxShadow: 0 2px 8px 0 rgba(0, 0, 0, 0.16), -2px -2px 4px 0 
 
 @mixin orderCard() {
     .c-orderCard {
-        display: block;
+        display: flex;
+        flex-direction: column;
         border-radius: 8px;
         box-shadow: $previousOrder-boxShadow;
         background-color: $white;
         overflow: hidden;
         text-decoration: none;
-        color: $grey--mid;
         width: 280px;
         max-width: 280px;
         min-height: 259px;
@@ -101,18 +101,20 @@ $previousOrder-hoverBoxShadow: 0 2px 8px 0 rgba(0, 0, 0, 0.16), -2px -2px 4px 0 
 
     .c-orderCard-order {
         text-align: center;
-        padding: spacing();
+        padding: spacing(x1.5);
         color: $blue;
         font-weight: $font-weight-bold;
         border-top: 1px solid $grey--offWhite;
         line-height: line-height(16px, 24px);
+        @include font-size(base--scaleUp, false);
+        margin-top: spacing();
     }
 
     .c-orderCard-title {
         font-family: $font-family-base;
+        font-weight: 500;
         @include font-size(base--scaleUp, false);
         line-height: line-height(16px, 24px);
-        color: $grey--darkest;
     }
 
     .c-orderCard-showMore {
@@ -122,26 +124,34 @@ $previousOrder-hoverBoxShadow: 0 2px 8px 0 rgba(0, 0, 0, 0.16), -2px -2px 4px 0 
     .c-orderCard-date {
         margin-top: 0;
         margin-bottom: spacing();
+        color: $grey--mid;
+        display: block;
     }
 
     .c-orderCard-summary-grid {
         display: flex;
-        flex-flow: row nowrap;
+        flex-flow: column nowrap;
         justify-content: space-between;
-        align-items: flex-end;
+        flex: 1 0 auto;
     }
 
     .c-orderCard-summary {
         line-height: line-height(16px, 23px);
+        width: 78%;
     }
 
     .c-orderCard-orderTotal {
         margin-right: spacing();
         margin-left: spacing(x3);
+        align-self: flex-end;
     }
 
     .c-orderCard-content {
-        padding: spacing() spacing(x2) spacing(x0.5);
+        padding: spacing() spacing(x2) 0;
+        color: $grey--darkest;
+        flex: 1 0 auto;
+        display: flex;
+        flex-direction: column;
     }
 
     .c-orderCard-content--defaultMessage {

--- a/src/scss/components/optional/_order-card.scss
+++ b/src/scss/components/optional/_order-card.scss
@@ -112,7 +112,7 @@ $previousOrder-hoverBoxShadow: 0 2px 8px 0 rgba(0, 0, 0, 0.16), -2px -2px 4px 0 
 
     .c-orderCard-title {
         font-family: $font-family-base;
-        font-weight: 500;
+        font-weight: $font-weight-bold;
         @include font-size(base--scaleUp, false);
         line-height: line-height(16px, 24px);
     }

--- a/src/scss/components/optional/_overflow-carousel.scss
+++ b/src/scss/components/optional/_overflow-carousel.scss
@@ -58,7 +58,7 @@
         }
 
         @include media('>mid') {
-            padding: spacing() spacing(x4);
+            padding: spacing(x2) spacing(x4) spacing();
         }
 
         .c-overflowCarousel-item {


### PR DESCRIPTION
### Changed
`c-order-card` style amends:

- Restaurant title font-weight should be 500;
- More spacing after order date;
- Order summary text colour should be the same as restaurant title (#333);
- If there is only one line of order summary in one tile, total amount should still be on lower line than summary, height of this part should be taken from the tallest order summary tile;
- "Order again" part should be always at the bottom, should be always the same height (48px);

`c-cuisinesWidget` underline text on hover state

Before:
![Screen Shot 2019-03-21 at 11 56 30](https://user-images.githubusercontent.com/19548183/54750675-661d7c80-4bd0-11e9-9452-d6a676bb485b.png)

After:
![Screen Shot 2019-03-21 at 11 28 52](https://user-images.githubusercontent.com/19548183/54749488-99f6a300-4bcc-11e9-8ca2-2ece0d39a738.png)


## Browsers Tested

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge
- [x] Internet Explorer 11
- [ ] Mobile (i.e. iPhone/Android - please list device)