### PR TITLE
v3.0.0 – Moving v3 out of beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v3.0.0
+------------------------------
+*August 3, 2020*
+
+### Changed
+- Bumping version to `v3` as colour changes should now be stable (and to enable us to prep for v4 which will be font changes).
+
+
 v3.0.0-beta.10
 ------------------------------
 *July 30, 2020*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "3.0.0-beta.10",
+  "version": "3.0.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",


### PR DESCRIPTION
### Changed
- Bumping version to `v3` as colour changes should now be stable (and to enable us to prep for v4 which will be font changes).