### PR TITLE
v1.48.0 apps banner styling adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.48.0
+------------------------------
+*May 21, 2019*
+
+### Fixed
+- Apps banner styling adjustments
+
+
 v1.47.1
 ------------------------------
 *May 15, 2019*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.47.1",
+  "version": "1.48.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_apps-banner.scss
+++ b/src/scss/components/optional/_apps-banner.scss
@@ -15,7 +15,6 @@
             text-align: left;
             position: relative;
             padding-top: spacing(x5);
-            padding-left: spacing(x3);
             display: flex;
             flex-flow: row nowrap;
             justify-content: center;
@@ -35,10 +34,10 @@
         .c-appsBanner-heading {
             position: absolute;
             top: 0;
-            left: 0;
+            right: 50%;
+            transform: translate(50%, 0);
             width: 100%;
             text-align: center;
-            padding-left: spacing(x3);
 
 
             @include media('>=mid') {
@@ -50,6 +49,7 @@
         .c-appsBanner-image {
             overflow: hidden;
             flex: 0 1 120px;
+            margin-top: spacing(x2);
 
             @include media('>=narrow') {
                 flex: 0 1 104px;
@@ -57,6 +57,7 @@
 
             @include media('>=narrow-mid') {
                 flex: 0 1 324px;
+                margin-top: 0;
             }
 
             @include media('>=wide') {
@@ -78,7 +79,7 @@
             }
 
             p {
-                margin-top: 0;
+                margin-top: spacing(x2);
 
                 @include media('>=mid') {
                     margin-top: spacing();

--- a/src/scss/components/optional/_apps-banner.scss
+++ b/src/scss/components/optional/_apps-banner.scss
@@ -11,78 +11,78 @@
 
 @mixin appsBanner() {
     @include media-context(('narrow-mid': 600px)) {
+        /* autoprefixer grid: autoplace */
         .c-appsBanner {
             text-align: left;
             position: relative;
-            padding-top: spacing(x5);
-            display: flex;
-            flex-flow: row nowrap;
-            justify-content: center;
-            align-items: flex-start;
-
-            @include media('>=mid') {
-                padding-top: 0;
-                text-align: center;
-                align-items: center;
-            }
-
-            @include media('>=wide') {
-                justify-content: flex-start;
-            }
-        }
-
-        .c-appsBanner-heading {
-            position: absolute;
-            top: 0;
-            right: 50%;
-            transform: translate(50%, 0);
-            width: 100%;
-            text-align: center;
-
-
-            @include media('>=mid') {
-                position: relative;
-                @include font-size('jumbo', false);
-            }
-        }
-
-        .c-appsBanner-image {
-            overflow: hidden;
-            flex: 0 1 120px;
-            margin-top: spacing(x2);
-
-            @include media('>=narrow') {
-                flex: 0 1 104px;
-            }
+            display: grid;
+            //for IE it should be explicit grid
+            grid-template-columns: auto auto;
+            grid-template-rows: auto auto;
 
             @include media('>=narrow-mid') {
-                flex: 0 1 324px;
-                margin-top: 0;
-            }
-
-            @include media('>=wide') {
-                flex: 0 1 492px;
-            }
-
-            img {
-                width: 100%;
-            }
-        }
-
-        .c-appsBanner-content {
-            margin-left: spacing(x2);
-            flex: 0 1 300px;
-
-            @include media('>=mid') {
                 text-align: center;
-                flex: 1 1 auto;
+                justify-items: center;
             }
 
-            p {
-                margin-top: spacing(x2);
+            .c-appsBanner-heading {
+                grid-column: 1 / 3;
+                grid-row: 1;
+                text-align: center;
+
+                @include media('>=narrow-mid') {
+                    grid-column: 2;
+                    align-self: end;
+                }
 
                 @include media('>=mid') {
-                    margin-top: spacing();
+                    max-width: 570px;
+                    @include font-size('jumbo', false);
+                }
+            }
+
+            .c-appsBanner-image {
+                overflow: hidden;
+                max-width: 120px;
+                margin-top: spacing(x2);
+                grid-column: 1;
+                grid-row: 2;
+
+                @include media('>=narrow-mid') {
+                    max-width: 324px;
+                    margin-top: 0;
+                    grid-column: 1;
+                    grid-row: 1 / 3;
+                }
+
+                @include media('>=wide') {
+                    max-width: 492px;
+                }
+
+                img {
+                    width: 100%;
+                }
+            }
+
+            .c-appsBanner-content {
+                margin-left: spacing(x2);
+                grid-column: 2;
+                grid-row: 2;
+
+                @include media('>=narrow-mid') {
+                    align-self: start;
+                }
+
+                @include media('>=mid') {
+                    text-align: center;
+                }
+
+                p {
+                    margin-top: spacing(x2);
+
+                    @include media('>=mid') {
+                        margin-top: spacing();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes the issue with NO/DK banner and centre the banner on mobile:

Before:
![Screen Shot 2019-05-20 at 15 36 11](https://user-images.githubusercontent.com/19548183/58113118-c5a60180-7bec-11e9-9840-d38d9a630307.png)

After:
![Screen Shot 2019-05-21 at 17 21 05](https://user-images.githubusercontent.com/19548183/58113191-e40bfd00-7bec-11e9-8589-d0d27c6890b1.png)


Browsers tested:
IE11
Chrome
Firefox
Safari
