### PR TITLE
v1.53.0 - Updates to overflow carousel and full screen popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+
+v1.53.0
+------------------------------
+*June 03, 2019*
+
+### Added
+- Added modifier to  `c-overflowCarousel` to also include mid version
+
+### Fixed
+- Updated media queries on full screen pop over to not exclude breakpoint
+
+
 v1.52.0
 ------------------------------
 *June 06, 2019*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.52.0",
+  "version": "1.53.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_fullscreen-pop-over.scss
+++ b/src/scss/components/optional/_fullscreen-pop-over.scss
@@ -48,14 +48,14 @@ $fullScreenPopOver-shadow-color      : rgba($black, 0.12);
         // within a modal if it's not visible on mid and below
         .c-fullScreenPopOver--noTab--mid {
             & > * {
-                @include media('<=mid') {
+                @include media('<mid') {
                     display: none;
                 }
             }
 
             &.is-open {
                 & > * {
-                    @include media('<=mid') {
+                    @include media('<mid') {
                         display: block;
                     }
                 }

--- a/src/scss/components/optional/_overflow-carousel.scss
+++ b/src/scss/components/optional/_overflow-carousel.scss
@@ -12,6 +12,20 @@
  * TBC
  */
 
+@mixin overflowCarouselInner() {
+    overflow-x: scroll;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    width: 100%;
+}
+
+@mixin overflowCarouselContent() {
+    display: inline-flex;
+    white-space: nowrap;
+    padding-left: spacing(x2);
+    padding-right: spacing(x2);
+}
+
 @mixin overflowCarousel() {
 
     .c-overflowCarousel {
@@ -22,23 +36,33 @@
 
     .c-overflowCarousel-inner {
         @include media('<mid') {
-            overflow-x: scroll;
-            overflow-y: hidden;
-            -webkit-overflow-scrolling: touch;
-            width: 100%;
+            @include overflowCarouselInner();
 
             &.is-active {
                 overflow: visible;
+            }
+        }
+
+        .c-overflowCarousel--fromMid & {
+            @include media('<=mid') {
+                @include overflowCarouselInner();
+
+                &.is-active {
+                    overflow: visible;
+                }
             }
         }
     }
 
     .c-overflowCarousel-content {
         @include media('<mid') {
-            display: inline-flex;
-            white-space: nowrap;
-            padding-left: spacing(x2);
-            padding-right: spacing(x2);
+            @include overflowCarouselContent();
+        }
+
+        .c-overflowCarousel--fromMid & {
+            @include media('<=mid') {
+                @include overflowCarouselContent();
+            }
         }
     }
 


### PR DESCRIPTION


- Addition of modifier to overflow carousel to include a mid version.
   - also split out some code into mixins to avoid duplication
- Update fullScreenPopOver to not exclude any breakpoints

## UI Review Checks

No _real_ change.


- [x] This PR has been checked with regard to our brand guidelines
## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile