### PR TITLE
v5.0.0-beta.3 - Add loading indicator component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ v5 Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v5.0.0-beta.3
+------------------------------
+*February 16, 2021*
+
+### Added
+- Loading indicator which was in version 4 with an optional size
+
+
 v5.0.0-beta.2
 ------------------------------
 *December 31, 2020*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0-beta.2",
+  "version": "5.0.0-beta.3",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/_dependencies.scss
+++ b/src/scss/_dependencies.scss
@@ -12,6 +12,7 @@
 // =================================
 @import 'settings/theme';
 
+
 // =================================
 // Mixins, helpers and functions
 // =================================
@@ -23,6 +24,7 @@
 @import 'f-utils'; // imports Fozzie SCSS helper functions and mixins – https://github.com/justeat/f-utils
 @import 'include-media'; // Cleaner media query declarations – http://include-media.com
 
+
 // =================================
 // Core variables
 // =================================
@@ -32,6 +34,7 @@
 
 @import 'settings/variables';
 @import 'f-utils/helpers/breakpoints'; // breakpoint helper – https://github.com/justeat/f-utils/blob/96508ae19809c4b8b83cebb55b9d74728d01c1a5/src/scss/helpers/_breakpoints.scss
+
 
 // CSS Normalise and then Reset
 @import 'normalize/import-now'; // https://www.npmjs.com/package/normalize-scss
@@ -97,6 +100,7 @@
 // Global layout definitions & helpers
 @import 'base/layout';
 
+
 /**
  * Experiments
  * =================================
@@ -107,6 +111,7 @@
  */
 // @import 'experiments/INTPB-1451-quick-checkout';
 
+
 /**
  * Utility classes
  * =====================================
@@ -115,10 +120,12 @@
 @import 'trumps/utilities';
 @import 'trumps/rwd';
 
+
 /**
  * Print styles
  */
 @import 'base/print';
+
 
 /**
  * Templates for including base sets of styles

--- a/src/scss/_dependencies.scss
+++ b/src/scss/_dependencies.scss
@@ -10,7 +10,7 @@
 // =================================
 // Fozzie Theme declaration
 // =================================
-@import "settings/theme";
+@import 'settings/theme';
 
 // =================================
 // Mixins, helpers and functions
@@ -20,27 +20,27 @@
 // See mixins/css3.scss for the full list
 
 // Including helper modules
-@import "f-utils"; // imports Fozzie SCSS helper functions and mixins – https://github.com/justeat/f-utils
-@import "include-media"; // Cleaner media query declarations – http://include-media.com
+@import 'f-utils'; // imports Fozzie SCSS helper functions and mixins – https://github.com/justeat/f-utils
+@import 'include-media'; // Cleaner media query declarations – http://include-media.com
 
 // =================================
 // Core variables
 // =================================
 // The colour variables are imported from https://www.npmjs.com/package/@justeat/fozzie-colour-palette
 // If a custom theme is specified, it applies a set of colour overides to the base theme depending on the $theme
-@import "fozzie-colour-palette";
+@import 'fozzie-colour-palette';
 
-@import "settings/variables";
-@import "f-utils/helpers/breakpoints"; // breakpoint helper – https://github.com/justeat/f-utils/blob/96508ae19809c4b8b83cebb55b9d74728d01c1a5/src/scss/helpers/_breakpoints.scss
+@import 'settings/variables';
+@import 'f-utils/helpers/breakpoints'; // breakpoint helper – https://github.com/justeat/f-utils/blob/96508ae19809c4b8b83cebb55b9d74728d01c1a5/src/scss/helpers/_breakpoints.scss
 
 // CSS Normalise and then Reset
-@import "normalize/import-now"; // https://www.npmjs.com/package/normalize-scss
-@import "base/reset";
+@import 'normalize/import-now'; // https://www.npmjs.com/package/normalize-scss
+@import 'base/reset';
 
 // Global typography styles
-@import "base/typography";
+@import 'base/typography';
 
-@import "base/grid"; // Grid system based on flexbox w float fallbacks – https://github.com/TryKickoff/kickoff-grid.css
+@import 'base/grid'; // Grid system based on flexbox w float fallbacks – https://github.com/TryKickoff/kickoff-grid.css
 
 /**
  * Objects
@@ -54,13 +54,13 @@
  *
  * Object styles should be prefixed with `.o-`
  */
