### PR TITLE
v1.46.0 - Adds fullscreen modal for small screens.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v1.46.0
+------------------------------
+*May 8, 2019*
+
+### Added
+- `c-modal--fullpage--belowMid` modal setting to enable fullscreen modals for small screens.
+
 v1.45.0
 ------------------------------
 *May 1, 2019*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_modal.scss
+++ b/src/scss/components/optional/_modal.scss
@@ -95,4 +95,27 @@ $modal-transitionTime    : 250ms !default;
             }
         }
 
+        .c-modal--fullpage--belowMid {
+            @include media('<mid') {
+                .c-modal-content {
+                    border-radius: 0;
+                    bottom: -100vh;
+                    display: block;
+                    left: 0;
+                    top: 0;
+                    transform: none;
+                    width: 100%;
+                    overflow-y: scroll;
+                }
+
+                .c-modal-closeBtn {
+                    z-index: zIndex(high);
+                    position: fixed;
+                }
+
+                .c-modal-content--visible {
+                    bottom: 0;
+                }
+            }
+        }
 }


### PR DESCRIPTION
Makes the modal full screen on smaller screens.

## Browsers Tested

- [x] Chrome
- [ ] Edge
- [ ] Internet Explorer 11
- [ ] Mobile (i.e. iPhone/Android - please list device)

