### PR TITLE
v4.1.0 - Added font-family property to headings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+
+v4.1.0
+------------------------------
+*September 23, 2020*
+
+### Changed
+- Added `font-family` property back for headings as the font-family can be overridden by the reset styles if headings are children of elements such as buttons.
+
+
 v4.0.0
 ------------------------------
 *September 18, 2020*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -61,6 +61,7 @@ h6,
     color: $color-headings;
     margin: 0;
     margin-bottom: 0;
+    font-family: $font-family-base;
     font-weight: $font-weight-headings;
 
     small {


### PR DESCRIPTION
### Changed
- Added `font-family` property back for headings as the font-family can be overridden by the reset styles if headings are children of elements such as buttons.