### PR TITLE
v5.0.0-beta.9 - aliases instead of global vars + missed vars update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ v5 Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v5.0.0-beta.9
+------------------------------
+*June 30, 2021*
+
+### Changed
+
+- More colour variables transitioned:
+  - `$color-headings--highlight` > `$color-content-brand`
+  - `$color-bg--accept` > `$color-support-positive-02`
+  - `$color-bg--notification` > `$color-support-warning-02`
+  - `$color-bg--error` > `$color-support-error-02`
+  - `$color-disabled` > `$color-disabled-01`
+  - `$color-bg--component` > `$color-container-default`
+- Changed some global tokens to aliases
+
+
 v5.0.0-beta.8
 ------------------------------
 *June 4, 2021*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0-beta.8",
+  "version": "5.0.0-beta.9",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -104,7 +104,7 @@
                 text-align: center;
             }
             .l-content-header--highlight {
-                color: $color-headings--highlight;
+                color: $color-content-brand;
             }
 
         .l-content-main {

--- a/src/scss/components/_alerts.scss
+++ b/src/scss/components/_alerts.scss
@@ -38,14 +38,14 @@
     // Generate contextual modifier classes for colorizing the alert.
 
     .c-alert--success {
-        @include alert-variant($color-bg--accept, $color-content-positive);
+        @include alert-variant($color-support-positive-02, $color-content-positive);
     }
 
     .c-alert--warning {
-        @include alert-variant($color-bg--notification, $color-content-brand-strong);
+        @include alert-variant($color-support-warning-02, $color-content-brand-strong);
     }
 
     .c-alert--danger {
-        @include alert-variant($color-bg--error, $color-content-error);
+        @include alert-variant($color-support-error-02, $color-content-error);
     }
 }

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -48,7 +48,7 @@
 
     $btnGroup-outline-textColor         : $color-grey-50;
     $btnGroup-outline-border            : $color-grey-30;
-    $btnGroup-outline-active-border     : $color-blue;
+    $btnGroup-outline-active-border     : $color-interactive-primary;
     $btnGroup-outline-active-text-color : $color-blue;
 
     $btnToggle-bg                       : $color-grey-20;

--- a/src/scss/objects/_form-controls.scss
+++ b/src/scss/objects/_form-controls.scss
@@ -33,7 +33,7 @@
     */
 
     $formControl-bgColor            : $color-white;
-    $formControl-bgColor--disabled  : $color-disabled;
+    $formControl-bgColor--disabled  : $color-disabled-01;
     $formControl-borderColor        : $color-border-strong;
     $formControl-borderColor--hover : $color-orange;
     $formControl-color              : $color-orange;

--- a/src/scss/objects/_tables.scss
+++ b/src/scss/objects/_tables.scss
@@ -18,7 +18,7 @@
     /**
     * Define associated Table variables
     */
-    $table-bgColor                : $color-bg--component !global; // Default background color used for all tables.
+    $table-bgColor                : $color-container-default !global; // Default background color used for all tables.
     $table-bgColor--accent        : $color-grey-10 !global; // Background color used for `.table-striped`.
     $table-border--color          : $color-grey-10 !global; // Border color for table and cell borders.
     $table-border--width          : 2px !global; // Border width for table border.
@@ -89,7 +89,7 @@
         // Nesting
         & table,
         & .table {
-            background-color: $color-bg;
+            background-color: $color-background-default;
         }
 
         &:not(.not-striped) {

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -187,7 +187,7 @@
     }
 
     .u-color-text--hint {
-        color: $color-grey-40;
+        color: $color-content-subdued;
     }
 
     .u-color-text--success {


### PR DESCRIPTION
### Changed

- More colour variables transitioned:
  - `$color-headings--highlight` > `$color-content-brand`
  - `$color-bg--accept` > `$color-support-positive-02`
  - `$color-bg--notification` > `$color-support-warning-02`
  - `$color-bg--error` > `$color-support-error-02`
  - `$color-disabled` > `$color-disabled-01`
  - `$color-bg--component` > `$color-container-default`
- Changed some global tokens to aliases