### PR TITLE
v3.0.0-beta.1 – Bump to `fozzie-colour-palette` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v3.0.0-beta.1
+------------------------------
+*June 4, 2020*
+
+### Changed
+- Bump to `fozzie-colour-palette` version.
+
+
 v3.0.0-beta.0
 ------------------------------
 *June 2, 2020*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -36,7 +36,7 @@
     "@justeat/f-dom": "1.1.0",
     "@justeat/f-logger": "0.8.1",
     "@justeat/f-utils": "0.3.0",
-    "@justeat/fozzie-colour-palette": "3.0.0-beta.0",
+    "@justeat/fozzie-colour-palette": "3.0.0-beta.1",
     "fontfaceobserver": "2.1.0",
     "include-media": "1.4.9",
     "kickoff-grid.css": "1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1017,10 +1017,10 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-0.3.0.tgz#1f18ba13ad7061e21c2112387234a77ba45fb5d3"
   integrity sha512-hqRiGA2lP++Z1oqawsv1V2Duf3YShaAbJ3S5JEPTpTMP5RjH36Xpc8nRbIVFBmwnZCu7L9iF7AebYTUX8XhiZA==
 
-"@justeat/fozzie-colour-palette@3.0.0-beta.0":
-  version "3.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.0.0-beta.0.tgz#12c88c3c1e9d81544c05773bea6eb12c75ac2447"
-  integrity sha512-QnPiHnYmOpLN+gswv9hOezegrsRpzqroamrVeh5JjEJXFSsUwCb+LnkrpQjlqoCfKNw3gL9WTFldptd+Om8syg==
+"@justeat/fozzie-colour-palette@3.0.0-beta.1":
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.0.0-beta.1.tgz#c4f7594b338f8f73470875174872c92ccdfd8f21"
+  integrity sha512-QlxDWTBfjS1n2W5wycqRNLSR+sX54qupAjl1WiVl0lW3dbPQAHnmi8wxcyrbMOlYw8PqeOUZffuSmHLR4exwlw==
 
 "@justeat/gulp-build-fozzie@10.2.1":
   version "10.2.1"


### PR DESCRIPTION
### Changed
- Bump to `fozzie-colour-palette` version.