### PR TITLE
Change orderCard for yourFavourites experiment

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.77.0",
+  "version": "1.78.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_order-card.scss
+++ b/src/scss/components/optional/_order-card.scss
@@ -40,12 +40,13 @@ $previousOrder-hoverBoxShadow: 0 2px 8px 0 rgba(0, 0, 0, 0.16), -2px -2px 4px 0 
             color: $grey--mid;
         }
 
-        .c-orderCard-yourFavourites {
-            min-height: 200px;
+    }
 
-            @include media('>=mid') {
-                min-height: 240px;
-            }
+    .c-orderCard-yourFavourites {
+        min-height: 200px;
+
+        @include media('>=mid') {
+            min-height: 240px;
         }
     }
 
@@ -82,10 +83,6 @@ $previousOrder-hoverBoxShadow: 0 2px 8px 0 rgba(0, 0, 0, 0.16), -2px -2px 4px 0 
             width: 100%;
         }
 
-        .c-orderCard-yourFavourites {
-            height: auto;
-        }
-
         &:after {
             content: '';
             width: 100%;
@@ -98,6 +95,9 @@ $previousOrder-hoverBoxShadow: 0 2px 8px 0 rgba(0, 0, 0, 0.16), -2px -2px 4px 0 
         }
     }
 
+    .c-orderCardImage-yourFavourites {
+        height: auto;
+    }
     .c-orderCard-iconContainer {
         width: 64px;
         height: 64px;
@@ -163,10 +163,10 @@ $previousOrder-hoverBoxShadow: 0 2px 8px 0 rgba(0, 0, 0, 0.16), -2px -2px 4px 0 
         flex: 1 0 auto;
         display: flex;
         flex-direction: column;
+    }
 
-        .c-orderCard-yourFavourites {
-            padding: spacing() spacing(x2);
-        }
+    .c-orderCardContent-yourFavourites {
+        padding: spacing() spacing(x2);
     }
 
     .c-orderCard-content--defaultMessage {


### PR DESCRIPTION
## UI Review Checks

![image](https://user-images.githubusercontent.com/48129301/70191712-96bb2d00-16f1-11ea-93b1-3e43e43ed044.png)


- [x] This PR has been checked with regard to our brand guidelines
- [ ] UI Documentation has been [created|updated]
- [ ] This code has been checked with regard to our accessibility standards
  - [ ] HTML is valid [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmlvalid)
  - [ ] HTML is well structured [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmlstructure)
  - [ ] HTML is well ordered [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmlorder)
  - [ ] HTML is semantic [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmlsemantic)
  - [ ] HTML is labelled [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmllabelled)
  - [ ] Passed an accessibility audit [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#audit)
  - [ ] Keyboard is supported [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#keyboard)
  - [ ] Tab stops in place [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#tabstops)
  - [ ] Focus is managed [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#focus)
  - [ ] States are updated [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#state)
  - [ ] Page is well spoken [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#wellspoken)

## Browsers Tested

- [x] Chrome
- [ ] Edge
- [ ] Internet Explorer 11
- [ ] Mobile (i.e. iPhone/Android - please list device)