### PR TITLE
v4.5.1 Fixed em scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v4.5.1
+------------------------------
+*July 5, 2021*
+
+### Fixed
+- fixed `em` scaling
 
 v4.5.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -68,7 +68,7 @@ $font-family-mono           : Menlo, Monaco, 'Courier New', monospace;
 
 $unit-intervals: (
   'px': 1,
-  'em': 0.063, //0.063ems converts to 1px (1 / 16 = 0.0625). We need this as some browsers are very specific with breakpoints
+  'em': 0.0001, // We need more sensitivity, some browsers are very specific with breakpoints
   'rem': 0.1,
   '': 0
 );


### PR DESCRIPTION
As per slack discussion a while ago, this chage fixes `em` scaling on some resolutions.

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile (i.e. iPhone/Android - please list device)
