### PR TITLE
v5.0.0-beta.6 - more color vars transition + link styles changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ v5 Todo List
 - File Restructure (will do as a separate PR).
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
+
+v5.0.0-beta.6
+------------------------------
+*March 31, 2021*
+
+### Changed
+- Underlined hover and focus state for `.o-link--noDecoration`.
+- More colour variables transitioned:
+  - `$color-bg` > `$color-background-default`
+  - `$color-text` > `$color-content-default`
+  - `$color-headings` > `$color-content-default`
+  - `$color-link-default` > `$color-content-link`
+  - `$color-border` > `$color-border-strong`
+  - `$color-link-hover` > `$color-content-link` & darken(4%)
+  - `$color-link-active` > `$color-content-link` & darken(6%)
+
+
 v5.0.0-beta.5
 ------------------------------
 *March 23, 2021*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0-beta.5",
+  "version": "5.0.0-beta.6",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -8,7 +8,7 @@
     */
 
     body {
-        background-color: $color-bg;
+        background-color: $color-background-default;
     }
 
     /*
@@ -113,7 +113,7 @@
 
     // Used for dividing pages or cards horizontally
     .l-divider {
-        border-bottom: 1px solid $color-border;
+        border-bottom: 1px solid $color-border-strong;
     }
 
     // utility that lets you align items side by side and vertically centered

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -31,7 +31,7 @@
     body {
         font-family: $font-family-base;
         @include font-size(body-s);
-        color: $color-text;
+        color: $color-content-default;
         font-weight: $font-weight-regular;
 
         text-rendering: optimizelegibility;
@@ -62,7 +62,7 @@
     .gamma,
     .delta,
     .epsilon {
-        color: $color-headings;
+        color: $color-content-default;
         margin: 0;
         margin-bottom: 0;
         font-family: $font-family-base;

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -17,11 +17,11 @@
     $card-arrow-bottom-position                     : 0;
     $card-padding                                   : spacing(x2);
     $card-radius                                    : 4px;
-    $card-borderColor                               : $color-border;
+    $card-borderColor                               : $color-border-strong;
     $card-section-margin                            : spacing(x4);
     $card-section-margin--large                     : spacing(x8);
     $card-section-highlight-backgroundColor         : $color-orange-10;
-    $card-section-highlight-color                   : $color-text;
+    $card-section-highlight-color                   : $color-content-default;
     $card-section-collapsible-paddingRight          : 60px;
     $card-section-collapsed-height                  : 40px;
 

--- a/src/scss/components/_media-element.scss
+++ b/src/scss/components/_media-element.scss
@@ -99,7 +99,7 @@
 
         // apply an outline to the mediaElement img
         .c-mediaElement-img--outlined {
-            border: solid 1px $color-border;
+            border: solid 1px $color-border-strong;
             border-radius: $mediaElement-img-borderRadius;
         }
 

--- a/src/scss/components/optional/_fullscreen-pop-over.scss
+++ b/src/scss/components/optional/_fullscreen-pop-over.scss
@@ -17,7 +17,7 @@
     $fullScreenPopOver-action-background : $color-white;
     $fullScreenPopOver-padding           : spacing(x2);
     $fullScreenPopOver-border-color      : $color-grey-30;
-    $fullScreenPopOver-shadow-color      : rgba(color-black, 0.12);
+    $fullScreenPopOver-shadow-color      : rgba($color-black, 0.12);
 
     .c-fullScreenPopOver {
         @include media('<mid') {

--- a/src/scss/components/optional/_listings.scss
+++ b/src/scss/components/optional/_listings.scss
@@ -29,7 +29,7 @@
     // code needs to be within its own media mixin.
 
     $listing-bg                     : $color-white;
-    $listing-borderColor            : $color-border;
+    $listing-borderColor            : $color-border-strong;
     $listing-border-radius          : 4px;
     $listing-img-border-radius      : 2px;
     $listing-promoIcon-color        : $color-orange;
@@ -168,7 +168,7 @@
             // make sure it doesn’t underline everything (only the main title)
             .c-listing-item-link {
                 display: block;
-                color: $color-text;
+                color: $color-content-default;
                 text-decoration: none;
 
                 &:hover,
@@ -232,7 +232,7 @@
 
             .c-listing-item-info {
                 position: relative;
-                color: $color-text;
+                color: $color-content-default;
                 padding-left: 70px;
                 min-height: 60px;
 

--- a/src/scss/components/optional/_menu.scss
+++ b/src/scss/components/optional/_menu.scss
@@ -15,16 +15,16 @@
 
     $menu-headerHeight                      : 57px;
     $menu-fontSize                          : body-l;
-    $menu-border-color                      : $color-border;
+    $menu-border-color                      : $color-border-strong;
     $menu-border-color--active              : $color-grey-50;
     $menu-border-width                      : 1px;
     $menu-border-width--active              : 2px;
-    $menu-link-color                        : $color-text;
+    $menu-link-color                        : $color-content-default;
     $menu-link-padding                      : spacing() spacing(x2);
     $menu-positionTop                       : $menu-headerHeight + spacing(x2);
     $menu--condensed-link-padding           : spacing(x0.5);
     $menu--expandable-bgColor               : $color-white;
-    $menu--expandable-borderBottom          : $color-border;
+    $menu--expandable-borderBottom          : $color-border-strong;
     $menu--expandable-linkFontSize          : body-s;
     $menu--expandable-linkActiveFontSize    : body-l;
 

--- a/src/scss/objects/_body.scss
+++ b/src/scss/objects/_body.scss
@@ -16,7 +16,7 @@
     }
 
         .o-body--bgWhite--belowMid {
-            background-color: $color-bg;
+            background-color: $color-background-default;
 
             @include media('<mid') {
                 background-color: $color-white;

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -315,18 +315,18 @@
         background-color: transparent;
         padding: 0;
         margin: 0;
-        color: $color-link-default;
+        color: $color-content-link;
         font-weight: 500;
         text-decoration: underline;
 
         &:hover {
             cursor: pointer;
-            color: $color-link-hover;
+            color: darken($color-content-link, $color-hover-01);
             background-color: transparent;
         }
         &:active,
         &:focus {
-            color: $color-link-active;
+            color: darken($color-content-link, $color-active-02);
             background-color: transparent;
         }
     }

--- a/src/scss/objects/_form-controls.scss
+++ b/src/scss/objects/_form-controls.scss
@@ -34,11 +34,11 @@
 
     $formControl-bgColor            : $color-white;
     $formControl-bgColor--disabled  : $color-disabled;
-    $formControl-borderColor        : $color-border;
+    $formControl-borderColor        : $color-border-strong;
     $formControl-borderColor--hover : $color-orange;
     $formControl-color              : $color-orange;
-    $formControl-color--hover       : darken($color-orange, 4%); // TODO update to include hover alias token
-    $formControl-background-color   : $color-bg;
+    $formControl-color--hover       : darken($color-orange, $color-hover-01);
+    $formControl-background-color   : $color-background-default;
     $formControl-margin-left        : 0;
     $formControl-padding-left       : spacing(x4);
     $formControl-width              : 24px;

--- a/src/scss/objects/_links.scss
+++ b/src/scss/objects/_links.scss
@@ -13,15 +13,15 @@
 
     a {
         & {
-            color: $color-link-default;
+            color: $color-content-link;
         }
 
         &:hover, &:focus {
-            color: $color-link-hover;
+            color: darken($color-content-link, $color-hover-01);
         }
 
         &:active {
-            color: $color-link-active;
+            color: darken($color-content-link, $color-active-02);
         }
         // have left in in case we want to use eventually
         // &:visited {
@@ -37,6 +37,12 @@
 
     .o-link--noDecoration {
         text-decoration: none;
+
+        // for accessibility reasons we are leaving
+        // text-decoration on hover and focus
+        &:hover, &:focus {
+            text-decoration: underline;
+        }
     }
 
     .o-link--bold {

--- a/src/scss/objects/_links.scss
+++ b/src/scss/objects/_links.scss
@@ -16,7 +16,8 @@
             color: $color-content-link;
         }
 
-        &:hover, &:focus {
+        &:hover,
+        &:focus {
             color: darken($color-content-link, $color-hover-01);
         }
 
@@ -40,7 +41,8 @@
 
         // for accessibility reasons we are leaving
         // text-decoration on hover and focus
-        &:hover, &:focus {
+        &:hover,
+        &:focus {
             text-decoration: underline;
         }
     }

--- a/src/scss/objects/_tables.scss
+++ b/src/scss/objects/_tables.scss
@@ -22,8 +22,8 @@
     $table-bgColor--accent        : $color-grey-10 !global; // Background color used for `.table-striped`.
     $table-border--color          : $color-grey-10 !global; // Border color for table and cell borders.
     $table-border--width          : 2px !global; // Border width for table border.
-    $table-innerBorder--color     : $color-border !global;
-    $table-verticalBorder--color  : $color-border--interactive !global;
+    $table-innerBorder--color     : $color-grey-40 !global;
+    $table-verticalBorder--color  : $color-grey-50 !global;
 
 
     /**

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -175,11 +175,11 @@
     // ==========================================================================
 
     .u-color-text {
-        color: $color-text;
+        color: $color-content-default;
     }
 
     .u-color-link {
-        color: $color-link-default;
+        color: $color-content-link;
     }
 
     .u-color-secondary {


### PR DESCRIPTION
### Changed
- Underlined hover and focus state for `.o-link--noDecoration`.
- More colour variables transitioned:
  - `$color-bg` > `$color-background-default`
  - `$color-text` > `$color-content-default`
  - `$color-headings` > `$color-content-default`
  - `$color-link-default` > `$color-content-link`
  - `$color-border` > `$color-border-strong`
  - `$color-link-hover` > `$color-content-link` & darken(4%)
  - `$color-link-active` > `$color-content-link` & darken(6%)