### PR TITLE
v1.62.1 - Removal of animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v1.62.1
+------------------------------
+*August 23, 2019*
+
+### Removed
+- Removed animation from the `c-listing-item-header` for performance increase
+
 v1.62.0
 ------------------------------
 *August 20, 2019*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.62.0",
+  "version": "1.62.1",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_listings.scss
+++ b/src/scss/components/optional/_listings.scss
@@ -146,8 +146,7 @@ $listing--inactive-bg           : rgba($listing-bg, 0.5);
                 }
 
                 &:not(.c-listing-item-header--noImage) {
-                    @include anim();
-                    will-change: transform, background-color;
+                    background: $grey--lightest;
                 }
             }
 


### PR DESCRIPTION
- remove animation from the c-listing-item-header for improved page performance

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile