### PR TITLE
v1.75.1 stop horizontal navbar appearing on vertical dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v1.75.1
+------------------------------
+*November 27, 2019*
+
+### Fixed
+- Vertical menu overflow x scroll axis
+
 
 v1.75.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.75.0",
+  "version": "1.75.1",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_menu.scss
+++ b/src/scss/components/optional/_menu.scss
@@ -171,7 +171,7 @@ $menu--expandable-linkActiveFontSize    : base--scaleUp !default;
             .c-menu--expandable--expanded {
                 @include media('<mid') {
                     max-height: 70vh;
-                    overflow: scroll;
+                    overflow-y: scroll;
                     padding-top: spacing(x2);
 
                     .c-menu-link {


### PR DESCRIPTION
Currently when using the `.c-menu--expandable--expanded` css classes it applies the `overflow` css attribute which applies an empty scrollbar for non-scrollable elements.
This creates this visual effect:
![image](https://user-images.githubusercontent.com/1962883/69650217-2e6faa00-1066-11ea-9f66-3b3dc6b213cb.png)

By setting it to overflow-y only it will stop the X axis being scrollable and allow the Y axis to be scrollable

![image](https://user-images.githubusercontent.com/1962883/69650334-5a8b2b00-1066-11ea-84a9-dde12878d0b9.png)


## UI Review Checks

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile (i.e. iPhone/Android - please list device)