### PR TITLE
v5.0.0-beta.5 - Import typography design tokens into Fozzie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v5 Todo List
 ------------------------------
-- Typography variable updates (next PR)
 - File Restructure (will do as a separate PR).
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
+
+v5.0.0-beta.5
+------------------------------
+*March 23, 2021*
+
+### Changed
+- Updated type-map with new typography variables for font-size and line-height.
+- `$font-weight-bold` was removed as it now comes straight from pie-design-tokens
+- Typography variables transitioned:
+  - `$font-weight-base` > `$font-weight-regular`
 
 
 v5.0.0-beta.4

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -32,7 +32,7 @@
         font-family: $font-family-base;
         @include font-size(body-s);
         color: $color-text;
-        font-weight: $font-weight-base;
+        font-weight: $font-weight-regular;
 
         text-rendering: optimizelegibility;
         -webkit-font-smoothing: antialiased;

--- a/src/scss/components/optional/_content-header.scss
+++ b/src/scss/components/optional/_content-header.scss
@@ -22,7 +22,7 @@
             padding: 0;
             display: inline-block;
             margin: 0 spacing(x2) 0 0;
-            font-weight: $font-weight-base;
+            font-weight: $font-weight-regular;
             @include font-size(body-l, false); // TODO – this should be updated with a more semantic font alias when it's ported to fozzie-components repo
         }
 
@@ -46,7 +46,7 @@
         .c-contentHeader-link {
             display: inline-block;
             text-decoration: none;
-            font-weight: $font-weight-base;
+            font-weight: $font-weight-regular;
 
             &:hover,
             &:focus {

--- a/src/scss/components/optional/_content-title.scss
+++ b/src/scss/components/optional/_content-title.scss
@@ -28,7 +28,7 @@
         .c-contentTitle-text {
             margin: 0;
             width: 100%;
-            font-weight: $font-weight-base;
+            font-weight: $font-weight-regular;
             @include font-size(body-l, false);
         }
 

--- a/src/scss/components/optional/_fullscreen-pop-over.scss
+++ b/src/scss/components/optional/_fullscreen-pop-over.scss
@@ -104,7 +104,7 @@
         .c-fullScreenPopOver-header-title {
             margin-top: 0;
             text-align: center;
-            font-weight: $font-weight-base;
+            font-weight: $font-weight-regular;
         }
 
         .c-fullScreenPopOver-footer {

--- a/src/scss/components/optional/_menu.scss
+++ b/src/scss/components/optional/_menu.scss
@@ -60,7 +60,7 @@
             .c-menu-item--active {
                 border-left: none;
                 border-bottom: solid $menu-border-width--active $menu-border-color--active;
-                font-weight: $font-weight-base;
+                font-weight: $font-weight-regular;
                 margin-left: 0;
             }
         }
@@ -156,7 +156,7 @@
                     &:focus,
                     &:hover {
                         border: 0;
-                        font-weight: $font-weight-base;
+                        font-weight: $font-weight-regular;
                     }
                 }
 

--- a/src/scss/components/optional/_order-card.scss
+++ b/src/scss/components/optional/_order-card.scss
@@ -114,7 +114,7 @@
     .c-orderCard-order {
         @include font-size(body-l, false);
         line-height: line-height(16px, 24px);
-        font-weight: $font-weight-base;
+        font-weight: $font-weight-regular;
         @include font-size(22px);
         color: $color-blue;
         text-align: center;

--- a/src/scss/objects/_lists.scss
+++ b/src/scss/objects/_lists.scss
@@ -59,7 +59,7 @@
             margin-bottom: spacing(x4);
 
             > div {
-                font-weight: $font-weight-base;
+                font-weight: $font-weight-regular;
                 @include font-size(body-s);
             }
         }

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -9,57 +9,55 @@
 // Set this in pixels (but do not add px),
 // the font-size mixin will convert to REMS
 
-$font-size-base             : 14;
+$font-size-base             : $font-paragraph-02;
 $font-size-base-px          : $font-size-base * 1px;
 
 // Type map – these are our global font-sizes and line-heights across the site
 $type: (
     caption: (
-        default: (12, 16)
+        default: ($font-size-a)
     ),
     body-s: (
-        default: (14, 20)
+        default: ($font-size-b)
     ),
     body-l: (
-        default: (16, 24)
+        default: ($font-size-c)
     ),
     subheading-s: (
-        default: (20, 28),
-        narrow: (16, 24)
+        default: ($font-size-d),
+        narrow: ($font-size-c)
     ),
     subheading-l: (
-        default: (24, 32),
-        narrow: (20, 28)
+        default: ($font-size-e),
+        narrow: ($font-size-d)
     ),
     heading-s: (
-        default: (20, 28),
-        narrow: (16, 24)
+        default: ($font-size-d),
+        narrow: ($font-size-c)
     ),
     heading-m: (
-        default: (24, 32),
-        narrow: (20, 28)
+        default: ($font-size-e),
+        narrow: ($font-size-d)
     ),
     heading-l: (
-        default: (28, 36),
-        narrow: (24, 32)
+        default: ($font-size-f),
+        narrow: ($font-size-e)
     ),
     heading-xl: (
-        default: (32, 40),
-        narrow: (28, 36)
+        default: ($font-size-g),
+        narrow: ($font-size-f)
     ),
     heading-xxl: (
-        default: (48, 56),
-        narrow: (32, 40)
+        default: ($font-size-h),
+        narrow: ($font-size-g)
     )
 ) !default;
 
-$font-weight-base           : 400;
-$font-weight-bold           : 600;
-$font-weight-headings       : 600;
+$font-weight-headings       : $font-weight-bold;
 $line-height-base           : line-height();
 
 // Font stacks
-$font-family-base           : 'JustEatBasis', Arial, sans-serif;
+$font-family-base           : $font-family-primary, Arial, sans-serif;
 $font-family-mono           : Menlo, Monaco, 'Courier New', monospace;
 
 


### PR DESCRIPTION
### Changed
- Updated type-map with new typography variables for font-size and line-height.
- Typography variables transitioned:
  - `$font-weight-base` > `$font-weight-regular`
  - `$font-weight-bold` definition was removed as it now comes from pie-design-tokens.

## UI Review Checks

- [ ] This PR has been checked with regard to our brand guidelines