### PR TITLE
v4.5.2 fixed the linter error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v4.5.2
+------------------------------
+*July 7, 2021*
+
+### Fixed
+- fixed the linter error
+
 v4.5.1
 ------------------------------
 *July 5, 2021*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -68,7 +68,7 @@ $font-family-mono           : Menlo, Monaco, 'Courier New', monospace;
 
 $unit-intervals: (
   'px': 1,
-  'em': 0.0001, // We need more sensitivity, some browsers are very specific with breakpoints
+  'em': 0.001, // We need more sensitivity, some browsers are very specific with breakpoints
   'rem': 0.1,
   '': 0
 );


### PR DESCRIPTION
Fixed the linter error

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile (i.e. iPhone/Android - please list device)