-@import "objects/body";
-@import "objects/buttons";
-@import "objects/links";
-@import "objects/lists";
-@import "objects/tables";
-@import "objects/form-controls";
-@import "objects/form-toggle";
+@import 'objects/body';
+@import 'objects/buttons';
+@import 'objects/links';
+@import 'objects/lists';
+@import 'objects/tables';
+@import 'objects/form-controls';
+@import 'objects/form-toggle';
 
 /**
  * Components:
@@ -69,33 +69,33 @@
  *
  * This is where the majority of our day-to-day styling will take place.  Component styles should be prefixed with `.c-`
  */
-@import "components/alerts";
-@import "components/breadcrumbs";
-@import "components/cards";
-@import "components/media-element";
+@import 'components/alerts';
+@import 'components/breadcrumbs';
+@import 'components/cards';
+@import 'components/media-element';
 
 // Optional components – need to be included with the associated mixin in your project dependencies
-@import "components/optional/apps-banner";
-@import "components/optional/badges";
-@import "components/optional/content-header";
-@import "components/optional/content-title";
-@import "components/optional/cookie-warning";
-@import "components/optional/cuisines-widget";
-@import "components/optional/fullscreen-pop-over";
-@import "components/optional/listings";
-@import "components/optional/listings-skeleton";
-@import "components/optional/loading-indicator";
-@import "components/optional/menu";
-@import "components/optional/modal";
-@import "components/optional/order-card";
-@import "components/optional/overflow-carousel";
-@import "components/optional/page-banner";
-@import "components/optional/ratings";
-@import "components/optional/toast";
-@import "components/optional/user-message";
+@import 'components/optional/apps-banner';
+@import 'components/optional/badges';
+@import 'components/optional/content-header';
+@import 'components/optional/content-title';
+@import 'components/optional/cookie-warning';
+@import 'components/optional/cuisines-widget';
+@import 'components/optional/fullscreen-pop-over';
+@import 'components/optional/listings';
+@import 'components/optional/listings-skeleton';
+@import 'components/optional/loading-indicator';
+@import 'components/optional/menu';
+@import 'components/optional/modal';
+@import 'components/optional/order-card';
+@import 'components/optional/overflow-carousel';
+@import 'components/optional/page-banner';
+@import 'components/optional/ratings';
+@import 'components/optional/toast';
+@import 'components/optional/user-message';
 
 // Global layout definitions & helpers
-@import "base/layout";
+@import 'base/layout';
 
 /**
  * Experiments
@@ -112,15 +112,15 @@
  * =====================================
  * These should always come last as they should 'trump' other properties
  */
-@import "trumps/utilities";
-@import "trumps/rwd";
+@import 'trumps/utilities';
+@import 'trumps/rwd';
 
 /**
  * Print styles
  */
-@import "base/print";
+@import 'base/print';
 
 /**
  * Templates for including base sets of styles
  */
-@import "templates";
+@import 'templates';

--- a/src/scss/_dependencies.scss
+++ b/src/scss/_dependencies.scss
@@ -10,8 +10,7 @@
 // =================================
 // Fozzie Theme declaration
 // =================================
-@import 'settings/theme';
-
+@import "settings/theme";
 
 // =================================
 // Mixins, helpers and functions
@@ -21,29 +20,27 @@
 // See mixins/css3.scss for the full list
 
 // Including helper modules
