### PR TITLE
v1.83.0 - Revert max height change to fix scrolling issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ v1.83.0
 ### Fixed
 - Reverted `max-height` change to `.c-modal-content-scrollable` as it prevents scrolling on small screen devices.
 
+### Changed
+- Use explicit value for rounded badge border radius.
+
 
 v1.82.0
 ------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.83.0
+------------------------------
+*January 20, 2020*
+
+### Fixed
+- Reverted `max-height` change to `.c-modal-content-scrollable` as it prevents scrolling on small screen devices.
+
+
 v1.82.0
 ------------------------------
 *January 20, 2020*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.82.0",
+  "version": "1.83.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_badges.scss
+++ b/src/scss/components/optional/_badges.scss
@@ -33,7 +33,7 @@ $badge-padding                  : 1px 5px;
 $badge-rounded-radius           : 14px;
 $badge-rounded-padding          : spacing(x0.5) spacing(x2);
 $badge-rounded-small-radius     : 2px;
-$badge-rounded-small-padding    : 2px spacing(x0.5);
+$badge-rounded-small-padding    : 2px 4px;
 $badge-angled-radius            : 2px;
 
 @mixin badge() {

--- a/src/scss/components/optional/_modal.scss
+++ b/src/scss/components/optional/_modal.scss
@@ -139,6 +139,7 @@ $modal-borderRadius     : 4px;
             }
 
         .c-modal-content-scrollable {
+            max-height: 100vh;
             overflow-x: hidden;
             overflow-y: auto;
             position: relative;


### PR DESCRIPTION
### Fixed
- Reverted `max-height` change to `.c-modal-content-scrollable` as it prevents scrolling on small screen devices.

### Changed
- Use explicit value for rounded badge border radius.