### PR TITLE
v3.0.0-beta.5 - Updating default colour palette to new JET colour scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v3.0.0-beta.5
+------------------------------
+*June 18, 2020*
+
+### Changed
+- All references to `grey--lightest` changed to `grey--lighter` (to match new colour palette).
+- All references to `grey--lighter` changed to `grey--light` (to match new colour palette).
+- All references to old colours that are no longer part of the new palette updated to new colour variables.
+
+### Removed
+- Glaze and Menulog colour overrides removed.
+
+
 v3.0.0-beta.4
 ------------------------------
 *June 5, 2020*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -36,7 +36,7 @@
     "@justeat/f-dom": "1.1.0",
     "@justeat/f-logger": "0.8.1",
     "@justeat/f-utils": "0.3.0",
-    "@justeat/fozzie-colour-palette": "3.0.0-beta.1",
+    "@justeat/fozzie-colour-palette": "3.0.0-beta.2",
     "fontfaceobserver": "2.1.0",
     "include-media": "1.4.9",
     "kickoff-grid.css": "1.2.0",

--- a/src/scss/_dependencies.scss
+++ b/src/scss/_dependencies.scss
@@ -31,12 +31,6 @@
 // The colour variables are imported from https://www.npmjs.com/package/@justeat/fozzie-colour-palette
 // If a custom theme is specified, it applies a set of colour overides to the base theme depending on the $theme
 @import 'fozzie-colour-palette';
-@if ($theme == 'ml') {
-    @include applyScheme-menulog;
-}
-@if ($theme == 'gl') {
-    @include applyScheme-glaze;
-}
 
 @import 'settings/variables';
 @import 'settings/glyphs';

