### PR TITLE
v4.2.0 - Only show focus styles when needed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+v4.2.0
+------------------------------
+*October 26, 2020*
+
+### Added
+- `:focus-visible` styles which provide more control over when focus outlines are displayed. See this article for more info - https://matthiasott.com/notes/focus-visible-is-here.
+
+
 v4.1.0
 ------------------------------
 *September 23, 2020*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -14,6 +14,20 @@ body {
     @extend %u-elementFocus;
 }
 
+/*
+* Hide focus styles if they're not needed, for example, when an element receives focus via the mouse.
+*/
+:focus:not(:focus-visible) {
+    outline: 0;
+}
+
+/*
+* Show focus styles on keyboard focus.
+*/
+:focus-visible {
+    @extend %u-elementFocus;
+}
+
 /**
  * Default layout container
  */


### PR DESCRIPTION
### Added
- `:focus-visible` styles which provide more control over when focus outlines are displayed. This allows us to only show the focus outlines when using a keyboard. 

    > show focus styles only when they are needed, using the same heuristic that the browser uses to decide whether to show the default focus indicator

    See this article for more info - https://matthiasott.com/notes/focus-visible-is-here.