### PR TITLE
v1.67.0 - update unit intervals to fix safari rounding issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v1.67.0
+------------------------------
+*October 7, 2019*
+
+### Changed
+- Updated breakpoint unit intervals to fix Safari rounding issue.
+
 v1.66.0
 ------------------------------
 *October 1, 2019*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.66.0",
+  "version": "1.67.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -83,8 +83,16 @@ $font-weight-headings-preload: 400;
 }
 
 
-//  Global Breakpoints
+//  Global Breakpoints and unit intervals
 // ==========================================================================
+
+$unit-intervals: (
+  'px': 1,
+  'em': 0.063, //0.063ems converts to 1px. We need this as some browsers are very specific with breakpoints
+  'rem': 0.1,
+  '': 0
+);
+
 $breakpoints: map-to-em((
     tiny       : 375px,
     narrow     : 414px,    // narrow devices

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -88,7 +88,7 @@ $font-weight-headings-preload: 400;
 
 $unit-intervals: (
   'px': 1,
-  'em': 0.063, //0.063ems converts to 1px. We need this as some browsers are very specific with breakpoints
+  'em': 0.063, //0.063ems converts to 1px (1 / 16 = 0.0625). We need this as some browsers are very specific with breakpoints
   'rem': 0.1,
   '': 0
 );


### PR DESCRIPTION
- update unit intervals to fix safari rounding issue

## Browsers Tested

- [x] Safari
- [x] Edge
- [x] Internet Explorer 11
- [x] Safari Mobile