--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -95,7 +95,7 @@ body {
 
 // Used for dividing pages or cards horizontally
 .l-divider {
-    border-bottom: 1px solid $grey--lighter;//$color-border;
+    border-bottom: 1px solid $color-border;
 }
 
 // utility that lets you align items side by side and vertically centered

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -224,7 +224,6 @@ dfn {
     font-style: italic;
 }
 
-// Addresses styling not present in IE6/7/8/9
 mark {
     background: $yellow--offWhite;
     padding: 2px 4px;

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -18,7 +18,7 @@
 //
 // @font-face rules (if any)
 //
-// JE fonts are loaded through Google fonts.  Menulog is a custom font.
+// JET fonts are loaded through Google fonts.  Menulog is a custom font.
 //
 // ******
 
@@ -226,7 +226,7 @@ dfn {
 
 // Addresses styling not present in IE6/7/8/9
 mark {
-    background: $yellow;
+    background: $yellow--offWhite;
     padding: 2px 4px;
     border-radius: 3px;
 }

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -8,12 +8,12 @@
  */
 
 $card-bgColor--active                           : $white;
-$card-bgColor--disabled                         : $grey--lightest;
+$card-bgColor--disabled                         : $grey--lighter;
 $card-tooltip-width                             : 10px;
 $card-arrow-bottom-position                     : 0;
 $card-padding                                   : spacing(x2);
 $card-radius                                    : 4px;
-$card-borderColor                               : $grey--lightest;
+$card-borderColor                               : $grey--lighter;
 $card-section-margin                            : spacing(x4);
 $card-section-margin--large                     : spacing(x8);
 $card-section-highlight-backgroundColor         : $orange;

--- a/src/scss/components/_media-element.scss
+++ b/src/scss/components/_media-element.scss
@@ -17,9 +17,6 @@ $mediaElement-infoLinkColor     : $blue;
 $mediaElement-fontSize          : base--scaleUp;
 $mediaElement-spacing           : spacing(x2);
 
-@if ($theme == 'ml') {
-    $mediaElement-infoLinkColor : $green;
-}
 
 // mediaElement module
 // Usually consists of having an image to the left and content to the right

--- a/src/scss/components/optional/_cuisines-widget.scss
+++ b/src/scss/components/optional/_cuisines-widget.scss
@@ -15,7 +15,7 @@
 
 
 $cuisinesWidget-titleColour: $white;
-$cuisinesWidget-defaultBackground: $grey--lightest;
+$cuisinesWidget-defaultBackground: $grey--lighter;
 $cuisinesWidget-boxShadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
 $cuisinesWidget-hoverBoxShadow: 0 2px 8px 0 rgba(0, 0, 0, 0.16), -2px -2px 4px 0 rgba(0, 0, 0, 0.04);
 $cuisinesWidget-gradient: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0));

--- a/src/scss/components/optional/_fullscreen-pop-over.scss
+++ b/src/scss/components/optional/_fullscreen-pop-over.scss
@@ -15,7 +15,7 @@
 $fullScreenPopOver-background        : $grey--offWhite;
 $fullScreenPopOver-action-background : $white;
 $fullScreenPopOver-padding           : spacing(x2);
-$fullScreenPopOver-border-color      : $grey--lightest;
+$fullScreenPopOver-border-color      : $grey--lighter;
 $fullScreenPopOver-shadow-color      : rgba($black, 0.12);
 
 @mixin fullScreenPopOver() {
@@ -78,7 +78,7 @@ $fullScreenPopOver-shadow-color      : rgba($black, 0.12);
         .c-fullScreenPopOver-header {
             top: 0;
             z-index: zIndex(high);
-            box-shadow: 0 3px 4px 0 $grey--lighter;
+            box-shadow: 0 3px 4px 0 $grey--light;
         }
 
         .c-fullScreenPopOver-header-actionFirst,
@@ -110,7 +110,7 @@ $fullScreenPopOver-shadow-color      : rgba($black, 0.12);
 
         .c-fullScreenPopOver-footer {
             bottom: 0;
-            box-shadow: 0 -2px 2px 0 $grey--lighter;
+            box-shadow: 0 -2px 2px 0 $grey--light;
         }
 
         .c-fullScreenPopOver-content {

--- a/src/scss/components/optional/_listings-skeleton.scss
+++ b/src/scss/components/optional/_listings-skeleton.scss
@@ -10,7 +10,7 @@
 
 @mixin anim() {
     border-radius: 2px;
-    background: linear-gradient(-45deg, $grey--offWhite, $grey--offWhite, $grey--lightest, $grey--offWhite, $grey--offWhite);
+    background: linear-gradient(-45deg, $grey--offWhite, $grey--offWhite, $grey--lighter, $grey--offWhite, $grey--offWhite);
     background-size: 2000px 600%;
     animation: skeletonGradient 2s ease infinite;
     animation-fill-mode: forwards;

--- a/src/scss/components/optional/_listings.scss
+++ b/src/scss/components/optional/_listings.scss
@@ -18,7 +18,7 @@ $listing-border-radius          : 4px;
 $listing-img-border-radius      : 2px;
 $listing-promoIcon-color        : $orange;
 
-$listing--subsequent-bg         : $grey--lightest;
+$listing--subsequent-bg         : $grey--lighter;
 $listing--inactive-bg           : rgba($listing-bg, 0.5);
 
 /*
@@ -146,7 +146,7 @@ $listing--inactive-bg           : rgba($listing-bg, 0.5);
                 }
 
                 &:not(.c-listing-item-header--noImage) {
-                    background: $grey--lightest;
+                    background: $grey--lighter;
                 }
             }
 
@@ -215,7 +215,7 @@ $listing--inactive-bg           : rgba($listing-bg, 0.5);
                 top: spacing(x2);
                 left: spacing(x2);
                 position: absolute;
-                border: 1px solid $grey--lightest;
+                border: 1px solid $grey--lighter;
                 border-radius: $listing-img-border-radius;
 
                 @include media('>=wide') {
@@ -355,7 +355,7 @@ $listing--inactive-bg           : rgba($listing-bg, 0.5);
             }
 
             .c-listing-item-promo-text--earned {
-                color: $green--dark;
+                color: $green;
             }
 
             .c-listing-item-rating {

--- a/src/scss/components/optional/_menu.scss
+++ b/src/scss/components/optional/_menu.scss
@@ -13,7 +13,7 @@
 
 $menu-headerHeight                      : 57px;
 $menu-fontSize                          : base--scaleUp;
-$menu-border-color                      : $grey--lightest;
+$menu-border-color                      : $grey--lighter;
 $menu-border-color--active              : $grey--dark;
 $menu-border-width                      : 1px;
 $menu-border-width--active              : 2px;
@@ -22,7 +22,7 @@ $menu-link-padding                      : spacing() spacing(x2);
 $menu-positionTop                       : $menu-headerHeight + spacing(x2);
 $menu--condensed-link-padding           : spacing(x0.5);
 $menu--expandable-bgColor               : $white !default;
-$menu--expandable-borderBottom          : $grey--lightest !default;
+$menu--expandable-borderBottom          : $grey--lighter !default;
 $menu--expandable-linkFontSize          : base !default;
 $menu--expandable-linkActiveFontSize    : base--scaleUp !default;
 

--- a/src/scss/components/optional/_order-card.scss
+++ b/src/scss/components/optional/_order-card.scss
@@ -63,7 +63,7 @@ $previousOrder-hoverBoxShadow: 0 2px 8px 0 rgba(0, 0, 0, 0.16), -2px -2px 4px 0 
         }
 
         .c-orderCard-image {
-            background-color: $grey--lightest;
+            background-color: $grey--lighter;
         }
     }
 

--- a/src/scss/components/optional/_ratings.scss
+++ b/src/scss/components/optional/_ratings.scss
@@ -127,10 +127,6 @@ $star-size--large           : 42px;
         height: 100%;
         width: 100%;
         @include rating-fill($star-count);
-
-        @if ($theme == 'ml') {
-            @extend %c-icon--star--fill--brandOrange !optional;
-        }
     }
 
     /*
@@ -149,10 +145,6 @@ $star-size--large           : 42px;
             & + label,
             & ~ input + label {
                 @extend %c-icon--star--fill !optional;
-
-                @if ($theme == 'ml') {
-                    @extend %c-icon--star--fill--brandOrange !optional;
-                }
             }
        }
     }
@@ -174,10 +166,6 @@ $star-size--large           : 42px;
         &:hover,
         &:hover ~ label {
             @extend %c-icon--star--fill !optional;
-
-            @if ($theme == 'ml') {
-                @extend %c-icon--star--fill--brandOrange !optional;
-            }
         }
     }
 

--- a/src/scss/components/optional/_toast.scss
+++ b/src/scss/components/optional/_toast.scss
@@ -12,7 +12,7 @@
 $toast-radius                           : 8px;
 $toast-textColor                        : $white;
 $toast-bgColor--default                 : $grey--darkest;
-$toast-bgColor--alert                   : $red--dark;
+$toast-bgColor--alert                   : $orange--aa;
 $toast-animation-duration               : 0.5s;
 $toast-height                           : 95px;
 $toast-translateY                       : -#{$toast-height - 5px};

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -11,51 +11,48 @@
  * Define associated Button variables
  */
 
-$btn-default-bgColor                : $grey--lightest;
+$btn-default-bgColor                : $grey--lighter;
 $btn-default-weight                 : 500;
 $btn-default-height                 : 2.6;
-$btn-default-font-size              : base--scaleUp;
-$btn-default-font-family            : 'Ubuntu';
-$btn-default-bgColor--hover         : $grey--lighter;
+$btn-default-font-size              : 18;
+$btn-default-font-family            : $font-family-headings;
+$btn-default-bgColor--hover         : $grey--light;
 $btn-default-borderRadius           : 2px;
 $btn-default-hozPadding             : 1em;
 $btn-default-vertPadding            : 11px;
 
-$btn-primary-bgColor                : $blue;
-$btn-primary-bgColor--hover         : $blue--dark;
-$btn-primary-bgColor--focus         : $blue--darkest;
+$btn-primary-bgColor                : $orange;
+$btn-primary-bgColor--hover         : $orange--dark;
+$btn-primary-bgColor--focus         : $orange--darkest;
 $btn-primary-textColor              : $white;
 
-$btn-secondary-bgColor              : $grey--lightest;
-$btn-secondary-bgColor--hover       : $grey--lighter;
-$btn-secondary-bgColor--active      : $grey--light;
+$btn-secondary-bgColor              : $blue--offWhite;
+$btn-secondary-bgColor--hover       : $blue--offWhite--dark;
+$btn-secondary-bgColor--active      : $blue--offWhite--darkest;
 $btn-secondary-textColor            : $blue;
 $btn-secondary-textColor--hover     : $blue;
 $btn-secondary-textColor--active    : $blue;
 
+$btn-tertiary-bgColor              : $white;
+$btn-tertiary-bgColor--hover       : $grey--light;
+$btn-tertiary-bgColor--active      : $grey--mid;
+$btn-tertiary-textColor            : $orange;
+$btn-tertiary-textColor--hover     : $orange;
+$btn-tertiary-textColor--active    : $orange;
+
 $btn-wide-hozPadding                : 2em;
 
-$btn-disabled-bgColor               : $grey--lighter;
-
-$btn-outline-borderColor            : $blue;
-$btn-outline-borderColor--hover     : $blue--dark;
-$btn-outline-borderColor--active    : $blue--lighter;
-$btn-outline-bgColor--highlight     : $blue--offWhite;
-$btn-outline-textColor--highlight   : $blue--dark;
+$btn-disabled-bgColor               : $grey--light;
 
 $btn-transparent-color              : $red;
 $btn-transparent-color--hover       : $grey--mid;
 
-$btn-roundedIcon-fillColor          : $white;
-$btn-roundedOutline-fillColor       : $blue;
-$btn-rounded-fillColor              : $blue;
-
 $btnGroup-outline-textColor         : $grey--dark;
-$btnGroup-outline-border            : $grey--lighter;
+$btnGroup-outline-border            : $grey--light;
 $btnGroup-outline-active-border     : $color-secondary;
 $btnGroup-outline-active-text-color : $color-secondary;
 
-$btnToggle-bg                       : $grey--lightest;
+$btnToggle-bg                       : $grey--lighter;
 $btnToggle-bg--active               : $white;
 $btnToggle-padding                  : 5px;
 
@@ -63,47 +60,6 @@ $btn-icon-dimension                 : 36px;
 $btn-icon-dimension--small          : 20px;
 $btn-rounded-width                  : 38px;
 
-
-// Menulog theme overrides
-@if ($theme == 'ml') {
-    // default font-size on buttons is updated so that the buttons are AA accessible
-    // (as otherwise white on brand orange isn't accessible)
-    $btn-default-font-size              : 18;
-
-    // TODO: these have been updated to new JET theme. Should be deleted once default theme is JET too
-    // TODO: these colour variable names will change once updated into new PIE design tokens
-    $btn-primary-bgColor                  : $orange-largeText;
-    $btn-primary-bgColor--hover           : $orange-largeText--dark;
-    $btn-primary-bgColor--focus           : $orange-largeText--darkest;
-
-    $btn-secondary-bgColor                : $violet--offWhite;
-    $btn-secondary-bgColor--hover         : $violet--offWhite--dark;
-    $btn-secondary-bgColor--active        : $violet--offWhite--darkest;
-    $btn-secondary-textColor              : $violet;
-    $btn-secondary-textColor--active      : $violet;
-    $btn-secondary-textColor--hover       : $violet;
-
-    $btn-roundedOutline-fillColor         : $orange-largeText;
-    $btn-roundedOutline-fillColor--active : $orange-largeText--dark;
-    $btn-rounded-fillColor                : $orange-largeText;
-}
-
-// Glaze theme overrides
-@if ($theme == 'gl') {
-    $btn-default-font-size                : mid;
-    $btn-default-font-family              : 'Nunito';
-
-    $btn-primary-bgColor                  : $coral--mid;
-    $btn-primary-bgColor--hover           : $coral--dark;
-    $btn-primary-bgColor--focus           : $coral--darkest;
-
-    $btn-secondary-bgColor                : $coral--lightest;
-    $btn-secondary-bgColor--hover         : $coral--lighter;
-    $btn-secondary-bgColor--active        : $coral--light;
-    $btn-secondary-textColor              : $coral--mid;
-    $btn-secondary-textColor--hover       : $coral--dark;
-    $btn-secondary-textColor--active      : $coral--darker;
-}
 
 /**
  * Base button styles – Based on csswizardry.com/beautons
@@ -226,11 +182,10 @@ $btn-rounded-width                  : 38px;
 /**
  * Modifier – .o-btn--secondary
  *
- * Sets the btn colour to positive colour (i.e. Green)
+ * Accompanying secondary style button (knocked back slightly from the primary button)
  */
 
-.o-btn--secondary,
-.o-btn--tertiary {
+.o-btn--secondary {
     background-color: $btn-secondary-bgColor;
     color: $btn-secondary-textColor;
 
@@ -247,8 +202,27 @@ $btn-rounded-width                  : 38px;
     }
 }
 
+/**
+ * Modifier – .o-btn--tertiary
+ *
+ * Accompanying button that can be used on solid background colours (such as grey)
+ */
+
 .o-btn--tertiary {
-    background-color: $white;
+    background-color: $btn-tertiary-bgColor;
+    color: $btn-tertiary-textColor;
+
+    &:hover {
+        background-color: $btn-tertiary-bgColor--hover;
+        color: $btn-tertiary-textColor--hover;
+    }
+
+    &:active,
+    &:focus {
+        background-color: $btn-tertiary-bgColor--active;
+        color: $btn-tertiary-textColor--active;
+        outline: none;
+    }
 }
 
 
@@ -280,35 +254,6 @@ $btn-rounded-width                  : 38px;
 .o-btn--wide {
     padding-left: $btn-wide-hozPadding;
     padding-right: $btn-wide-hozPadding;
-}
-
-/**
- * Outline Button
- * -------------------------
- * Essentially, a button, with same color bg as container, but with an outline
- */
-
-.o-btn--outline {
-    background-color: transparent;
-    border: 1px solid $btn-outline-borderColor;
-    color: $btn-outline-borderColor;
-
-    &:focus,
-    &:hover,
-    &:active,
-    &.is-active {
-        outline: none; // no need as already has a focus state
-        background-color: $btn-outline-bgColor--highlight;
-        color: $btn-outline-textColor--highlight;
-    }
-
-    &:hover,
-    &:focus {
-        border: 1px solid $btn-outline-borderColor--hover;
-    }
-    &:active {
-        border: 1px solid $btn-outline-borderColor--active;
-    }
 }
 
 //remove uneeded styles (like colours) from a button when only an icon is on it (like a close button)

--- a/src/scss/objects/_form-controls.scss
+++ b/src/scss/objects/_form-controls.scss
@@ -28,20 +28,20 @@
  *
  */
 
- $formControl-bgColor           : $white !default;
- $formControl-bgColor-disabled  : $color-disabled !default;
- $formControl-borderColor       : $color-border !default;
- $formControl-color             : $orange !default;
+ $formControl-bgColor            : $white !default;
+ $formControl-bgColor--disabled  : $color-disabled !default;
+ $formControl-borderColor        : $color-border !default;
+ $formControl-borderColor--hover : $orange !default;
+ $formControl-color              : $orange !default;
  $formControl-color--hover       : $orange--dark !default;
- $formControl-background-color  : $color-bg !default;
- $formControl-borderColor-hover : $orange !default;
- $formControl-margin-left       : 0 !default;
- $formControl-padding-left      : spacing(x4) !default;
- $formControl-width--wide       : 20px !default;
- $formControl-width             : 24px !default;
- $formControl-height--wide      : 20px !default;
- $formControl-height            : 24px !default;
- $formControl-border-width      : 1px;
+ $formControl-background-color   : $color-bg !default;
+ $formControl-margin-left        : 0 !default;
+ $formControl-padding-left       : spacing(x4) !default;
+ $formControl-width              : 24px !default;
+ $formControl-width--wide        : 20px !default;
+ $formControl-height             : 24px !default;
+ $formControl-height--wide       : 20px !default;
+ $formControl-border-width       : 1px;
 
 
  .o-formControl-label {
@@ -53,7 +53,7 @@
      padding-left: $formControl-padding-left;
 
      &:hover .o-formControl-indicator {
-         border-color: $formControl-borderColor-hover;
+         border-color: $formControl-borderColor--hover;
      }
 
      &:hover .o-formControl-input:disabled ~ .o-formControl-indicator {
@@ -62,7 +62,7 @@
      }
 
      .o-formControl-input:disabled ~ .o-formControl-indicator {
-        background-color: $formControl-bgColor-disabled;
+        background-color: $formControl-bgColor--disabled;
      }
  }
 

--- a/src/scss/objects/_form-controls.scss
+++ b/src/scss/objects/_form-controls.scss
@@ -31,10 +31,10 @@
  $formControl-bgColor           : $white !default;
  $formControl-bgColor-disabled  : $color-disabled !default;
  $formControl-borderColor       : $color-border !default;
- $formControl-color             : $blue !default;
+ $formControl-color             : $orange !default;
+ $formControl-color--hover       : $orange--dark !default;
  $formControl-background-color  : $color-bg !default;
- $formControl-hover-color       : $blue--dark !default;
- $formControl-borderColor-hover : $blue !default;
+ $formControl-borderColor-hover : $orange !default;
  $formControl-margin-left       : 0 !default;
  $formControl-padding-left      : spacing(x4) !default;
  $formControl-width--wide       : 20px !default;
@@ -42,14 +42,6 @@
  $formControl-height--wide      : 20px !default;
  $formControl-height            : 24px !default;
  $formControl-border-width      : 1px;
-
-
-// Menulog theme overrides
-@if ($theme == 'ml') {
-    $formControl-color: $orange-largeText;
-    $formControl-hover-color: $orange-largeText--dark;
-    $formControl-borderColor-hover: $orange-largeText;
-}
 
 
  .o-formControl-label {
@@ -99,7 +91,7 @@
          display: inline-block;
          width: $formControl-width;
          height: $formControl-height;
-         border: $formControl-border-width solid $grey--lightest;
+         border: $formControl-border-width solid $grey--lighter;
          background-color: $formControl-bgColor;
          vertical-align: middle;
          margin-left: $formControl-margin-left;
@@ -177,8 +169,8 @@
      .o-formControl-input:checked ~ .o-formControl-indicator--radio {
 
          label:hover & {
-             background-color: $formControl-hover-color;
-             border-color: $formControl-hover-color;
+             background-color: $formControl-color--hover;
+             border-color: $formControl-color--hover;
          }
      }
 
@@ -232,7 +224,7 @@
          &:before {
              content: '';
              background-color: $formControl-color;
-             border: 3px solid $grey--lightest;
+             border: 3px solid $grey--lighter;
              border-radius: 50%;
              width: $formControl-width - 2;
              height: $formControl-height - 2;

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -13,18 +13,18 @@
  */
 
 $formToggle-padding                 : spacing() !default;
-$formToggle-border-color            : $grey--lightest;
-$formToggle-border-color-interact   : $grey--lighter;
+$formToggle-border-color            : $grey--lighter;
+$formToggle-border-color-interact   : $grey--light;
 $formToggle-border-color-checked    : $green;
 $formToggle-border-width            : 1px;
 $formToggle-border-radius           : 8px;
 $formToggle-icon-background         : $green;
-$formToggle-icon-hover-background   : $grey--lighter;
+$formToggle-icon-hover-background   : $grey--light;
 $formToggle-background              : $white;
 $formToggle-large-size              : 48px;
 $formToggle-button-color            : $blue;
 $formToggle-button-background       : $blue--offWhite;
-$formToggle-disabled-text           : $grey--lighter;
+$formToggle-disabled-text           : $grey--light;
 $formToggle-checked-text            : $green;
 
 // associated form toggle mixins

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -14,18 +14,18 @@
 
 $formToggle-padding                 : spacing() !default;
 $formToggle-border-color            : $grey--lighter;
-$formToggle-border-color-interact   : $grey--light;
-$formToggle-border-color-checked    : $green;
+$formToggle-border-color--interact  : $grey--light;
+$formToggle-border-color--checked   : $green;
 $formToggle-border-width            : 1px;
 $formToggle-border-radius           : 8px;
 $formToggle-icon-background         : $green;
-$formToggle-icon-hover-background   : $grey--light;
+$formToggle-icon-background--hover  : $grey--light;
 $formToggle-background              : $white;
 $formToggle-large-size              : 48px;
 $formToggle-button-color            : $blue;
 $formToggle-button-background       : $blue--offWhite;
-$formToggle-disabled-text           : $grey--light;
-$formToggle-checked-text            : $green;
+$formToggle-text--disabled          : $grey--light;
+$formToggle-text--checked           : $green;
 
 // associated form toggle mixins
 @mixin formToggle-large() {
@@ -68,7 +68,7 @@ $formToggle-checked-text            : $green;
         width: calc(100% + 2px);
         height: calc(100% + 2px);
         border-radius: $formToggle-border-radius;
-        border: $formToggle-border-width solid $formToggle-border-color-interact;
+        border: $formToggle-border-width solid $formToggle-border-color--interact;
     }
 }
 
@@ -82,7 +82,7 @@ $formToggle-checked-text            : $green;
         width: calc(100% - 2px);
         height: calc(100% - 2px);
         border-radius: $formToggle-border-radius;
-        border: $formToggle-border-width solid $formToggle-border-color-interact;
+        border: $formToggle-border-width solid $formToggle-border-color--interact;
     }
 }
 
@@ -94,7 +94,7 @@ $formToggle-checked-text            : $green;
         width: calc(200% + 4px);
         height: calc(200% + 4px);
         border-radius: ($formToggle-border-radius * 2);
-        border: $formToggle-border-width solid $formToggle-border-color-checked;
+        border: $formToggle-border-width solid $formToggle-border-color--checked;
         transform: scale(0.5) translate(-50%, -50%);
     }
 }
@@ -205,7 +205,7 @@ $formToggle-checked-text            : $green;
 
             .o-formToggle-input:checked ~ & {
                 font-weight: $font-weight-bold;
-                color: $formToggle-checked-text;
+                color: $formToggle-text--checked;
                 @include formToggle-checkedSpacing();
             }
 
@@ -275,7 +275,7 @@ $formToggle-checked-text            : $green;
                 .o-formToggle-input:not([disabled]):focus ~ &,
                 .o-formToggle-input:not([checked]):focus ~ & {
                     @include media('>=mid') {
-                        fill: $formToggle-icon-hover-background;
+                        fill: $formToggle-icon-background--hover;
                     }
                 }
 
@@ -317,6 +317,6 @@ $formToggle-checked-text            : $green;
 
         .o-formToggle--disabled {
             background: none;
-            color: $formToggle-disabled-text;
+            color: $formToggle-text--disabled;
         }
 }