-@import 'f-utils'; // imports Fozzie SCSS helper functions and mixins – https://github.com/justeat/f-utils
-@import 'include-media'; // Cleaner media query declarations – http://include-media.com
-
+@import "f-utils"; // imports Fozzie SCSS helper functions and mixins – https://github.com/justeat/f-utils
+@import "include-media"; // Cleaner media query declarations – http://include-media.com
 
 // =================================
 // Core variables
 // =================================
 // The colour variables are imported from https://www.npmjs.com/package/@justeat/fozzie-colour-palette
 // If a custom theme is specified, it applies a set of colour overides to the base theme depending on the $theme
-@import 'fozzie-colour-palette';
+@import "fozzie-colour-palette";
 
-@import 'settings/variables';
-@import 'f-utils/helpers/breakpoints'; // breakpoint helper – https://github.com/justeat/f-utils/blob/96508ae19809c4b8b83cebb55b9d74728d01c1a5/src/scss/helpers/_breakpoints.scss
-
+@import "settings/variables";
+@import "f-utils/helpers/breakpoints"; // breakpoint helper – https://github.com/justeat/f-utils/blob/96508ae19809c4b8b83cebb55b9d74728d01c1a5/src/scss/helpers/_breakpoints.scss
 
 // CSS Normalise and then Reset
-@import 'normalize/import-now'; // https://www.npmjs.com/package/normalize-scss
-@import 'base/reset';
+@import "normalize/import-now"; // https://www.npmjs.com/package/normalize-scss
+@import "base/reset";
 
 // Global typography styles
-@import 'base/typography';
+@import "base/typography";
 
-@import 'base/grid'; // Grid system based on flexbox w float fallbacks – https://github.com/TryKickoff/kickoff-grid.css
+@import "base/grid"; // Grid system based on flexbox w float fallbacks – https://github.com/TryKickoff/kickoff-grid.css
 
 /**
  * Objects
@@ -57,13 +54,13 @@
  *
  * Object styles should be prefixed with `.o-`
  */
-@import 'objects/body';
-@import 'objects/buttons';
-@import 'objects/links';
-@import 'objects/lists';
-@import 'objects/tables';
-@import 'objects/form-controls';
-@import 'objects/form-toggle';
+@import "objects/body";
+@import "objects/buttons";
+@import "objects/links";
+@import "objects/lists";
+@import "objects/tables";
+@import "objects/form-controls";
+@import "objects/form-toggle";
 
 /**
  * Components:
@@ -72,33 +69,33 @@
  *
  * This is where the majority of our day-to-day styling will take place.  Component styles should be prefixed with `.c-`
  */
-@import 'components/alerts';
-@import 'components/breadcrumbs';
-@import 'components/cards';
-@import 'components/media-element';
+@import "components/alerts";
+@import "components/breadcrumbs";
+@import "components/cards";
+@import "components/media-element";
 
 // Optional components – need to be included with the associated mixin in your project dependencies
-@import 'components/optional/apps-banner';
-@import 'components/optional/badges';
-@import 'components/optional/content-header';
-@import 'components/optional/content-title';
-@import 'components/optional/cookie-warning';
-@import 'components/optional/cuisines-widget';
-@import 'components/optional/fullscreen-pop-over';
-@import 'components/optional/listings';
-@import 'components/optional/listings-skeleton';
-@import 'components/optional/menu';
-@import 'components/optional/modal';
-@import 'components/optional/order-card';
-@import 'components/optional/overflow-carousel';
-@import 'components/optional/page-banner';
-@import 'components/optional/ratings';
-@import 'components/optional/toast';
-@import 'components/optional/user-message';
+@import "components/optional/apps-banner";
+@import "components/optional/badges";
+@import "components/optional/content-header";
+@import "components/optional/content-title";
+@import "components/optional/cookie-warning";
+@import "components/optional/cuisines-widget";
+@import "components/optional/fullscreen-pop-over";
+@import "components/optional/listings";
+@import "components/optional/listings-skeleton";
+@import "components/optional/loading-indicator";
+@import "components/optional/menu";
+@import "components/optional/modal";
+@import "components/optional/order-card";
+@import "components/optional/overflow-carousel";
+@import "components/optional/page-banner";
+@import "components/optional/ratings";
+@import "components/optional/toast";
+@import "components/optional/user-message";
 
 // Global layout definitions & helpers
