### PR TITLE
v5.0.0-beta.8 - Adding a mixin in loading-indicator to be able to customise the colours of the spinner.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ v5 Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v5.0.0-beta.8
+------------------------------
+*June 4, 2021*
+
+### Added
+- Mixin in `loading-indicator` to be able to customise the colours of the spinner.
+
+
 v5.0.0-beta.7
 ------------------------------
 *April 29, 2021*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0-beta.7",
+  "version": "5.0.0-beta.8",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_loading-indicator.scss
+++ b/src/scss/components/optional/_loading-indicator.scss
@@ -15,6 +15,14 @@ $loading-indicator-borderSize: 3px;
 $loading-indicator-borderColorOpaque-default: rgba(243, 109, 0, 0.2);
 $loading-indicator-spacing: 20px;
 
+@mixin spinnerColor($loading-indicator-color: $loading-indicator-color-default, $loading-indicator-borderColorOpaque: $loading-indicator-borderColorOpaque-default) {
+  .c-spinner {
+    border: $loading-indicator-borderSize solid $loading-indicator-color;
+    border-top: $loading-indicator-borderSize solid $loading-indicator-borderColorOpaque;
+    border-right: $loading-indicator-borderSize solid $loading-indicator-borderColorOpaque;
+  }
+}
+
 @mixin loadingIndicator($loading-indicator-size: 'medium', $loading-indicator-color: $loading-indicator-color-default, $loading-indicator-borderColorOpaque: $loading-indicator-borderColorOpaque-default) {
   @keyframes spin {
     from {
@@ -33,11 +41,10 @@ $loading-indicator-spacing: 20px;
 
   .c-spinner {
     margin-right: $loading-indicator-spacing;
-    border: $loading-indicator-borderSize solid $loading-indicator-color;
-    border-top: $loading-indicator-borderSize solid $loading-indicator-borderColorOpaque;
-    border-right: $loading-indicator-borderSize solid $loading-indicator-borderColorOpaque;
     border-radius: 50%;
     animation: spin 1s linear 0s infinite;
+
+    @include spinnerColor();
 
     @if $loading-indicator-size=='large' {
       width: $loading-indicator-size-large;

--- a/src/scss/components/optional/_loading-indicator.scss
+++ b/src/scss/components/optional/_loading-indicator.scss
@@ -10,12 +10,12 @@
 
 $loading-indicator-size-medium: 20px;
 $loading-indicator-size-large: 48px;
-$loading-indicator-color: $color-orange;
+$loading-indicator-color-default: $color-orange;
 $loading-indicator-borderSize: 3px;
-$loading-indicator-borderColorOpaque: rgba(243, 109, 0, 0.2);
+$loading-indicator-borderColorOpaque-default: rgba(243, 109, 0, 0.2);
 $loading-indicator-spacing: 20px;
 
-@mixin loadingIndicator($loading-indicator-size: 'medium') {
+@mixin loadingIndicator($loading-indicator-size: 'medium', $loading-indicator-color: $loading-indicator-color-default, $loading-indicator-borderColorOpaque: $loading-indicator-borderColorOpaque-default) {
   @keyframes spin {
     from {
       transform: rotate(0);
@@ -34,15 +34,17 @@ $loading-indicator-spacing: 20px;
   .c-spinner {
     margin-right: $loading-indicator-spacing;
     border: $loading-indicator-borderSize solid $loading-indicator-color;
-    border-top: $loading-indicator-borderSize solid
-      $loading-indicator-borderColorOpaque;
+    border-top: $loading-indicator-borderSize solid $loading-indicator-borderColorOpaque;
+    border-right: $loading-indicator-borderSize solid $loading-indicator-borderColorOpaque;
     border-radius: 50%;
     animation: spin 1s linear 0s infinite;
 
-    @if $loading-indicator-size == 'large' {
+    @if $loading-indicator-size=='large' {
       width: $loading-indicator-size-large;
       height: $loading-indicator-size-large;
-    } @else {
+    }
+
+    @else {
       width: $loading-indicator-size-medium;
       height: $loading-indicator-size-medium;
     }


### PR DESCRIPTION
v5.0.0-beta.8
------------------------------
*June 4, 2021*

### Added
- Mixin in `loading-indicator` to be able to customise the colours of the spinner.

_Note: tested by `yalc'ing` these changes to `fozzie-components`_