### PR TITLE
v5.0.0-beta.7 - more pie design tokens colour vars transitioned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ v5 Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v5.0.0-beta.7
+------------------------------
+*April 29, 2021*
+
+### Changed
+- More colour variables transitioned:
+  - `$color-secondary` > `$color-blue`
+  - `$color-text--hint` > `$color-grey-40`
+  - `$color-text--success` > `$color-content-positive`
+  - `$color-text--danger` > `$color-content-error`
+  - `$color-text--warning` > `$color-content-brand-strong`
+  - `$color-focus-outline` > `$color-focus`
+- Updated `f-utils` to v2.0.0
+
+
 v5.0.0-beta.6
 ------------------------------
 *March 31, 2021*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0-beta.6",
+  "version": "5.0.0-beta.7",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -35,7 +35,7 @@
   "dependencies": {
     "@justeat/f-dom": "1.1.0",
     "@justeat/f-logger": "0.8.1",
-    "@justeat/f-utils": "1.1.0",
+    "@justeat/f-utils": "2.0.0",
     "@justeat/pie-design-tokens": "0.18.0",
     "fontfaceobserver": "2.1.0",
     "include-media": "1.4.9",

--- a/src/scss/components/_alerts.scss
+++ b/src/scss/components/_alerts.scss
@@ -38,14 +38,14 @@
     // Generate contextual modifier classes for colorizing the alert.
 
     .c-alert--success {
-        @include alert-variant($color-bg--accept, $color-text--success);
+        @include alert-variant($color-bg--accept, $color-content-positive);
     }
 
     .c-alert--warning {
-        @include alert-variant($color-bg--notification, $color-text--warning);
+        @include alert-variant($color-bg--notification, $color-content-brand-strong);
     }
 
     .c-alert--danger {
-        @include alert-variant($color-bg--error, $color-text--danger);
+        @include alert-variant($color-bg--error, $color-content-error);
     }
 }

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -48,8 +48,8 @@
 
     $btnGroup-outline-textColor         : $color-grey-50;
     $btnGroup-outline-border            : $color-grey-30;
-    $btnGroup-outline-active-border     : $color-secondary;
-    $btnGroup-outline-active-text-color : $color-secondary;
+    $btnGroup-outline-active-border     : $color-blue;
+    $btnGroup-outline-active-text-color : $color-blue;
 
     $btnToggle-bg                       : $color-grey-20;
     $btnToggle-bg--active               : $color-white;

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -183,23 +183,23 @@
     }
 
     .u-color-secondary {
-        color: $color-secondary;
+        color: $color-blue;
     }
 
     .u-color-text--hint {
-        color: $color-text--hint;
+        color: $color-grey-40;
     }
 
     .u-color-text--success {
-        color: $color-text--success;
+        color: $color-content-positive;
     }
 
     .u-color-text--danger {
-        color: $color-text--danger;
+        color: $color-content-error;
     }
 
     .u-color-text--warning {
-        color: $color-text--warning;
+        color: $color-content-brand-strong;
     }
 
     //
@@ -363,14 +363,14 @@
     /* Custom outline styling for elements that have a focus state */
     %u-elementFocus,
     .u-elementFocus {
-        outline: 2px solid $color-focus-outline;
+        outline: 2px solid $color-focus;
     }
 
     /* Custom visual outline emulation for better appearance on elements with rounded corners */
     %u-elementFocus--boxShadow,
     .u-elementFocus--boxShadow {
     outline: none;
-    box-shadow: 0 0 0 2px $color-focus-outline;
+    box-shadow: 0 0 0 2px $color-focus;
     }
 
     /*
@@ -384,7 +384,7 @@
     }
     %u-focusShadow-content,
     .u-focusShadow:focus > .u-focusShadow-content {
-        box-shadow: 0 0 2px 2px $color-focus-outline; /* keyboard-only focus styles */
+        box-shadow: 0 0 2px 2px $color-focus; /* keyboard-only focus styles */
     }
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1057,10 +1057,10 @@
     handlebars-helper-i18n "^0.1.0"
     handlebars-helper-inlinesvg "^1.0.4"
 
-"@justeat/f-utils@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-1.1.0.tgz#7407d0accec0de8c542478f63e0a015ec9098877"
-  integrity sha512-5nR77wCUngMfrBlPsM+nQJiOEh+I/DZWZiqO3cxZaOg9seanKBZnXMwyWnNAfx3ICzhJ3ejkMj2PSrAz2CxNYw==
+"@justeat/f-utils@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-2.0.0.tgz#34e34870f20ec85b5d0aca8a87e2bc2225e2f597"
+  integrity sha512-fFkNH39Qe6sg6e2YZmbh4l4g4qegvpsaEKnj1grCDRspQQvzpmBQBifx6nkHsdaEhetZTJC3LqwOXybmlVJI/g==
 
 "@justeat/gulp-build-fozzie@10.2.1":
   version "10.2.1"


### PR DESCRIPTION
### Changed
- More colour variables transitioned:
  - `$color-secondary` > `$color-blue`
  - `$color-text--hint` > `$color-grey-40`
  - `$color-text--success` > `$color-content-positive`
  - `$color-text--danger` > `$color-content-error`
  - `$color-text--warning` > `$color-content-brand-strong`
  - `$color-focus-outline` > `$color-focus`
- Updated `f-utils` to v2.0.0