--- a/src/scss/objects/_lists.scss
+++ b/src/scss/objects/_lists.scss
@@ -7,12 +7,7 @@
  * TBC
  */
 
-$list-bullet-color: $red;
-
-// Menulog theme overrides
-@if ($theme == 'ml') {
-    $list-bullet-color: $orange-largeText;
-}
+$list-bullet-color: $orange;
 
 
 ul,

--- a/src/scss/objects/_tables.scss
+++ b/src/scss/objects/_tables.scss
@@ -15,8 +15,8 @@
  * Define associated Table variables
  */
 $table-bgColor                : $color-bg--component !default; // Default background color used for all tables.
-$table-bgColor--accent        : $blue--offWhite !default; // Background color used for `.table-striped`.
-$table-border--color          : $blue--offWhite !default; // Border color for table and cell borders.
+$table-bgColor--accent        : $grey--offWhite !default; // Background color used for `.table-striped`.
+$table-border--color          : $grey--offWhite !default; // Border color for table and cell borders.
 $table-border--width          : 2px !default; // Border width for table border.
 $table-innerBorder--color     : $color-border !default;
 $table-verticalBorder--color  : $color-border--interactive !default;
@@ -26,12 +26,6 @@ $table-verticalBorder--color  : $color-border--interactive !default;
  * Customizes the `.table` component with basic values, each used across all table variations.
  */
 $table-cell-padding           : 14px !default; // Padding for `<th>`s and `<td>`s.