-@import 'base/layout';
-
+@import "base/layout";
 
 /**
  * Experiments
@@ -110,23 +107,20 @@
  */
 // @import 'experiments/INTPB-1451-quick-checkout';
 
-
 /**
  * Utility classes
  * =====================================
  * These should always come last as they should 'trump' other properties
  */
-@import 'trumps/utilities';
-@import 'trumps/rwd';
-
-
+@import "trumps/utilities";
+@import "trumps/rwd";
 
 /**
  * Print styles
  */
-@import 'base/print';
+@import "base/print";
 
 /**
  * Templates for including base sets of styles
  */
-@import 'templates';
+@import "templates";

--- a/src/scss/components/optional/_loading-indicator.scss
+++ b/src/scss/components/optional/_loading-indicator.scss
@@ -1,0 +1,50 @@
+/**
+* Components > Spinner Indicator
+* =================================
+*
+* Example: f-searchbox -  Loqate feature enabled (Full address capture)
+*
+* If you'd like to use it in your project you can include it by adding `@include loadingIndicator();` into your SCSS dependencies file.
+*
+*/
+
+$loading-indicator-size-medium: 20px;
+$loading-indicator-size-large: 48px;
+$loading-indicator-color: $orange;
+$loading-indicator-borderSize: 3px;
+$loading-indicator-borderColorOpaque: rgba(243, 109, 0, 0.2);
+$loading-indicator-spacing: 20px;
+
+@mixin loadingIndicator($loading-indicator-size: "medium") {
+  @keyframes spin {
+    from {
+      transform: rotate(0);
+    }
+
+    to {
+      transform: rotate(359deg);
+    }
+  }
+
+  .c-spinner-wrapper {
+    position: absolute;
+    right: 0;
+  }
+
+  .c-spinner {
+    margin-right: $loading-indicator-spacing;
+    border: $loading-indicator-borderSize solid $loading-indicator-color;
+    border-top: $loading-indicator-borderSize solid
+      $loading-indicator-borderColorOpaque;
+    border-radius: 50%;
+    animation: spin 1s linear 0s infinite;
+
+    @if $loading-indicator-size == "large" {
+      width: $loading-indicator-size-large;
+      height: $loading-indicator-size-large;
+    } @else {
+      width: $loading-indicator-size-medium;
+      height: $loading-indicator-size-medium;
+    }
+  }
+}


### PR DESCRIPTION
v5.0.0-beta.3
------------------------------
*February 16, 2021*

### Added
- Loading indicator which was in version 4 with an optional size

- [x] This PR has been checked with regard to our brand guidelines
- [ ] UI Documentation has been [created|updated]
- [ ] This code has been checked with regard to our accessibility standards
  - [ ] HTML is valid [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmlvalid)
  - [x] HTML is well structured [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmlstructure)
  - [x] HTML is well ordered [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmlorder)
  - [ ] HTML is semantic [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmlsemantic)
  - [ ] HTML is labelled [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmllabelled)
  - [ ] Passed an accessibility audit [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#audit)
  - [ ] Keyboard is supported [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#keyboard)
  - [ ] Tab stops in place [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#tabstops)
  - [ ] Focus is managed [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#focus)
  - [ ] States are updated [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#state)
  - [ ] Page is well spoken [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#wellspoken)

## Browsers Tested

- [x] Chrome
- [ ] Edge
- [ ] Internet Explorer 11
- [ ] Mobile (i.e. iPhone/Android - please list device)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
