### PR TITLE
v2.1.0 - Updated modal max width.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v2.1.0
+------------------------------
+*March 10, 2020*
+
+### Fixed
+- Updated `c-modal` max width to an even number as odd numbered widths cause text to become blurry in some browsers.
+
+
 v2.0.0
 ------------------------------
 *March 9, 2020*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_modal.scss
+++ b/src/scss/components/optional/_modal.scss
@@ -174,7 +174,7 @@ $modal-borderRadius     : 4px;
             max-width: 100%;
 
             @include media('>=narrowMid') {
-                max-width: 425px;
+                max-width: 450px;
             }
         }
 


### PR DESCRIPTION
### Fixed
- Updated `c-modal` max-width to an even number as odd-numbered widths cause text to become blurry in some browsers.