-
-// Menulog theme overrides
-@if ($theme == 'ml') {
-    $table-bgColor--accent: $grey--offWhite;
-    $table-border--color: $grey--offWhite;
-}
 
 // Baseline styles
 table,

--- a/src/scss/settings/_theme.scss
+++ b/src/scss/settings/_theme.scss
@@ -4,12 +4,12 @@
 //
 // $theme variable let's you specify the theme to be generated for fozzie components
 //
-// This allows control over colour and component overrides that are theme specific
+// This allows control over component overrides that are theme specific
 //
 // Currently accepted themes this value can be set to:
-// 'je' = Just Eat (default)
-// 'ml' = Menulog (AU/NZ theme)
-// 'gl' = Glaze
-$theme: 'je' !default;
+// 'jet' = Just Eat Takeaway (default)
+// 'ml' = Menulog (AU/NZ theme) – used for very limited component overrides such as typography and differences in logo padding
+
+$theme: 'jet' !default;
 
 @debug 'Fozzie Theme is set to `#{$theme}`';

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -75,13 +75,6 @@ $font-weight-headings-preload: 400;
     $font-weight-headings   : 800; // Heading style is Aspira Heavy, which is 800 font-weight
 }
 
-// Glaze font overrides
-// ==========================================================================
-@if ($theme == 'gl') {
-    $font-family-base       : 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    $font-family-headings   : 'Nunito', 'Arial Round', Arial, sans-serif;
-}
-
 
 //  Global Breakpoints and unit intervals
 // ==========================================================================

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -372,6 +372,20 @@
   box-shadow: 0 0 0 2px $color-focus-outline;
 }
 
