### PR TITLE
v1.81.0 - Removed max-height for iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.81.0
+------------------------------
+*January 20, 2020*
+
+### Removed
+- `max-height` on `.c-modal-content-scrollable` to prevent locking on iOS
+
+
 v1.80.0
 ------------------------------
 *January 7, 2020*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.80.0",
+  "version": "1.81.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_modal.scss
+++ b/src/scss/components/optional/_modal.scss
@@ -146,7 +146,6 @@ $modal-transitionTime    : 250ms !default;
             }
 
         .c-modal-content-scrollable {
-            max-height: 100vh;
             overflow-x: hidden;
             overflow-y: auto;
             position: relative;


### PR DESCRIPTION
## Changelog

### Removed
- `max-height` on `.c-modal-content-scrollable` to prevent locking on iOS
