### PR TITLE
v1.88.0: New helper to _rwd.scss for hiding items on tiny devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ v1.88.0
 ### Added
 - New helper to _rwd.scss for hiding items on tiny devices
 
+### Added
+- Stylelint disable rule for Firefox only element as it was throwing error when running Homeweb
+
 v1.87.0
 ------------------------------
 *January 30, 2020*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v1.88.0
 ------------------------------
-*February 04, 2020*
+*February 05, 2020*
 
 ### Added
-- New helper to _rwd.scss for hiding items on tiny devices
+- New helper to rwd.scss for hiding items on tiny devices
 - Stylelint disable rule for Firefox only element as it was throwing error when running Homeweb
 
 v1.87.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v1.88.0
+------------------------------
+*February 04, 2020*
+
+### Added
+- New helper to _rwd.scss for hiding items on tiny devices
+
 v1.87.0
 ------------------------------
 *January 30, 2020*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ v1.88.0
 
 ### Added
 - New helper to _rwd.scss for hiding items on tiny devices
-
-### Added
 - Stylelint disable rule for Firefox only element as it was throwing error when running Homeweb
 
 v1.87.0

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "1.87.0",
+  "version": "1.88.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_overflow-carousel.scss
+++ b/src/scss/components/optional/_overflow-carousel.scss
@@ -97,6 +97,7 @@
 
     .c-overflowCarousel--hideScroll {
         @include media('>=wide') {
+         /* stylelint-disable-next-line property-no-unknown */
             scrollbar-width: none;
         }
     }

--- a/src/scss/components/optional/_overflow-carousel.scss
+++ b/src/scss/components/optional/_overflow-carousel.scss
@@ -97,7 +97,7 @@
 
     .c-overflowCarousel--hideScroll {
         @include media('>=wide') {
-         /* stylelint-disable-next-line property-no-unknown */
+            /* stylelint-disable-next-line property-no-unknown */
             scrollbar-width: none;
         }
     }

--- a/src/scss/trumps/_rwd.scss
+++ b/src/scss/trumps/_rwd.scss
@@ -36,6 +36,12 @@
     }
 }
 
+.u-showAboveTiny {
+    @include media('<=tiny') {
+        display: none !important;
+    }
+}
+
 .u-showAboveMid,
 .no-js .u-showAboveMid--noJS {
     @include media('<mid') {


### PR DESCRIPTION
# Changelog
### Added 
New helper to `_rwd.scss` for hiding items on tiny devices

[Relevant Pull Request with zeplin attached](https://jira.just-eat.net/browse/CCS-218)

The page banner picture needs to be hidden on 375px  (and lower) devices