### PR TITLE
v1.66.0 Improved CSS fallback font cascade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v1.66.0
+------------------------------
+*October 1, 2019*
+
+### Changed
+- Updated CSS fallback fonts cascade to be more design-sympathetic.
+
 v1.65.0
 ------------------------------
 *September 30, 2019*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.65.0",
+  "version": "1.66.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -28,6 +28,7 @@
         font-family: Aspira;
         font-style: normal;
         font-weight: 800;
+        font-display: swap;
         src: url('#{$font-path}/menulog/aspira-heavy.woff2') format('woff2'),
              url('#{$font-path}/menulog/aspira-heavy.woff') format('woff'),
              url('#{$font-path}/menulog/aspira-heavy.ttf') format('truetype');

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -57,29 +57,29 @@ $line-height-headings       : 1.2;
 $line-height-base           : line-height();
 
 // Font stacks
-$font-family-base           : 'Hind Vadodara', 'Helvetica Neue', Helvetica, sans-serif;
-$font-family-headings       : 'Ubuntu'; // we need to define some fallbacks here!
+$font-family-base           : 'Hind Vadodara', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+$font-family-headings       : 'Ubuntu', Arial, sans-serif; // we need to define some fallbacks here!
 $font-family-mono           : Menlo, Monaco, 'Courier New', monospace;
 
 // Fonts for preload
 // ==========================================================================
 // base fonts and headings have a preload system font, when the webfonts are loaded we style with JustEat fonts.
 
-$font-family-preload: 'Helvetica Neue', Helvetica, sans-serif;
+$font-family-preload: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 $font-weight-headings-preload: 400;
 
 // Menulog font overrides
 // ==========================================================================
 @if ($theme == 'ml') {
-    $font-family-headings   : 'Aspira', 'Times New Roman', Times, serif;
+    $font-family-headings   : 'Aspira', Arial, sans-serif;
     $font-weight-headings   : 800; // Heading style is Aspira Heavy, which is 800 font-weight
 }
 
 // Glaze font overrides
 // ==========================================================================
 @if ($theme == 'gl') {
-    $font-family-base       : 'Open Sans', 'Helvetica Neue', Helvetica, sans-serif;
-    $font-family-headings   : 'Nunito';
+    $font-family-base       : 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    $font-family-headings   : 'Nunito', 'Arial Round', Arial, sans-serif;
 }
 
 


### PR DESCRIPTION
Simple update to the CSS font fallback cascade using more visually harmonious fallbacks, e.g. sans-serif system fallbacks for all sans-serif Web fonts (likewise serif-for-serif).

## UI Review Checks
- [x] This PR has been checked with regard to our brand guidelines

## Browsers Tested
- [x] Chrome
- [ ] Edge
- [ ] Internet Explorer 11
- [ ] Mobile (i.e. iPhone/Android - please list device)