+/*
+ * Clever hack to have focus on an element but only when keyboard focused (not click)
+ * https://stackoverflow.com/questions/31402576/enable-focus-only-on-keyboard-use-or-tab-press
+ */
+%u-focusShadow,
+.u-focusShadow:focus,
+.u-focusShadow-content:focus {
+    outline: none;
+}
+%u-focusShadow-content,
+.u-focusShadow:focus > .u-focusShadow-content {
+    box-shadow: 0 0 2px 2px $color-focus-outline; /* keyboard-only focus styles */
+}
+
 
 //
 // Misc classes
@@ -381,7 +395,7 @@
 
     @include media('<mid') {
         &:after {
-            background-color: $grey--lightest;
+            background-color: $grey--lighter;
             border: 0;
             box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, 0.1);
             content: '';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1017,10 +1017,10 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-0.3.0.tgz#1f18ba13ad7061e21c2112387234a77ba45fb5d3"
   integrity sha512-hqRiGA2lP++Z1oqawsv1V2Duf3YShaAbJ3S5JEPTpTMP5RjH36Xpc8nRbIVFBmwnZCu7L9iF7AebYTUX8XhiZA==
 
-"@justeat/fozzie-colour-palette@3.0.0-beta.1":
-  version "3.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.0.0-beta.1.tgz#c4f7594b338f8f73470875174872c92ccdfd8f21"
-  integrity sha512-QlxDWTBfjS1n2W5wycqRNLSR+sX54qupAjl1WiVl0lW3dbPQAHnmi8wxcyrbMOlYw8PqeOUZffuSmHLR4exwlw==
+"@justeat/fozzie-colour-palette@3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.0.0-beta.2.tgz#cbcc8b339936d61bb7ea7e0356af8fc815eac2ec"
+  integrity sha512-dNBUbKUb32RysorwMy1J7/3/By8/Pu7YxfaPjhtkbkEuEzFh9Y8C4NvykFOtDMgD8VmcU6lnUeeg8tLUKDPhXA==
 
 "@justeat/gulp-build-fozzie@10.2.1":
   version "10.2.1"


### PR DESCRIPTION
### Changed
- All references to `grey--lightest` changed to `grey--lighter` (to match new colour palette).
- All references to `grey--lighter` changed to `grey--light` (to match new colour palette).
- All references to old colours that are no longer part of the new palette updated to new colour variables.

### Removed
- Glaze and Menulog colour overrides removed.

## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines
- [x] UI Documentation has been updated (PR for global-component-library incoming once all changes have been made)
- [x] This code has been checked with regard to our accessibility standards

## Browsers Tested

- [x] Chrome
- [x] Mobile (i.e. iPhone/Android - please list device)
