### PR TITLE
v3.0.0-beta.2 - Add styles for Menulog review stars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v3.0.0-beta.1
+------------------------------
+*June 4, 2020*
+
+### Changed
+- Updated Menulog review stars to be brand orange (uses `@justeat/f-icons` v1.34.0)
+
+
 v3.0.0-beta.0
 ------------------------------
 *June 2, 2020*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_ratings.scss
+++ b/src/scss/components/optional/_ratings.scss
@@ -129,7 +129,7 @@ $star-size--large           : 42px;
         @include rating-fill($star-count);
 
         @if ($theme == 'ml') {
-            @extend %c-icon--star--fill--yellow !optional;
+            @extend %c-icon--star--fill--brandOrange !optional;
         }
     }
 
@@ -151,7 +151,7 @@ $star-size--large           : 42px;
                 @extend %c-icon--star--fill !optional;
 
                 @if ($theme == 'ml') {
-                    @extend %c-icon--star--fill--yellow !optional;
+                    @extend %c-icon--star--fill--brandOrange !optional;
                 }
             }
        }
@@ -176,7 +176,7 @@ $star-size--large           : 42px;
             @extend %c-icon--star--fill !optional;
 
             @if ($theme == 'ml') {
-                @extend %c-icon--star--fill--yellow !optional;
+                @extend %c-icon--star--fill--brandOrange !optional;
             }
         }
     }


### PR DESCRIPTION
_Update review stars in Menulog theme to new brand orange. This change is dependent on `f-icons` v1.34.0_

## UI Review Checks

![orange stars](https://user-images.githubusercontent.com/42008764/83750345-156f3380-a65d-11ea-96ba-43e88cb67e64.JPG)

## Browsers Tested

- [x] Chrome
- [ ] Edge
- [ ] Internet Explorer 11
- [ ] Mobile (i.e. iPhone/Android - please list device)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
