### PR TITLE
v1.86.0: Styling for Opening Up Homepage (Phase 1)

### DIFF
--- a/src/scss/components/optional/_page-banner.scss
+++ b/src/scss/components/optional/_page-banner.scss
@@ -160,4 +160,25 @@ $rays--coloured-spacing--huge: 230px;
         vertical-align: bottom;
         width: 100%;
     }
+
+    .c-pageBanner-noDisplay-belowTiny {
+        @include media('<=tiny'){
+            display: none;
+        }
+    }
+
+    .l-boxWrapper--openingHome {
+        @include media('<=tiny'){
+            width: 90%;
+            background-color: white;
+        }
+    }
+
+    .l-container-relative--openingHome {
+        @include media('<=tiny'){
+            background-color: red;
+            padding-bottom: 90px;
+            position: relative;
+        }
+    }
 }


### PR DESCRIPTION
https://jira.just-eat.net/browse/CCS-218

The first phase of this work, applying some initial styling (removing the banner at small width, changing background colour of banner etc)

All hidden behind a feature toggle as of present, prod users will not see this work until later phases.

## Browsers Tested

- [x] Chrome
- [ ] Edge
- [ ] Internet Explorer 11
- [ ] Mobile (i.e. iPhone/Android - please list device)

