### PR TITLE
v3.0.0-beta.8 - Updating various uses of grey across components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v3.0.0-beta.8
+------------------------------
+*July 22, 2020*
+
+### Changed
+- Updating various uses of grey across components and updating `fozzie-colour-palette` version with new alias colours for default text and borders.
+
+
 v3.0.0-beta.7
 ------------------------------
 *July 20, 2020*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "3.0.0-beta.7",
+  "version": "3.0.0-beta.8",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -36,7 +36,7 @@
     "@justeat/f-dom": "1.1.0",
     "@justeat/f-logger": "0.8.1",
     "@justeat/f-utils": "0.3.0",
-    "@justeat/fozzie-colour-palette": "3.0.0-beta.3",
+    "@justeat/fozzie-colour-palette": "3.0.0-beta.4",
     "fontfaceobserver": "2.1.0",
     "include-media": "1.4.9",
     "kickoff-grid.css": "1.2.0",

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -13,7 +13,7 @@ $card-tooltip-width                             : 10px;
 $card-arrow-bottom-position                     : 0;
 $card-padding                                   : spacing(x2);
 $card-radius                                    : 4px;
-$card-borderColor                               : $grey--lighter;
+$card-borderColor                               : $color-border;
 $card-section-margin                            : spacing(x4);
 $card-section-margin--large                     : spacing(x8);
 $card-section-highlight-backgroundColor         : $orange--offWhite;

--- a/src/scss/components/optional/_fullscreen-pop-over.scss
+++ b/src/scss/components/optional/_fullscreen-pop-over.scss
@@ -15,7 +15,7 @@
 $fullScreenPopOver-background        : $grey--offWhite;
 $fullScreenPopOver-action-background : $white;
 $fullScreenPopOver-padding           : spacing(x2);
-$fullScreenPopOver-border-color      : $grey--lighter;
+$fullScreenPopOver-border-color      : $grey--light;
 $fullScreenPopOver-shadow-color      : rgba($black, 0.12);
 
 @mixin fullScreenPopOver() {

--- a/src/scss/components/optional/_menu.scss
+++ b/src/scss/components/optional/_menu.scss
@@ -13,7 +13,7 @@
 
 $menu-headerHeight                      : 57px;
 $menu-fontSize                          : base--scaleUp;
-$menu-border-color                      : $grey--lighter;
+$menu-border-color                      : $color-border;
 $menu-border-color--active              : $grey--dark;
 $menu-border-width                      : 1px;
 $menu-border-width--active              : 2px;
@@ -22,7 +22,7 @@ $menu-link-padding                      : spacing() spacing(x2);
 $menu-positionTop                       : $menu-headerHeight + spacing(x2);
 $menu--condensed-link-padding           : spacing(x0.5);
 $menu--expandable-bgColor               : $white !default;
-$menu--expandable-borderBottom          : $grey--lighter !default;
+$menu--expandable-borderBottom          : $color-border !default;
 $menu--expandable-linkFontSize          : base !default;
 $menu--expandable-linkActiveFontSize    : base--scaleUp !default;
 

--- a/src/scss/objects/_form-controls.scss
+++ b/src/scss/objects/_form-controls.scss
@@ -91,7 +91,7 @@
          display: inline-block;
          width: $formControl-width;
          height: $formControl-height;
-         border: $formControl-border-width solid $grey--lighter;
+         border: $formControl-border-width solid $grey--light;
          background-color: $formControl-bgColor;
          vertical-align: middle;
          margin-left: $formControl-margin-left;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1025,10 +1025,10 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-0.3.0.tgz#1f18ba13ad7061e21c2112387234a77ba45fb5d3"
   integrity sha512-hqRiGA2lP++Z1oqawsv1V2Duf3YShaAbJ3S5JEPTpTMP5RjH36Xpc8nRbIVFBmwnZCu7L9iF7AebYTUX8XhiZA==
 
-"@justeat/fozzie-colour-palette@3.0.0-beta.3":
-  version "3.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.0.0-beta.3.tgz#2778982a3982099d2d077eb49fd1fc75b5f449cf"
-  integrity sha512-DaP6Qs+5LTed44wNzLVitKmu6O4MfMFIKZXLtpq9wcndU30oToOI2YwYIQ1ULguCAHCPwNg5pc9bR7uQqkAtTw==
+"@justeat/fozzie-colour-palette@3.0.0-beta.4":
+  version "3.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.0.0-beta.4.tgz#cd36b52d9ae346f5101d3a5914bc91d086177461"
+  integrity sha512-LOcUh6H66CzNAakHTvy9QDRwzLGGBP+evZwOJDj2oV6lbYhWLN2Sb7ldnooFdgSBNwwuTSOm8tW0o/8KLMqnsQ==
 
 "@justeat/gulp-build-fozzie@10.2.1":
   version "10.2.1"


### PR DESCRIPTION
### Changed
- Updating various uses of grey across components and updating `fozzie-colour-palette` version with new alias colours for default text and borders.

## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines

## Browsers Tested

- [x] Chrome
