### PR TITLE
v1.47.1 - Fix IE11 styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.47.1
+------------------------------
+*May 15, 2019*
+
+### Fixed
+- User message component styles in IE11
+
+
 v1.47.0
 ------------------------------
 *May 9, 2019*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_user-message.scss
+++ b/src/scss/components/optional/_user-message.scss
@@ -18,8 +18,7 @@
         max-width: 350px;
         margin: 0 auto;
         padding: spacing(x2) 0;
-        display: grid;
-        grid-template-columns: 40px auto;
+        display: flex;
 
         @include media('>=narrow') {
             max-width: 540px;
@@ -32,6 +31,8 @@
 
         svg {
             fill: white;
+            min-width: 28px;
+            max-width: 28px;
             width: 28px;
             height: 28px;
             display: block;
@@ -40,7 +41,7 @@
     }
 
     .c-userMessageText {
-        padding-left: spacing(x2);
+        margin-left: spacing(x2);
         margin-top: 0;
 
         @include media('>=mid') {


### PR DESCRIPTION
`grid-template-columns` does not work on IE11 so I've replaced `display: grid` with `display: flex`.

## Browsers Tested
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Internet Explorer 11
- [x] Opera
- [x] Mobile emulated through Chrome