### PR TITLE
v5.0.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ v5 Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v5.0.0-beta.1
+------------------------------
+*December 31, 2020*
+
+### Changed
+- Eyeglass version bumped to v3.
+
+
 v5.0.0-beta.0
 ------------------------------
 *November 3, 2020*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v5 Todo List
 ------------------------------
-- Typography variable updates (next PR)
 - File Restructure (will do as a separate PR).
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
+
+v5.0.0-beta.5
+------------------------------
+*March 23, 2021*
+
+### Changed
+- Updated type-map with new typography variables for font-size and line-height.
+- `$font-weight-bold` was removed as it now comes straight from pie-design-tokens
+- Typography variables transitioned:
+  - `$font-weight-base` > `$font-weight-regular`
 
 
 v5.0.0-beta.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ v5 Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v5.0.0-beta.10
+------------------------------
+*July 8, 2021*
+
+### Updated
+- pie-design-tokens package
+
+
 v5.0.0-beta.9
 ------------------------------
 *June 30, 2021*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ v5 Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v5.0.0-beta.3
+------------------------------
+*February 16, 2021*
+
+### Added
+- Loading indicator which was in version 4 with an optional size
+
+
 v5.0.0-beta.2
 ------------------------------
 *December 31, 2020*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,42 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v5 Todo List
 ------------------------------
+- Typography variable updates (next PR)
 - File Restructure (will do as a separate PR).
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
+
+
+v5.0.0-beta.4
+------------------------------
+*March 5, 2021*
+
+### Changed
+- Moved from using `fozzie-colour-palette` to `pie-design-tokens`.
+- Colour variables transitioned:
+  - `$black` > `$color-black`
+  - `$white` > `$color-white`
+  - `$grey--light` > `$color-grey-30`
+  - `$brand--orange` > `$color-orange-30`
+  - `$orange` > `$color-orange`
+  - `$orange-dark` > `$color-orange` & darken(4%)
+  - `$orange-darkest` > `$color-orange` & darken(10%)
+  - `$orange--aa` > `$color-orange-60`
+  - `$orange--offWhite` > `$color-orange-10`
+  - `$blue` > `$color-blue`
+  - `$blue--offWhite` > `$color-blue-10`
+  - `$blue--offWhite--dark`> `$color-blue-10` & darken(4%)
+  - `$blue--offWhite--darkest`> `$color-blue-10` & darken(10%)
+  - `$red` > `$color-red`
+  - `$green` > `$color-green`
+  - `$green--offWhite` > `$color-green-10`
+  - `$yellow--offWhite` > `$color-yellow-10`
+  - `$grey--offWhite` > `$color-grey-10`
+  - `$grey--lighter` > `$color-grey-20`
+  - `$grey--mid` > `$color-grey-40`
+  - `$grey--dark` > `$color-grey-50`
+  - `$grey--darkest` > `$color-grey`
+  - `$purple` > `$color-purple`
+  - `$purple--light` > `color-purple-10`
 
 
 v5.0.0-beta.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,41 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
-v5 Todo List
+Future Todo List
 ------------------------------
-- File Restructure (will do as a separate PR).
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
+
+
+v5.0.0
+------------------------------
+*August 23, 2021*
+
+## Main changes:
+- Colour and typography variables updated to use `pie-design-tokens` repo instead of `fozzie-colour-palette`.
+- When importing v5 fozzie, consuming applications only get included variables, functions and mixins (no classes). Component styles for buttons, form-fields etc are being deprecated as we move our components over to versionable packages, but can still be included via optional mixins applications that still need this as part of the transition.
+- Two optional variables can be used to include a base set of styles (similar to v4). These are `$includeBaseFramework` and `$includeMinimalFramework`. Check out the `_templates.scss` file to see what styles are included when these are set to true.
+
+### Changed
+- Eyeglass version bumped to v3.
+- Made all styles and components optional (wrapped in a mixin).
+- Lots of colour variables moved over as part of using the new `pie-design-tokens` repo instead of `fozzie-colour-palette`.
+- Updated type-map with new typography variables for font-size and line-height.
+
+### Removed
+- `/settings/glyphs` moved into badges, as it is the only place it is used.
+- `/images` as not used.
+- `kickoff-grid` dependency brought into fozzie, to remove external dependency (making it easier to change if needed).
+- `$font-weight-bold` was removed as it now comes straight from `pie-design-tokens`.
+
+
+** Full list of changes (including all colour variable changes) can be found below in beta release CHANGELOGs **
 
 
 v5.0.0-beta.10
 ------------------------------
 *July 8, 2021*
 
-### Updated
+### Changed
 - pie-design-tokens package
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ v5 Todo List
 - File Restructure (will do as a separate PR).
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
+
+v5.0.0-beta.6
+------------------------------
+*March 31, 2021*
+
+### Changed
+- Underlined hover and focus state for `.o-link--noDecoration`.
+- More colour variables transitioned:
+  - `$color-bg` > `$color-background-default`
+  - `$color-text` > `$color-content-default`
+  - `$color-headings` > `$color-content-default`
+  - `$color-link-default` > `$color-content-link`
+  - `$color-border` > `$color-border-strong`
+  - `$color-link-hover` > `$color-content-link` & darken(4%)
+  - `$color-link-active` > `$color-content-link` & darken(6%)
+
+
 v5.0.0-beta.5
 ------------------------------
 *March 23, 2021*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ v5 Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v5.0.0-beta.2
+------------------------------
+*December 31, 2020*
+
+### Changed
+- Updated versions of `f-utils` and `fozzie-colour-palette` and other minor deps.
+
+
 v5.0.0-beta.1
 ------------------------------
 *December 31, 2020*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ v5 Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v5.0.0-beta.9
+------------------------------
+*June 30, 2021*
+
+### Changed
+
+- More colour variables transitioned:
+  - `$color-headings--highlight` > `$color-content-brand`
+  - `$color-bg--accept` > `$color-support-positive-02`
+  - `$color-bg--notification` > `$color-support-warning-02`
+  - `$color-bg--error` > `$color-support-error-02`
+  - `$color-disabled` > `$color-disabled-01`
+  - `$color-bg--component` > `$color-container-default`
+- Changed some global tokens to aliases
+
+
 v5.0.0-beta.8
 ------------------------------
 *June 4, 2021*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ v5 Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v5.0.0-beta.8
+------------------------------
+*June 4, 2021*
+
+### Added
+- Mixin in `loading-indicator` to be able to customise the colours of the spinner.
+
+
 v5.0.0-beta.7
 ------------------------------
 *April 29, 2021*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+v5 Todo List
+------------------------------
+- File Restructure (will do as a separate PR).
+- Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
+
+
+v5.0.0-beta.0
+------------------------------
+*November 3, 2020*
+
+### Added
+- Base template includes for legacy consuming applications (PoC – needs testing).
+
+### Changed
+- Made all styles and components optional (wrapped in a mixin).
+
+### Removed
+- `/settings/glyphs` moved into badges, as it is the only place it is used.
+- `/images` as not used.
+- `kickoff-grid` dependency brought into fozzie, to remove external dependency (making it easier to change if needed).
+
+
 v4.5.2
 ------------------------------
 *July 7, 2021*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ v5 Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v5.0.0-beta.7
+------------------------------
+*April 29, 2021*
+
+### Changed
+- More colour variables transitioned:
+  - `$color-secondary` > `$color-blue`
+  - `$color-text--hint` > `$color-grey-40`
+  - `$color-text--success` > `$color-content-positive`
+  - `$color-text--danger` > `$color-content-error`
+  - `$color-text--warning` > `$color-content-brand-strong`
+  - `$color-focus-outline` > `$color-focus`
+- Updated `f-utils` to v2.0.0
+
+
 v5.0.0-beta.6
 ------------------------------
 *March 31, 2021*

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,5 +14,8 @@ module.exports = {
         '**/*.{spec,test}.(js|jsx|ts|tsx)',
         '**/__tests__/*.(js|jsx|ts|tsx)'
     ],
+    testPathIgnorePatterns: [
+        '/.yalc/'
+    ],
     testURL: 'http://localhost/'
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0-beta.3",
+  "version": "5.0.0-beta.4",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -36,7 +36,7 @@
     "@justeat/f-dom": "1.1.0",
     "@justeat/f-logger": "0.8.1",
     "@justeat/f-utils": "1.1.0",
-    "@justeat/fozzie-colour-palette": "3.1.0",
+    "@justeat/pie-design-tokens": "0.18.0",
     "fontfaceobserver": "2.1.0",
     "include-media": "1.4.9",
     "normalize-scss": "7.0.1"
@@ -45,9 +45,9 @@
     "@justeat/browserslist-config-fozzie": "1.2.0",
     "@justeat/gulp-build-fozzie": "10.2.1",
     "@justeat/js-test-buddy": "0.4.1",
-    "concurrently": "5.3.0",
+    "concurrently": "6.0.0",
     "coveralls": "3.1.0",
-    "danger": "10.6.0"
+    "danger": "10.6.3"
   },
   "resolutions": {
     "babel-core": "7.0.0-bridge.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0-beta.6",
+  "version": "5.0.0-beta.7",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -35,7 +35,7 @@
   "dependencies": {
     "@justeat/f-dom": "1.1.0",
     "@justeat/f-logger": "0.8.1",
-    "@justeat/f-utils": "1.1.0",
+    "@justeat/f-utils": "2.0.0",
     "@justeat/pie-design-tokens": "0.18.0",
     "fontfaceobserver": "2.1.0",
     "include-media": "1.4.9",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0-beta.9",
+  "version": "5.0.0-beta.10",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -36,7 +36,7 @@
     "@justeat/f-dom": "1.1.0",
     "@justeat/f-logger": "0.8.1",
     "@justeat/f-utils": "2.0.0",
-    "@justeat/pie-design-tokens": "0.18.0",
+    "@justeat/pie-design-tokens": "0.19.0",
     "fontfaceobserver": "2.1.0",
     "include-media": "1.4.9",
     "normalize-scss": "7.0.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -59,7 +59,7 @@
   "eyeglass": {
     "name": "fozzie",
     "sassDir": "src/scss",
-    "needs": "^1.1.2",
+    "needs": "^3.0.2",
     "exports": false
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0-beta.2",
+  "version": "5.0.0-beta.3",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0-beta.7",
+  "version": "5.0.0-beta.8",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0-beta.4",
+  "version": "5.0.0-beta.5",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0-beta.5",
+  "version": "5.0.0-beta.6",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0-beta.8",
+  "version": "5.0.0-beta.9",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "4.5.2",
+  "version": "5.0.0-beta.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -39,7 +39,6 @@
     "@justeat/fozzie-colour-palette": "3.1.0",
     "fontfaceobserver": "2.1.0",
     "include-media": "1.4.9",
-    "kickoff-grid.css": "1.2.0",
     "normalize-scss": "7.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0-beta.10",
+  "version": "5.0.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -38,16 +38,16 @@
     "@justeat/f-utils": "2.0.0",
     "@justeat/pie-design-tokens": "0.19.0",
     "fontfaceobserver": "2.1.0",
-    "include-media": "1.4.9",
+    "include-media": "1.4.10",
     "normalize-scss": "7.0.1"
   },
   "devDependencies": {
     "@justeat/browserslist-config-fozzie": "1.2.0",
     "@justeat/gulp-build-fozzie": "10.2.1",
     "@justeat/js-test-buddy": "0.4.1",
-    "concurrently": "6.0.0",
-    "coveralls": "3.1.0",
-    "danger": "10.6.3"
+    "concurrently": "6.2.1",
+    "coveralls": "3.1.1",
+    "danger": "10.6.6"
   },
   "resolutions": {
     "babel-core": "7.0.0-bridge.0"

--- a/src/scss/_dependencies.scss
+++ b/src/scss/_dependencies.scss
@@ -87,6 +87,7 @@
 @import 'components/optional/fullscreen-pop-over';
 @import 'components/optional/listings';
 @import 'components/optional/listings-skeleton';
+@import 'components/optional/loading-indicator';
 @import 'components/optional/menu';
 @import 'components/optional/modal';
 @import 'components/optional/order-card';
@@ -121,11 +122,11 @@
 @import 'trumps/rwd';
 
 
-
 /**
  * Print styles
  */
 @import 'base/print';
+
 
 /**
  * Templates for including base sets of styles

--- a/src/scss/_dependencies.scss
+++ b/src/scss/_dependencies.scss
@@ -30,7 +30,7 @@
 // =================================
 // The colour variables are imported from https://www.npmjs.com/package/@justeat/fozzie-colour-palette
 // If a custom theme is specified, it applies a set of colour overides to the base theme depending on the $theme
-@import 'fozzie-colour-palette';
+@import 'pie-design-tokens';
 
 @import 'settings/variables';
 @import 'f-utils/helpers/breakpoints'; // breakpoint helper – https://github.com/justeat/f-utils/blob/96508ae19809c4b8b83cebb55b9d74728d01c1a5/src/scss/helpers/_breakpoints.scss

--- a/src/scss/_dependencies.scss
+++ b/src/scss/_dependencies.scss
@@ -33,7 +33,6 @@
 @import 'fozzie-colour-palette';
 
 @import 'settings/variables';
-@import 'settings/glyphs';
 @import 'f-utils/helpers/breakpoints'; // breakpoint helper – https://github.com/justeat/f-utils/blob/96508ae19809c4b8b83cebb55b9d74728d01c1a5/src/scss/helpers/_breakpoints.scss
 
 
@@ -44,7 +43,7 @@
 // Global typography styles
 @import 'base/typography';
 
-@import 'kickoff-grid'; // Grid system based on flexbox w float fallbacks – https://github.com/TryKickoff/kickoff-grid.css
+@import 'base/grid'; // Grid system based on flexbox w float fallbacks – https://github.com/TryKickoff/kickoff-grid.css
 
 /**
  * Objects
@@ -60,7 +59,6 @@
  */
 @import 'objects/body';
 @import 'objects/buttons';
-@import 'objects/images';
 @import 'objects/links';
 @import 'objects/lists';
 @import 'objects/tables';
@@ -128,3 +126,8 @@
  * Print styles
  */
 @import 'base/print';
+
+/**
+ * Templates for including base sets of styles
+ */
+@import 'templates';

--- a/src/scss/_templates.scss
+++ b/src/scss/_templates.scss
@@ -1,0 +1,60 @@
+/**
+ * Setting $includeBaseFramework to `true` includes the base styles that were included
+ * as part of Fozzie v4 (useful for anyone upgrading that wants to keep things as-is)
+**/
+@if $includeBaseFramework {
+    @include reset();
+    @include typography();
+
+    @include grid();
+
+    // base objects
+    @include bodyStyles();
+    @include buttons();
+    @include links();
+    @include lists();
+    @include tables();
+    @include formControls();
+    @include formToggle();
+
+    // base components
+    @include alerts();
+    @include breadcrumbs();
+    @include cards();
+    @include mediaElement();
+
+    // layout
+    @include layout();
+
+    // trumps
+    @include trumps-utilities();
+    @include trumps-rwd();
+
+    @include print();
+}
+
+/**
+ * Setting $includeMinimalFramework to `true` includes a recommended base set of styles
+ * that provides styling for most use-cases (links, lists, buttons, grid)
+ **/
+@if $includeMinimalFramework {
+    @include reset();
+    @include typography();
+
+    @include grid();
+
+    // base objects
+    @include bodyStyles();
+    @include buttons();
+    @include links();
+    @include lists();
+
+    // layout
+    @include layout();
+
+    // trumps
+    @include trumps-utilities();
+    @include trumps-rwd();
+
+    @include print();
+}

--- a/src/scss/base/_grid.scss
+++ b/src/scss/base/_grid.scss
@@ -1,0 +1,378 @@
+/**
+ * The Kickoff Flexbox Grid
+ * =================================
+ * Default grid classes
+ * Grid gutter options
+ * Modifier Classes (column height and cell alignment)
+ * Legacy fallbacks for flexbox
+ * Grid span classes
+ * Breakpoint stacking
+ */
+
+
+/* Import Grid helpers and mixins */
+
+/**
+ * Kickoff grid helpers
+ */
+
+ @mixin ko-gridSpanHelper($breakpoint: null) {
+    $suffix: null;
+
+    @if $breakpoint {
+        $suffix: --#{$breakpoint};
+    }
+
+    @for $i from 1 to $grid-column-count + 1 {
+        $col-width: ko-gridColumnWidthCalc($i, true);
+        $col-width-guttered: ko-gridColumnWidthCalc($i, true, true);
+
+        .g-span#{$i}#{$suffix} {
+            flex-basis: $col-width !important;
+            flex-grow: 0;
+            // need this next line for a weird IE9/10/11 bug, where adding padding to a flex-item can throw out the flex-basis and wrap the columns incorrectly
+            // see this for more detail – https://github.com/philipwalton/flexbugs/issues/3
+            max-width: $col-width !important;
+
+            // maybe have an option to include this in a variable
+            &.g-holdWidth#{$suffix} {
+                @include ko-pixelMinWidth($i);
+
+                .g--gutter--scaled & {
+                    @include ko-pixelMinWidth($i, true); // get the hold-width minus the gutter
+                }
+            }
+
+            .g--gutter--scaled & {
+                flex-basis: $col-width-guttered !important;
+                // need this next line for a weird IE9/10/11 bug, where adding padding to a flex-item can throw out the flex-basis and wrap the columns incorrectly
+                // see this for more detail – https://github.com/philipwalton/flexbugs/issues/3
+                max-width: $col-width-guttered;
+
+                @if $i < $grid-column-count {
+                    margin-left: ko-gutterCalc();
+                }
+                @else {
+                    margin-left: 0;
+                }
+            }
+
+            @if $use-legacy-grid {
+
+                // used in combination with modernizr or another detection mechanism
+                .no-flexbox & {
+                    width: ko-gridColumnWidthCalc($i, true) !important;
+                }
+
+            }
+            // @if $use-legacy-grid
+
+        }
+        @if $i < 12 {
+            .g-offset#{$i}#{$suffix} {
+                margin-left: $col-width !important;
+            }
+        }
+    }
+}
+
+/**
+* Grid stacking
+* Stack grids based on a given breakpoint
+*
+* Usage:
+* .g--stack--narrow
+* .g--stack--wide
+*/
+@mixin ko-grid-stack($breakpoint: 'wide') {
+    @include media('<#{$breakpoint}') {
+        flex-flow: column nowrap;
+
+        & > .g-col {
+            flex-basis: auto !important;
+            max-width: 100% !important;
+            margin-left: 0; // get rid of any grid margins if there are any
+
+            @if $use-legacy-grid {
+                .no-flexbox & {
+                    width: 100% !important;
+                }
+            }
+        }
+    }
+}
+
+/**
+* Gutter Calculations
+* Default: percent
+* Usage: ko-gutterCalc() or ko-gutterCalc(false)
+* When show-unit is true, returns the percentage, otherwise return a decimal
+*/
+@function ko-gutterCalc($show-unit: true) {
+    @if $show-unit == true {
+        @return percentage(strip-units($grid-gutter-width) / strip-units($layout-max-width));
+    } @else {
+        @return $grid-gutter-width / $layout-max-width;
+    }
+}
+
+
+
+/**
+* Grid columns width calculations
+* This is where the magic of working out the column widths happens
+*
+* $column-span: define the width for the number of columns required
+* $show-unit: Switch return value between percentage (default) and decimal
+* $include-gutters: if gutters should be included in the calculations. Default = false
+* $legacy-calc: if we are working out a legacy column width calculation, or not. Default = false
+*/
+@function ko-gridColumnWidthCalc($column-span: 1, $show-unit: true, $include-gutters: false) {
+    $number-of-blocks-in-container : $grid-column-count / $column-span;
+    $total-width-of-all-blocks     : 1;
+
+    // when including gutters, we need to adjust our % width or flex-basis appropriately
+    @if $include-gutters {
+        $total-width-of-all-gutters    : ko-gutterCalc(false) * ($number-of-blocks-in-container - 1);
+        $total-width-of-all-blocks     : 1 - $total-width-of-all-gutters;
+    }
+
+    $width-of-a-single-block       : $total-width-of-all-blocks / $number-of-blocks-in-container;
+
+    @if $show-unit == true {
+        @return percentage(strip-units($width-of-a-single-block));
+    } @else {
+        @return $width-of-a-single-block;
+    }
+}
+
+@mixin ko-pixelMinWidth($column-span: 1, $minusGutter: false) {
+    @if $minusGutter == true {
+        min-width: ($layout-max-width * ko-gridColumnWidthCalc($column-span, false)) - ($layout-max-width * ko-gutterCalc(false)) + px;
+    }
+    @else {
+        min-width: ($layout-max-width * ko-gridColumnWidthCalc($column-span, false)) + px;
+    }
+}
+
+
+/**
+* Column width mixin
+* Usage:
+* @include column(2);
+*/
+@mixin column($column-span: 1) {
+    width: ko-gridColumnWidthCalc($column-span, true);
+}
+
+
+@mixin grid() {
+
+    /**
+    * Basic Usage:
+    * =================================
+        <div class="g">
+            <div class="g-col g-span4 g-span6--mid"></div>
+            <div class="g-col g-span8 g-span6--mid"></div>
+        </div>
+    */
+    .g {
+        display: flex !important; // force display: flex, as otherwise may clash with other components display properties (and the grid won’t work)
+        flex-flow: row wrap;
+
+        // any image in the grid should have a max-width of it’s container
+        & img {
+            max-width: 100%;
+        }
+    }
+
+        .g-col {
+            display: block;
+            box-sizing: border-box; // Ensure border-box is specified as the grid proportions rely on this
+
+            // By default, evenly distribute columns
+            // n.b. to support non-flexbox browsers, you should always add .g-spanx
+            flex: 1 0 0;
+            min-width: 0; // this is to make sure that long words don’t get cut off, but wrap as expected
+        }
+
+    /**
+    * Gutter calcs – applied to grid columns in our grid (direct descendants only)
+    * Default: pixels (can look at changing to percentage)
+    * Usage: gutterCalc() or gutterCalc(false)
+    */
+
+    // Three types of gutter
+    // -------------------
+    // .g--gutter
+    // Uses padding and fixed gutter px values.
+    // Pros = Margins will be equal to your $grid-gutter-width (even at larger/smaller container sizes), if that’s what you require
+    // Cons = Can’t set a border directly to grid containers, as uses negative margins.  Need extra element to get the desired effect
+
+    $g-gutter-half: ($grid-gutter-width / 2) + px;
+
+    .g--gutter {
+        margin-left: -$g-gutter-half;
+        margin-right: -$g-gutter-half;
+
+        & > .g-col {
+            padding-left: $g-gutter-half;
+            padding-right: $g-gutter-half;
+        }
+    }
+
+    // .g--gutter--<breakpoints>
+    // Generates gutter settings for each defined breakpoint for better gutter control in responsive designs
+    // Only generated if $responsive-gutters == true
+
+    @if $responsive-gutters {
+        @each $name, $value in $breakpoints {
+            .g--gutter--#{$name} {
+                @include media('>=#{$name}') {
+                    margin-left: -$g-gutter-half;
+                    margin-right: -$g-gutter-half;
+
+                    & > .g-col {
+                        padding-left: $g-gutter-half;
+                        padding-right: $g-gutter-half;
+                    }
+                }
+            }
+        }
+    }
+
+    // .g--gutter--scaled
+    // Uses margin and percentage values.  Scales the margin as the viewport gets smaller (for RWD)
+    // Pro = Good for when your container is always the $layout-max-width.  Means can apply borders to grid elements without more markup
+    // Cons = If container isn’t same size as $layout-max-width, the gutters will also scale (so larger container width === larger gutters and vice versa)
+
+    .g--gutter--scaled {
+        & > .g-col {
+            margin-left: ko-gutterCalc();
+            margin-right: 0;
+
+            &:first-child {
+                margin-left: 0;
+            }
+        }
+    }
+
+    .g--stack {
+        & > .g-col {
+            flex-basis: 100%;
+            max-width: 100%;
+        }
+        &.g--gutter--scaled > .g-col {
+            margin-left: 0;
+        }
+    }
+
+
+    /**
+    * .g--equalHeight – Equal Height Child Elements
+    */
+    .g--equalHeight {
+        > .g-col {
+            display: flex;
+
+            & > * {
+                flex-basis: 100%;
+            }
+        }
+    }
+
+
+    /**
+    * Alignment
+    * Modifier classes to move our grid elements around
+    */
+    .g--alignTop        { align-items: flex-start; }
+    .g--alignBottom     { align-items: flex-end; }
+    .g--alignSelfBottom { align-self: flex-end; }
+    .g--alignRight      { justify-content: flex-end; }
+    .g--alignCenter     { justify-content: center; }
+    .g--alignCenter--v  { align-items: center; }
+
+
+    /**
+    * Centering
+    * Centers an individual column, rather than the entire grid
+    */
+    .g-col--centered {
+        margin: 0 auto;
+    }
+
+    /**
+    * Shrinking Content
+    * Shrink a .g-col down to only the space it needs (flexbox only)
+    *
+    * Effectively just changes it’s values back to the default flex properties
+    */
+    .g-col--shrink {
+        flex: 0 1 auto;
+    }
+
+
+    /**
+    * Add fallbacks for non-flexbox supporting browsers (for example, IE8/9)
+    */
+    @if $use-legacy-grid {
+        .no-flexbox {
+            .g {
+                display: block !important; // need this for old Safari, as it thinks it understands flexbox but doesn’t really
+
+                // clearfix
+                &:after {
+                    content: '';
+                    display: table;
+                    clear: both;
+                }
+            }
+
+            .g-col {
+                float: left;
+                min-height: 1px;
+                clear: none;
+                box-sizing: border-box;
+            }
+
+            .g--stack .g-col {
+                width: 100%;
+            }
+
+            .g--equalHeight {
+                > .g-col {
+                    display: block; // again need to overide old safari thinking it knows flexbox, when it doesn’t really
+                }
+            }
+        }
+        //end .no-flexbox
+    }
+
+
+
+    /**
+    * Grid Span classes (for different breakpoints)
+    *
+    * Applied by using .g-spanx to .g-col elements, where x is the number of columns
+    */
+
+    @include ko-gridSpanHelper; // Default sizes
+
+    // Responsive sizes only generated if $responsive-grid-sizes == true
+    @if $responsive-grid-sizes {
+        //loop through our breakpoints
+        @each $name, $value in $breakpoints {
+            @include media('>=#{$value}') {
+                @include ko-gridSpanHelper($name);
+            }
+        }
+    }
+
+    @each $name, $value in $breakpoints {
+        .g--stack--#{$name} {
+            @include ko-grid-stack($name);
+        }
+    }
+
+}

--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -104,7 +104,7 @@
                 text-align: center;
             }
             .l-content-header--highlight {
-                color: $color-headings--highlight;
+                color: $color-content-brand;
             }
 
         .l-content-main {

--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -8,7 +8,7 @@
     */
 
     body {
-        background-color: $color-bg;
+        background-color: $color-background-default;
     }
 
     /*
@@ -113,7 +113,7 @@
 
     // Used for dividing pages or cards horizontally
     .l-divider {
-        border-bottom: 1px solid $color-border;
+        border-bottom: 1px solid $color-border-strong;
     }
 
     // utility that lets you align items side by side and vertically centered

--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -1,137 +1,142 @@
-/**
- * Global Layout Definitions & Helpers
- * ===================================
- */
+@mixin layout() {
+    /**
+    * Global Layout Definitions & Helpers
+    * =================================
+    *
+    * This is an optional component within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include layout();` into your SCSS dependencies file.
+    */
 
-body {
-    background-color: $color-bg;
-}
-
-/*
-* By default we want to give focus styling to all elements that are focusable.
-*/
-:focus {
-    @extend %u-elementFocus;
-}
-
-/*
-* Hide focus styles if they're not needed, for example, when an element receives focus via the mouse.
-*/
-:focus:not(:focus-visible) {
-    outline: 0;
-}
-
-/*
-* Show focus styles on keyboard focus.
-*/
-:focus-visible {
-    @extend %u-elementFocus;
-}
-
-/**
- * Default layout container
- */
-.l-container {
-    width: 100%;
-    max-width: #{$layout-max-width}px;
-    margin: 0 auto;
-    padding-left: #{$layout-margin}px;
-    padding-right: #{$layout-margin}px;
-
-    @include media('<mid') {
-        padding-left: #{$layout-margin--mid}px;
-        padding-right: #{$layout-margin--mid}px;
+    body {
+        background-color: $color-bg;
     }
 
-    @include media('<narrow') {
-        padding-left: #{$layout-margin--narrow}px;
-        padding-right: #{$layout-margin--narrow}px;
-    }
-}
-
-/**
- * Layout container for blocks that don't need padding on the sides
- */
-.l-innerContainer {
-    width: 100%;
-    max-width: #{$layout-max-width}px;
-    margin: 0 auto;
-}
-
-.l-innerContainer--verticalSpacing {
-    margin: spacing(x4) 0;
-
-    @include media('>=mid') {
-        margin: spacing(x5) auto spacing(x6);
+    /*
+    * By default we want to give focus styling to all elements that are focusable.
+    */
+    :focus {
+        @extend %u-elementFocus;
     }
 
-    @include media('>=wide') {
-        margin: spacing(x8) auto;
+    /*
+    * Hide focus styles if they're not needed, for example, when an element receives focus via the mouse.
+    */
+    :focus:not(:focus-visible) {
+        outline: 0;
     }
-}
 
-/**
- * Layout class for containers that contain content (such as T&cs and Privacy pages)
- */
-.l-content {
-    padding-top: spacing(x2);
-
-    @include media('>mid') {
-        padding-top: spacing(x4);
+    /*
+    * Show focus styles on keyboard focus.
+    */
+    :focus-visible {
+        @extend %u-elementFocus;
     }
-}
 
-    .l-content-header {
-        margin: 0 0 spacing(x2);
+    /**
+    * Default layout container
+    */
+    .l-container {
+        width: 100%;
+        max-width: #{$layout-max-width}px;
+        margin: 0 auto;
+        padding-left: #{$layout-margin}px;
+        padding-right: #{$layout-margin}px;
+
+        @include media('<mid') {
+            padding-left: #{$layout-margin--mid}px;
+            padding-right: #{$layout-margin--mid}px;
+        }
+
+        @include media('<narrow') {
+            padding-left: #{$layout-margin--narrow}px;
+            padding-right: #{$layout-margin--narrow}px;
+        }
+    }
+
+    /**
+    * Layout container for blocks that don't need padding on the sides
+    */
+    .l-innerContainer {
+        width: 100%;
+        max-width: #{$layout-max-width}px;
+        margin: 0 auto;
+    }
+
+    .l-innerContainer--verticalSpacing {
+        margin: spacing(x4) 0;
+
+        @include media('>=mid') {
+            margin: spacing(x5) auto spacing(x6);
+        }
+
+        @include media('>=wide') {
+            margin: spacing(x8) auto;
+        }
+    }
+
+    /**
+    * Layout class for containers that contain content (such as T&cs and Privacy pages)
+    */
+    .l-content {
+        padding-top: spacing(x2);
 
         @include media('>mid') {
-            margin: spacing(x2) 0 spacing(x4);
+            padding-top: spacing(x4);
         }
+    }
 
-        > h1 {
-            @include font-size(heading-xxl, true, narrow);
+        .l-content-header {
+            margin: 0 0 spacing(x2);
 
             @include media('>mid') {
-                @include font-size(heading-xxl);
+                margin: spacing(x2) 0 spacing(x4);
+            }
+
+            > h1 {
+                @include font-size(heading-xxl, true, narrow);
+
+                @include media('>mid') {
+                    @include font-size(heading-xxl);
+                }
             }
         }
-    }
-        .l-content-header--centred {
-            text-align: center;
+            .l-content-header--centred {
+                text-align: center;
+            }
+            .l-content-header--highlight {
+                color: $color-headings--highlight;
+            }
+
+        .l-content-main {
+            @extend %u-bordered;
         }
-        .l-content-header--highlight {
-            color: $color-headings--highlight;
-        }
 
-    .l-content-main {
-        @extend %u-bordered;
+    // Used for dividing pages or cards horizontally
+    .l-divider {
+        border-bottom: 1px solid $color-border;
     }
 
-// Used for dividing pages or cards horizontally
-.l-divider {
-    border-bottom: 1px solid $color-border;
-}
-
-// utility that lets you align items side by side and vertically centered
-%l-inlined,
-.l-inlined {
-    display: flex;
-    align-items: center;
-
-    .no-flexbox & {
-       display: inline-block;
-    }
-}
-
-    .l-inlined--top {
+    // utility that lets you align items side by side and vertically centered
+    %l-inlined,
+    .l-inlined {
         display: flex;
-        align-items: flex-start;
+        align-items: center;
+
+        .no-flexbox & {
+            display: inline-block;
+        }
     }
 
-// uses flexbox to centre align content both vertically and horizontally
-.l-centred, // British or US English spellings..
-.l-centered {
-    align-items: center;
-    display: flex;
-    justify-content: center;
+        .l-inlined--top {
+            display: flex;
+            align-items: flex-start;
+        }
+
+    // uses flexbox to centre align content both vertically and horizontally
+    .l-centred, // British or US English spellings..
+    .l-centered {
+        align-items: center;
+        display: flex;
+        justify-content: center;
+    }
 }

--- a/src/scss/base/_print.scss
+++ b/src/scss/base/_print.scss
@@ -1,71 +1,76 @@
-/**
- * Print styles
- * =================================
- */
+@mixin print() {
+    /**
+    * Print styles
+    * =================================
+    *
+    * This is an optional component within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include print();` into your SCSS dependencies file.
+    */
 
-@media print {
-    *,
-    *:before,
-    *:after,
-    *:first-letter {
-        background: transparent !important;
-        color: #000 !important; /* Black prints faster: http://www.sanbeiji.com/archives/953 */
-        box-shadow: none !important;
-        text-shadow: none !important;
-    }
-
-    a {
-        &:visited {
-            text-decoration: underline;
+    @media print {
+        *,
+        *:before,
+        *:after,
+        *:first-letter {
+            background: transparent !important;
+            color: #000 !important; /* Black prints faster: http://www.sanbeiji.com/archives/953 */
+            box-shadow: none !important;
+            text-shadow: none !important;
         }
 
-        &[href]:after {
-            content: ' (' attr(href) ')';
+        a {
+            &:visited {
+                text-decoration: underline;
+            }
+
+            &[href]:after {
+                content: ' (' attr(href) ')';
+            }
         }
-    }
 
-    abbr[title]:after {
-        content: ' (' attr(title) ')';
-    }
+        abbr[title]:after {
+            content: ' (' attr(title) ')';
+        }
 
-    /*
-     * Don't show links for images, or javascript/internal links
-     */
-    .ir a:after,
-    a[href^='javascript:']:after,
-    a[href^='#']:after {
-        content: '';
-    }
+        /*
+        * Don't show links for images, or javascript/internal links
+        */
+        .ir a:after,
+        a[href^='javascript:']:after,
+        a[href^='#']:after {
+            content: '';
+        }
 
-    pre,
-    blockquote {
-        border: 1px solid #999;
-        page-break-inside: avoid;
-    }
+        pre,
+        blockquote {
+            border: 1px solid #999;
+            page-break-inside: avoid;
+        }
 
-    thead {
-        display: table-header-group; /* h5bp.com/t */
-    }
+        thead {
+            display: table-header-group; /* h5bp.com/t */
+        }
 
-    tr,
-    img {
-        page-break-inside: avoid;
-    }
+        tr,
+        img {
+            page-break-inside: avoid;
+        }
 
-    img {
-        max-width: 100% !important;
-    }
+        img {
+            max-width: 100% !important;
+        }
 
-    @page {
-        margin: 0.5cm;
-    }
+        @page {
+            margin: 0.5cm;
+        }
 
-    p, h2, h3 {
-        orphans: 3;
-        widows: 3;
-    }
+        p, h2, h3 {
+            orphans: 3;
+            widows: 3;
+        }
 
-    h2, h3 {
-        page-break-after: avoid;
+        h2, h3 {
+            page-break-after: avoid;
+        }
     }
 }

--- a/src/scss/base/_reset.scss
+++ b/src/scss/base/_reset.scss
@@ -1,16 +1,21 @@
-/**
- * Just Eat Reset Styles
- * =================================
- * We use normalize.css for the bulk of our 'reset'
- * but anything else 'reset-y' lives in here
- */
+@mixin reset() {
+    /**
+    * Fozzie Reset Styles
+    * =================================
+    * We use normalize.css for the bulk of our 'reset'
+    * but anything else 'reset-y' lives in here
+    *
+    * This is an optional component within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include reset();` into your SCSS dependencies file.
+    */
 
-html {
-    box-sizing: border-box;
-}
+    html {
+        box-sizing: border-box;
+    }
 
-*,
-*:before,
-*:after {
-    box-sizing: inherit;
+    *,
+    *:before,
+    *:after {
+        box-sizing: inherit;
+    }
 }

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -194,7 +194,7 @@
     }
 
     mark {
-        background: $yellow--offWhite;
+        background: $color-yellow-10;
         padding: 2px 4px;
         border-radius: 3px;
     }
@@ -226,8 +226,7 @@
     hr {
         margin: ($baseline) 0;
         border: 0;
-        border-top: 1px solid $hr-color;
-        border-bottom: 1px solid $white;
+        border-top: 1px solid $color-divider-default;
     }
 
     // https://justmarkup.com/log/2015/07/dealing-with-long-words-in-css/

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -32,7 +32,7 @@
         font-family: $font-family-base;
         @include font-size(body-s);
         color: $color-text;
-        font-weight: $font-weight-base;
+        font-weight: $font-weight-regular;
 
         text-rendering: optimizelegibility;
         -webkit-font-smoothing: antialiased;

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -31,7 +31,7 @@
     body {
         font-family: $font-family-base;
         @include font-size(body-s);
-        color: $color-text;
+        color: $color-content-default;
         font-weight: $font-weight-regular;
 
         text-rendering: optimizelegibility;
@@ -62,7 +62,7 @@
     .gamma,
     .delta,
     .epsilon {
-        color: $color-headings;
+        color: $color-content-default;
         margin: 0;
         margin-bottom: 0;
         font-family: $font-family-base;

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -1,234 +1,239 @@
-/**
- * Typography
- * =================================
- * - Base
- * - Paragraphs
- * - Headings
- * - Type sizes
- * - Misc
- * - Utilities
- *
- * Body font size, leadings etc have been set in _variables.scss
- *
- * Documentation:
- * TBC
- */
+@mixin typography() {
+    /**
+    * Typography
+    * =================================
+    * - Base
+    * - Paragraphs
+    * - Headings
+    * - Type sizes
+    * - Misc
+    * - Utilities
+    *
+    * Body font size, leadings etc have been set in _variables.scss
+    *
+    * This is an optional component within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include typography();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * TBC
+    */
 
 
-/**
- * Typography preloading styles
- */
+    /**
+    * Typography preloading styles
+    */
 
-html {
-    font-size: $font-size-base-px;
-    text-size-adjust: 100%;
-}
-
-body {
-    font-family: $font-family-base;
-    @include font-size(body-s);
-    color: $color-text;
-    font-weight: $font-weight-base;
-
-    text-rendering: optimizelegibility;
-    -webkit-font-smoothing: antialiased;
-    -moz-font-smoothing: antialiased;
-}
-
-/**
- * Paragraphs
- */
-p {
-    @include font-size(body-s);
-    margin-top: $baseline;
-    margin-bottom: 0;
-}
-
-/**
- * Headings
- */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-.alpha,
-.beta,
-.gamma,
-.delta,
-.epsilon {
-    color: $color-headings;
-    margin: 0;
-    margin-bottom: 0;
-    font-family: $font-family-base;
-    font-weight: $font-weight-headings;
-
-    small {
-        font-weight: normal;
-    }
-}
-
-// Use the helper classes to emulate styles for another element
-// For example: h3.h1 or h3.alpha
-h1,
-.alpha {
-    @include font-size(heading-xl, true, narrow);
-    margin-top: $baseline * 2;
-    margin-bottom: $baseline;
-
-    @include media('>mid') {
-        @include font-size(heading-xl);
+    html {
+        font-size: $font-size-base-px;
+        text-size-adjust: 100%;
     }
 
-    &:first-child {
-        margin-top: 0;
-    }
-}
-
-h2,
-.beta {
-    @include font-size(heading-m, true, narrow);
-
-    @include media('>mid') {
-        @include font-size(heading-m);
-    }
-}
-
-h3,
-.gamma,
-h4,
-.delta,
-h5,
-.epsilon {
-    @include font-size(heading-s);
-}
-
-h6,
-.zeta {
-    @include font-size(caption);
-}
-
-// Only give these headings a margin-top if they are after other elements
-* + h2,
-* + .beta {
-    margin-top: $baseline * 2;
-}
-
-* + h3,
-* + .gamma,
-* + h4,
-* + .delta {
-    margin-top: $baseline;
-}
-
-small {
-    font-size: 80%;
-}
-
-/**
- * Miscellaneous
- */
-
-// Emphasis
-strong,
-b {
-    font-weight: $font-weight-bold;
-}
-
-em,
-i {
-    font-style: italic;
-}
-
-// Abbreviations and acronyms
-abbr[title] {
-    border-bottom: 1px dotted #ddd;
-    cursor: help;
-}
-
-/**
- * Blockquotes
- */
-blockquote {
-    padding-left: 10px;
-    margin: $baseline;
-    border-left: 4px solid lighten(#000, 80%);
-
-    p {
-        margin-bottom: 0;
+    body {
+        font-family: $font-family-base;
         @include font-size(body-s);
-        font-weight: 300;
+        color: $color-text;
+        font-weight: $font-weight-base;
+
+        text-rendering: optimizelegibility;
+        -webkit-font-smoothing: antialiased;
+        -moz-font-smoothing: antialiased;
     }
 
-    small {
-        display: block;
-        color: lighten(#000, 70%);
+    /**
+    * Paragraphs
+    */
+    p {
+        @include font-size(body-s);
+        margin-top: $baseline;
+        margin-bottom: 0;
+    }
 
-        &:before {
-            content: '\2014 \00A0';
+    /**
+    * Headings
+    */
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    .alpha,
+    .beta,
+    .gamma,
+    .delta,
+    .epsilon {
+        color: $color-headings;
+        margin: 0;
+        margin-bottom: 0;
+        font-family: $font-family-base;
+        font-weight: $font-weight-headings;
+
+        small {
+            font-weight: normal;
         }
     }
-}
 
-// Quotes
-q,
-blockquote {
-    &:before,
-    &:after {
-        content: '';
+    // Use the helper classes to emulate styles for another element
+    // For example: h3.h1 or h3.alpha
+    h1,
+    .alpha {
+        @include font-size(heading-xl, true, narrow);
+        margin-top: $baseline * 2;
+        margin-bottom: $baseline;
+
+        @include media('>mid') {
+            @include font-size(heading-xl);
+        }
+
+        &:first-child {
+            margin-top: 0;
+        }
     }
-}
 
-cite {
-    font-style: normal;
-}
+    h2,
+    .beta {
+        @include font-size(heading-m, true, narrow);
 
-// Addresses styling not present in S5, Chrome
-dfn {
-    font-style: italic;
-}
+        @include media('>mid') {
+            @include font-size(heading-m);
+        }
+    }
 
-mark {
-    background: $yellow--offWhite;
-    padding: 2px 4px;
-    border-radius: 3px;
-}
+    h3,
+    .gamma,
+    h4,
+    .delta,
+    h5,
+    .epsilon {
+        @include font-size(heading-s);
+    }
 
-address {
-    font-style: normal;
-    margin-top: $baseline;
-    margin-bottom: 0;
-}
+    h6,
+    .zeta {
+        @include font-size(caption);
+    }
 
-// Prevents sub and sup affecting line-height in all browsers
-// gist.github.com/413930
-sub,
-sup {
-    font-size: 75%;
-    line-height: 0;
-    position: relative;
-    vertical-align: baseline;
-}
+    // Only give these headings a margin-top if they are after other elements
+    * + h2,
+    * + .beta {
+        margin-top: $baseline * 2;
+    }
 
-sup { top: -0.5em; }
-sub { bottom: -0.25em; }
-samp { font-family: $font-family-mono; }
+    * + h3,
+    * + .gamma,
+    * + h4,
+    * + .delta {
+        margin-top: $baseline;
+    }
 
-//
-// @include ko-text-selection($color-selection, $color-selection-bg);
+    small {
+        font-size: 80%;
+    }
 
-// Horizontal rules
-hr {
-    margin: ($baseline) 0;
-    border: 0;
-    border-top: 1px solid $hr-color;
-    border-bottom: 1px solid $white;
-}
+    /**
+    * Miscellaneous
+    */
 
-// https://justmarkup.com/log/2015/07/dealing-with-long-words-in-css/
-.hyphenate {
-    overflow-wrap: break-word;
-    word-wrap: break-word;
-    hyphens: auto;
+    // Emphasis
+    strong,
+    b {
+        font-weight: $font-weight-bold;
+    }
+
+    em,
+    i {
+        font-style: italic;
+    }
+
+    // Abbreviations and acronyms
+    abbr[title] {
+        border-bottom: 1px dotted #ddd;
+        cursor: help;
+    }
+
+    /**
+    * Blockquotes
+    */
+    blockquote {
+        padding-left: 10px;
+        margin: $baseline;
+        border-left: 4px solid lighten(#000, 80%);
+
+        p {
+            margin-bottom: 0;
+            @include font-size(body-s);
+            font-weight: 300;
+        }
+
+        small {
+            display: block;
+            color: lighten(#000, 70%);
+
+            &:before {
+                content: '\2014 \00A0';
+            }
+        }
+    }
+
+    // Quotes
+    q,
+    blockquote {
+        &:before,
+        &:after {
+            content: '';
+        }
+    }
+
+    cite {
+        font-style: normal;
+    }
+
+    // Addresses styling not present in S5, Chrome
+    dfn {
+        font-style: italic;
+    }
+
+    mark {
+        background: $yellow--offWhite;
+        padding: 2px 4px;
+        border-radius: 3px;
+    }
+
+    address {
+        font-style: normal;
+        margin-top: $baseline;
+        margin-bottom: 0;
+    }
+
+    // Prevents sub and sup affecting line-height in all browsers
+    // gist.github.com/413930
+    sub,
+    sup {
+        font-size: 75%;
+        line-height: 0;
+        position: relative;
+        vertical-align: baseline;
+    }
+
+    sup { top: -0.5em; }
+    sub { bottom: -0.25em; }
+    samp { font-family: $font-family-mono; }
+
+    //
+    // @include ko-text-selection($color-selection, $color-selection-bg);
+
+    // Horizontal rules
+    hr {
+        margin: ($baseline) 0;
+        border: 0;
+        border-top: 1px solid $hr-color;
+        border-bottom: 1px solid $white;
+    }
+
+    // https://justmarkup.com/log/2015/07/dealing-with-long-words-in-css/
+    .hyphenate {
+        overflow-wrap: break-word;
+        word-wrap: break-word;
+        hyphens: auto;
+    }
 }

--- a/src/scss/components/_alerts.scss
+++ b/src/scss/components/_alerts.scss
@@ -38,14 +38,14 @@
     // Generate contextual modifier classes for colorizing the alert.
 
     .c-alert--success {
-        @include alert-variant($color-bg--accept, $color-text--success);
+        @include alert-variant($color-bg--accept, $color-content-positive);
     }
 
     .c-alert--warning {
-        @include alert-variant($color-bg--notification, $color-text--warning);
+        @include alert-variant($color-bg--notification, $color-content-brand-strong);
     }
 
     .c-alert--danger {
-        @include alert-variant($color-bg--error, $color-text--danger);
+        @include alert-variant($color-bg--error, $color-content-error);
     }
 }

--- a/src/scss/components/_alerts.scss
+++ b/src/scss/components/_alerts.scss
@@ -1,46 +1,51 @@
-/**
- * Components > Alert
- * =================================
- * Messages that appear on the screen to highlight a state (usually with associated text)
- *
- * Example: Most form pages or wherever a message is fed back to the user
- *
- * Documentation:
- * TBC
- */
+@mixin alerts() {
+    /**
+    * Components > Alert
+    * =================================
+    * Messages that appear on the screen to highlight a state (usually with associated text)
+    *
+    * Example: Most form pages or wherever a message is fed back to the user
+    *
+    * This is an optional component within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include alerts();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * TBC
+    */
 
-$alert-border-radius: 2px;
+    $alert-border-radius: 2px;
 
-// Base styles
-// -------------------------
+    // Base styles
+    // -------------------------
 
-.c-alert {
-    padding: spacing();
-    margin-top: spacing(x2);
-    border: 1px solid transparent;
-    border-radius: $alert-border-radius;
-
-    &:first-child {
-        margin-top: 0;
-    }
-
-    & + * {
+    .c-alert {
+        padding: spacing();
         margin-top: spacing(x2);
+        border: 1px solid transparent;
+        border-radius: $alert-border-radius;
+
+        &:first-child {
+            margin-top: 0;
+        }
+
+        & + * {
+            margin-top: spacing(x2);
+        }
     }
-}
 
-// Alternate styles
-//
-// Generate contextual modifier classes for colorizing the alert.
+    // Alternate styles
+    //
+    // Generate contextual modifier classes for colorizing the alert.
 
-.c-alert--success {
-    @include alert-variant($color-bg--accept, $color-text--success);
-}
+    .c-alert--success {
+        @include alert-variant($color-bg--accept, $color-text--success);
+    }
 
-.c-alert--warning {
-    @include alert-variant($color-bg--notification, $color-text--warning);
-}
+    .c-alert--warning {
+        @include alert-variant($color-bg--notification, $color-text--warning);
+    }
 
-.c-alert--danger {
-    @include alert-variant($color-bg--error, $color-text--danger);
+    .c-alert--danger {
+        @include alert-variant($color-bg--error, $color-text--danger);
+    }
 }

--- a/src/scss/components/_alerts.scss
+++ b/src/scss/components/_alerts.scss
@@ -38,14 +38,14 @@
     // Generate contextual modifier classes for colorizing the alert.
 
     .c-alert--success {
-        @include alert-variant($color-bg--accept, $color-content-positive);
+        @include alert-variant($color-support-positive-02, $color-content-positive);
     }
 
     .c-alert--warning {
-        @include alert-variant($color-bg--notification, $color-content-brand-strong);
+        @include alert-variant($color-support-warning-02, $color-content-brand-strong);
     }
 
     .c-alert--danger {
-        @include alert-variant($color-bg--error, $color-content-error);
+        @include alert-variant($color-support-error-02, $color-content-error);
     }
 }

--- a/src/scss/components/_breadcrumbs.scss
+++ b/src/scss/components/_breadcrumbs.scss
@@ -1,132 +1,137 @@
-/**
- * Components > Breadcrumb
- * =================================
- * Used for website navigation breadcrumbs
- *
- * Documentation:
- * https://fozzie.just-eat.com/styleguide/ui-components/breadcrumbs
- */
+@mixin breadcrumbs() {
+    /**
+    * Components > Breadcrumb
+    * =================================
+    * Used for website navigation breadcrumbs
+    *
+    * This is an optional component within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include breadcrumbs();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * https://fozzie.just-eat.com/styleguide/ui-components/breadcrumbs
+    */
 
-$breadcrumb-font-weight: $font-weight-bold;
-$breadcrumb--compact-background: rgba($black, 0.2);
+    $breadcrumb-font-weight: $font-weight-bold;
+    $breadcrumb--compact-background: rgba($black, 0.2);
 
-.c-breadcrumb {
-    width: 100%;
-    line-height: 2.5;
-    @include media('>=mid') {
-        @include font-size(body-l, false);
+    .c-breadcrumb {
+        width: 100%;
+        line-height: 2.5;
+        @include media('>=mid') {
+            @include font-size(body-l, false);
+        }
     }
-}
-
-.c-breadcrumb-item {
-    float: left;
-    color: $grey--dark;
-    svg {
-        fill: $black;
-    }
-}
-
-.c-breadcrumb-item--home {
-    padding-left: 0;
-}
-
-.c-breadcrumb-item-link {
-    text-decoration: none;
-    color: $grey--darkest;
-    font-weight: $breadcrumb-font-weight;
-
-    &:hover {
-        text-decoration: underline;
-        color: $grey--dark;
-    }
-}
-
-.c-breadcrumb-item-icon {
-    margin: 0 spacing(base);
-}
-
-.c-breadcrumb--transparent {
-    background-color: transparent;
 
     .c-breadcrumb-item {
-        color: $white;
+        float: left;
+        color: $grey--dark;
         svg {
-            fill: $white;
+            fill: $black;
         }
+    }
+
+    .c-breadcrumb-item--home {
+        padding-left: 0;
     }
 
     .c-breadcrumb-item-link {
-        color: $white;
-    }
-}
+        text-decoration: none;
+        color: $grey--darkest;
+        font-weight: $breadcrumb-font-weight;
 
-.c-breadcrumb--compact {
-    @include media('<mid') {
-        .c-breadcrumb-item {
-            display: none;
+        &:hover {
+            text-decoration: underline;
+            color: $grey--dark;
         }
-        // only show previous page's link
-        .c-breadcrumb-item:nth-last-child(2) {
-            display: list-item;
-            background-color: $breadcrumb--compact-background;
-            border-radius: $baseline;
-            line-height: 2;
-            padding-right: $baseline;
+    }
 
-            .c-breadcrumb-item-icon {
-                float: left;
+    .c-breadcrumb-item-icon {
+        margin: 0 spacing(base);
+    }
 
-                svg {
-                    transform: translateY(-2px) rotate(90deg);
-                }
+    .c-breadcrumb--transparent {
+        background-color: transparent;
+
+        .c-breadcrumb-item {
+            color: $white;
+            svg {
+                fill: $white;
             }
         }
-    }
-}
 
-/**
- * c-breadcrumb--pill
- * =================================
- * Adds a black transparent background with rounded corners to the breadcrumb list.
- * On smaller screens the icon and text are re-ordered.
- */
-
-.c-breadcrumb--pill {
-    background-color: rgba(0, 0, 0, 0.5);
-    border-radius: 12px;
-    line-height: normal;
-    display: inline-block;
-    width: auto;
-    padding-right: 12px;
-
-    a {
-        &:hover,
-        &:focus {
+        .c-breadcrumb-item-link {
             color: $white;
         }
     }
 
-    @include media('>=mid') {
-        padding: 0 12px;
-    }
-
-    .c-breadcrumb-item {
-        @include media('<=mid') {
-            display: flex;
-            align-items: center;
-
-            a {
-                order: 2;
+    .c-breadcrumb--compact {
+        @include media('<mid') {
+            .c-breadcrumb-item {
+                display: none;
             }
+            // only show previous page's link
+            .c-breadcrumb-item:nth-last-child(2) {
+                display: list-item;
+                background-color: $breadcrumb--compact-background;
+                border-radius: $baseline;
+                line-height: 2;
+                padding-right: $baseline;
 
-            svg {
-                transform: rotate(90deg);
+                .c-breadcrumb-item-icon {
+                    float: left;
+
+                    svg {
+                        transform: translateY(-2px) rotate(90deg);
+                    }
+                }
             }
         }
     }
 
-    .c-breadcrumb-item,
-    .c-breadcrumb-item-link {
-        color: $white;
+    /**
+    * c-breadcrumb--pill
+    * =================================
+    * Adds a black transparent background with rounded corners to the breadcrumb list.
+    * On smaller screens the icon and text are re-ordered.
+    */
+
+    .c-breadcrumb--pill {
+        background-color: rgba(0, 0, 0, 0.5);
+        border-radius: 12px;
+        line-height: normal;
+        display: inline-block;
+        width: auto;
+        padding-right: 12px;
+
+        a {
+            &:hover,
+            &:focus {
+                color: $white;
+            }
+        }
+
+        @include media('>=mid') {
+            padding: 0 12px;
+        }
+
+        .c-breadcrumb-item {
+            @include media('<=mid') {
+                display: flex;
+                align-items: center;
+
+                a {
+                    order: 2;
+                }
+
+                svg {
+                    transform: rotate(90deg);
+                }
+            }
+        }
+
+        .c-breadcrumb-item,
+        .c-breadcrumb-item-link {
+            color: $white;
+        }
     }
 }

--- a/src/scss/components/_breadcrumbs.scss
+++ b/src/scss/components/_breadcrumbs.scss
@@ -11,8 +11,19 @@
     * https://fozzie.just-eat.com/styleguide/ui-components/breadcrumbs
     */
 
-    $breadcrumb-font-weight: $font-weight-bold;
-    $breadcrumb--compact-background: rgba($black, 0.2);
+    $breadcrumb-text-color                   : $color-grey-50;
+    $breadcrumb-text-weight                  : $font-weight-bold;
+    $breadcrumb-link-color                   : $color-grey;
+    $breadcrumb-link-color--hover            : $color-grey-50;
+    $breadcrumb-icon-fillColor               : $color-black;
+    $breadcrumb--compact-background          : rgba($color-black, 0.2);
+
+    $breadcrumb--transparent-text-color      : $color-white;
+    $breadcrumb--transparent-icon-fillColor  : $color-white;
+    $breadcrumb--transparent-link-color      : $color-white;
+
+    $breadcrumb--pill-text-color             : $color-white;
+    $breadcrumb--pill-link-color--hover      : $color-white;
 
     .c-breadcrumb {
         width: 100%;
@@ -24,9 +35,10 @@
 
     .c-breadcrumb-item {
         float: left;
-        color: $grey--dark;
+        color: $breadcrumb-text-color;
+
         svg {
-            fill: $black;
+            fill: $breadcrumb-icon-fillColor;
         }
     }
 
@@ -36,12 +48,12 @@
 
     .c-breadcrumb-item-link {
         text-decoration: none;
-        color: $grey--darkest;
-        font-weight: $breadcrumb-font-weight;
+        color: $breadcrumb-link-color;
+        font-weight: $breadcrumb-text-weight;
 
         &:hover {
             text-decoration: underline;
-            color: $grey--dark;
+            color: $breadcrumb-link-color--hover;
         }
     }
 
@@ -53,14 +65,15 @@
         background-color: transparent;
 
         .c-breadcrumb-item {
-            color: $white;
+            color: $breadcrumb--transparent-text-color;
+
             svg {
-                fill: $white;
+                fill: $breadcrumb--transparent-icon-fillColor;
             }
         }
 
         .c-breadcrumb-item-link {
-            color: $white;
+            color: $breadcrumb--transparent-link-color;
         }
     }
 
@@ -96,7 +109,7 @@
     */
 
     .c-breadcrumb--pill {
-        background-color: rgba(0, 0, 0, 0.5);
+        background-color: rgba($color-black, 0.5);
         border-radius: 12px;
         line-height: normal;
         display: inline-block;
@@ -106,7 +119,7 @@
         a {
             &:hover,
             &:focus {
-                color: $white;
+                color: $breadcrumb--pill-link-color--hover;
             }
         }
 
@@ -131,7 +144,7 @@
 
         .c-breadcrumb-item,
         .c-breadcrumb-item-link {
-            color: $white;
+            color: $breadcrumb--pill-text-color;
         }
     }
 }

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -11,8 +11,8 @@
     * https://fozzie.just-eat.com/styleguide/ui-components/cards
     */
 
-    $card-bgColor--active                           : $white;
-    $card-bgColor--disabled                         : $grey--lighter;
+    $card-bgColor--active                           : $color-white;
+    $card-bgColor--disabled                         : $color-grey-20;
     $card-tooltip-width                             : 10px;
     $card-arrow-bottom-position                     : 0;
     $card-padding                                   : spacing(x2);
@@ -20,7 +20,7 @@
     $card-borderColor                               : $color-border;
     $card-section-margin                            : spacing(x4);
     $card-section-margin--large                     : spacing(x8);
-    $card-section-highlight-backgroundColor         : $orange--offWhite;
+    $card-section-highlight-backgroundColor         : $color-orange-10;
     $card-section-highlight-color                   : $color-text;
     $card-section-collapsible-paddingRight          : 60px;
     $card-section-collapsed-height                  : 40px;

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -1,259 +1,264 @@
-/**
- * Components > Card
- * =================================
- * Used for content listing cards.
- *
- * Documentation:
- * https://fozzie.just-eat.com/styleguide/ui-components/cards
- */
+@mixin cards() {
+    /**
+    * Components > Card
+    * =================================
+    * Used for content listing cards.
+    *
+    * This is an optional component within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include cards();` into your SCSS dependencies file.
 
-$card-bgColor--active                           : $white;
-$card-bgColor--disabled                         : $grey--lighter;
-$card-tooltip-width                             : 10px;
-$card-arrow-bottom-position                     : 0;
-$card-padding                                   : spacing(x2);
-$card-radius                                    : 4px;
-$card-borderColor                               : $color-border;
-$card-section-margin                            : spacing(x4);
-$card-section-margin--large                     : spacing(x8);
-$card-section-highlight-backgroundColor         : $orange--offWhite;
-$card-section-highlight-color                   : $color-text;
-$card-section-collapsible-paddingRight          : 60px;
-$card-section-collapsed-height                  : 40px;
+    * Documentation:
+    * https://fozzie.just-eat.com/styleguide/ui-components/cards
+    */
 
-
-.c-card {
-    background-color: $card-bgColor--active;
-    display: block;
-    margin-bottom: spacing();
-    padding: $card-padding;
-    position: relative;
-
-    @include media('>=mid') {
-        margin-bottom: 0;
-    }
-}
-
-    //
-    // Spacing Modifiers
-    // ==========================================================================
-
-    .c-card--noPad {
-        padding: 0;
-    }
-
-    .c-card--noPadVertical {
-        padding-top: 0;
-        padding-bottom: 0;
-    }
-
-    .c-card--noPadBottom {
-        padding-bottom: 0;
-    }
-
-        .c-card--noPadBottom--aboveMid {
-            @include media('>=mid') {
-                padding-bottom: 0;
-            }
-        }
-
-        .c-card--padBottom--belowMid {
-            @include media('<mid') {
-                padding-bottom: spacing(x4);
-            }
-        }
-
-    // stretches the card contents outside of their container
-    .c-card--negativeSpacing {
-        margin-left: -#{spacing(x2)};
-        margin-right: -#{spacing(x2)};
-        padding-left: spacing(x2);
-        padding-right: spacing(x2);
-    }
-
-        .c-card--negativeSpacing--belowMid {
-            @include media('<mid') {
-                margin-left: -#{spacing(x2)};
-                margin-right: -#{spacing(x2)};
-            }
-        }
-
-        .c-card--negativeSpacing--belowMid--small {
-            @include media('<mid') {
-                margin-left: -#{spacing()};
-                margin-right: -#{spacing()};
-            }
-        }
+    $card-bgColor--active                           : $white;
+    $card-bgColor--disabled                         : $grey--lighter;
+    $card-tooltip-width                             : 10px;
+    $card-arrow-bottom-position                     : 0;
+    $card-padding                                   : spacing(x2);
+    $card-radius                                    : 4px;
+    $card-borderColor                               : $color-border;
+    $card-section-margin                            : spacing(x4);
+    $card-section-margin--large                     : spacing(x8);
+    $card-section-highlight-backgroundColor         : $orange--offWhite;
+    $card-section-highlight-color                   : $color-text;
+    $card-section-collapsible-paddingRight          : 60px;
+    $card-section-collapsed-height                  : 40px;
 
 
-    //
-    // Outline Modifiers
-    // ==========================================================================
-
-    .c-card--rounded {
-        border-radius: $card-radius;
-    }
-
-    .c-card--outline {
-        border: solid 1px $card-borderColor;
-    }
-
-        .c-card--outline--aboveMid {
-            @include media('<mid') {
-                border: none;
-                border-radius: 0;
-            }
-        }
-
-        .c-card--outlineTop--belowMid {
-            @include media('<mid') {
-                border-top: solid 1px $card-borderColor;
-            }
-        }
-
-    //
-    // Other Modifiers
-    // ==========================================================================
-
-    .c-card--disabled {
-        background: $card-bgColor--disabled;
-    }
-
-    .c-card--noBgColor {
-        background-color: transparent;
-    }
-
-    // sets all link styles to behave as if they were standard text
-    .c-card--normaliseLinks {
-        text-decoration: none;
-
-        &:hover,
-        &:active,
-        &:focus {
-            color: inherit;
-        }
-    }
-
-    //
-    // Child Elements
-    // ==========================================================================
-
-    // creates a section which is separated off by a border on larger screens
-    .c-card-section {
-        margin-left: -#{spacing(x2)};
-        padding-left: spacing(x2);
-        width: calc(100% + #{$card-section-margin});
+    .c-card {
+        background-color: $card-bgColor--active;
+        display: block;
+        margin-bottom: spacing();
+        padding: $card-padding;
+        position: relative;
 
         @include media('>=mid') {
-            border-top: solid 1px $card-borderColor;
-            margin-left: -#{spacing(x2)};
-            padding-left: spacing(x3);
+            margin-bottom: 0;
         }
     }
 
-        // used to create a section which has a highlighted background colour applied
-        .c-card-section--highlight {
-            background-color: $card-section-highlight-backgroundColor;
-            border-top: none;
-            color: $card-section-highlight-color;
-            margin-top: spacing(x2);
-            padding: spacing(x0.5) spacing();
+        //
+        // Spacing Modifiers
+        // ==========================================================================
 
-            + .c-card-section--highlight {
-                margin-top: 1px;
+        .c-card--noPad {
+            padding: 0;
+        }
 
-                &:last-of-type {
+        .c-card--noPadVertical {
+            padding-top: 0;
+            padding-bottom: 0;
+        }
+
+        .c-card--noPadBottom {
+            padding-bottom: 0;
+        }
+
+            .c-card--noPadBottom--aboveMid {
+                @include media('>=mid') {
+                    padding-bottom: 0;
+                }
+            }
+
+            .c-card--padBottom--belowMid {
+                @include media('<mid') {
+                    padding-bottom: spacing(x4);
+                }
+            }
+
+        // stretches the card contents outside of their container
+        .c-card--negativeSpacing {
+            margin-left: -#{spacing(x2)};
+            margin-right: -#{spacing(x2)};
+            padding-left: spacing(x2);
+            padding-right: spacing(x2);
+        }
+
+            .c-card--negativeSpacing--belowMid {
+                @include media('<mid') {
+                    margin-left: -#{spacing(x2)};
+                    margin-right: -#{spacing(x2)};
+                }
+            }
+
+            .c-card--negativeSpacing--belowMid--small {
+                @include media('<mid') {
+                    margin-left: -#{spacing()};
+                    margin-right: -#{spacing()};
+                }
+            }
+
+
+        //
+        // Outline Modifiers
+        // ==========================================================================
+
+        .c-card--rounded {
+            border-radius: $card-radius;
+        }
+
+        .c-card--outline {
+            border: solid 1px $card-borderColor;
+        }
+
+            .c-card--outline--aboveMid {
+                @include media('<mid') {
+                    border: none;
+                    border-radius: 0;
+                }
+            }
+
+            .c-card--outlineTop--belowMid {
+                @include media('<mid') {
+                    border-top: solid 1px $card-borderColor;
+                }
+            }
+
+        //
+        // Other Modifiers
+        // ==========================================================================
+
+        .c-card--disabled {
+            background: $card-bgColor--disabled;
+        }
+
+        .c-card--noBgColor {
+            background-color: transparent;
+        }
+
+        // sets all link styles to behave as if they were standard text
+        .c-card--normaliseLinks {
+            text-decoration: none;
+
+            &:hover,
+            &:active,
+            &:focus {
+                color: inherit;
+            }
+        }
+
+        //
+        // Child Elements
+        // ==========================================================================
+
+        // creates a section which is separated off by a border on larger screens
+        .c-card-section {
+            margin-left: -#{spacing(x2)};
+            padding-left: spacing(x2);
+            width: calc(100% + #{$card-section-margin});
+
+            @include media('>=mid') {
+                border-top: solid 1px $card-borderColor;
+                margin-left: -#{spacing(x2)};
+                padding-left: spacing(x3);
+            }
+        }
+
+            // used to create a section which has a highlighted background colour applied
+            .c-card-section--highlight {
+                background-color: $card-section-highlight-backgroundColor;
+                border-top: none;
+                color: $card-section-highlight-color;
+                margin-top: spacing(x2);
+                padding: spacing(x0.5) spacing();
+
+                + .c-card-section--highlight {
+                    margin-top: 1px;
+
+                    &:last-of-type {
+                        border-bottom-right-radius: $card-radius;
+                        border-bottom-left-radius: $card-radius;
+                    }
+                }
+
+                &.is-last {
                     border-bottom-right-radius: $card-radius;
                     border-bottom-left-radius: $card-radius;
                 }
             }
 
-            &.is-last {
-                border-bottom-right-radius: $card-radius;
-                border-bottom-left-radius: $card-radius;
-            }
-        }
-
-        .c-card-section--collapsible {
-            overflow: hidden;
-            padding-bottom: spacing(x2);
-            padding-right: $card-section-collapsible-paddingRight;
-            position: relative;
-            user-select: none;
-
-            @include media('>=mid') {
-                padding-bottom: 0;
+            .c-card-section--collapsible {
+                overflow: hidden;
+                padding-bottom: spacing(x2);
                 padding-right: $card-section-collapsible-paddingRight;
+                position: relative;
+                user-select: none;
 
-                &.c-card-section {
-                    margin-bottom: spacing(x2);
+                @include media('>=mid') {
+                    padding-bottom: 0;
+                    padding-right: $card-section-collapsible-paddingRight;
 
-                    &.has-noSpacing {
-                        margin-bottom: 0;
+                    &.c-card-section {
+                        margin-bottom: spacing(x2);
+
+                        &.has-noSpacing {
+                            margin-bottom: 0;
+                        }
+                    }
+                }
+
+                &:hover {
+                    cursor: pointer;
+                }
+            }
+
+            .c-card-section--collapsible--noPad {
+                margin-left: -#{spacing(x4)};
+                padding: 0 $card-section-collapsible-paddingRight 0 spacing(x2);
+                width: calc(100% + #{$card-section-margin--large});
+
+                @include media('>=mid') {
+                    margin-left: -#{spacing(x2)};
+                    padding: 0 $card-section-collapsible-paddingRight 0 spacing(x3);
+                    width: calc(100% + #{$card-section-margin});
+                }
+            }
+
+            .c-card-section--collapsed {
+                @include media('<mid') {
+                    height: $card-section-collapsed-height;
+                }
+
+                p {
+                    @include truncate();
+
+                    &:not(:first-of-type) {
+                        display: none;
                     }
                 }
             }
 
-            &:hover {
-                cursor: pointer;
-            }
-        }
-
-        .c-card-section--collapsible--noPad {
-            margin-left: -#{spacing(x4)};
-            padding: 0 $card-section-collapsible-paddingRight 0 spacing(x2);
-            width: calc(100% + #{$card-section-margin--large});
-
-            @include media('>=mid') {
-                margin-left: -#{spacing(x2)};
-                padding: 0 $card-section-collapsible-paddingRight 0 spacing(x3);
-                width: calc(100% + #{$card-section-margin});
-            }
-        }
-
-        .c-card-section--collapsed {
-            @include media('<mid') {
-                height: $card-section-collapsed-height;
-            }
-
-            p {
-                @include truncate();
-
-                &:not(:first-of-type) {
-                    display: none;
-                }
-            }
-        }
-
-        .c-card-section-indicator {
-            height: 6px;
-            display: none;
-            position: absolute;
-            right: spacing(x2);
-            top: 22px;
-            transform: rotate(180deg);
-            transition: transform 0.4s;
-            width: 10px;
-
-            @include media('>=mid') {
-                height: 8px;
-                right: spacing(x3);
-                width: 14px;
-            }
-
-            .c-card-section--collapsible & {
-                display: block;
-            }
-
-            .c-card-section--collapsed & {
-                transform: rotate(0);
-            }
-
-            .c-card-section--collapsible--noPad & {
-                right: 21px;
+            .c-card-section-indicator {
+                height: 6px;
+                display: none;
+                position: absolute;
+                right: spacing(x2);
+                top: 22px;
+                transform: rotate(180deg);
+                transition: transform 0.4s;
+                width: 10px;
 
                 @include media('>=mid') {
+                    height: 8px;
                     right: spacing(x3);
+                    width: 14px;
+                }
+
+                .c-card-section--collapsible & {
+                    display: block;
+                }
+
+                .c-card-section--collapsed & {
+                    transform: rotate(0);
+                }
+
+                .c-card-section--collapsible--noPad & {
+                    right: 21px;
+
+                    @include media('>=mid') {
+                        right: spacing(x3);
+                    }
                 }
             }
-        }
+}

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -17,11 +17,11 @@
     $card-arrow-bottom-position                     : 0;
     $card-padding                                   : spacing(x2);
     $card-radius                                    : 4px;
-    $card-borderColor                               : $color-border;
+    $card-borderColor                               : $color-border-strong;
     $card-section-margin                            : spacing(x4);
     $card-section-margin--large                     : spacing(x8);
     $card-section-highlight-backgroundColor         : $color-orange-10;
-    $card-section-highlight-color                   : $color-text;
+    $card-section-highlight-color                   : $color-content-default;
     $card-section-collapsible-paddingRight          : 60px;
     $card-section-collapsed-height                  : 40px;
 

--- a/src/scss/components/_media-element.scss
+++ b/src/scss/components/_media-element.scss
@@ -1,173 +1,177 @@
-/**
- * Components > Media element
- * ===================================
- * A common pattern that sees an image followed by a block of information.
- *
- * Example: SERP – Restaurant logos
- *
- * Documentation:
- * https://fozzie.just-eat.com/styleguide/ui-components/mediaElement
- */
+@mixin mediaElement() {
+    /**
+    * Components > Media element
+    * ===================================
+    * A common pattern that sees an image followed by a block of information.
+    *
+    * Example: SERP – Restaurant logos
+    * This is an optional component within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include mediaElement();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * https://fozzie.just-eat.com/styleguide/ui-components/mediaElement
+    */
 
-$mediaElement-img-width         : 50px;
-$mediaElement-img-width--mid    : 78px;
-$mediaElement-img-width--wide   : 67px;
-$mediaElement-img-borderRadius  : 2px;
-$mediaElement-infoLinkColor     : $blue;
-$mediaElement-fontSize          : body-l;
-$mediaElement-spacing           : spacing(x2);
+    $mediaElement-img-width         : 50px;
+    $mediaElement-img-width--mid    : 78px;
+    $mediaElement-img-width--wide   : 67px;
+    $mediaElement-img-borderRadius  : 2px;
+    $mediaElement-infoLinkColor     : $blue;
+    $mediaElement-fontSize          : body-l;
+    $mediaElement-spacing           : spacing(x2);
 
 
-// mediaElement module
-// Usually consists of having an image to the left and content to the right
-.c-mediaElement {
-    display: flex; //defaults to row
-    align-items: flex-start;
-    width: 100%;
+    // mediaElement module
+    // Usually consists of having an image to the left and content to the right
+    .c-mediaElement {
+        display: flex; //defaults to row
+        align-items: flex-start;
+        width: 100%;
 
-    & > :not(:last-child) {
-        @include media('>=mid') {
-            margin-right: spacing(base);
+        & > :not(:last-child) {
+            @include media('>=mid') {
+                margin-right: spacing(base);
+            }
         }
     }
-}
 
-// stacks the elements (across all viewports)
-.c-mediaElement--fullstack {
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-}
-
-// stacks the elements (only on narrow)
-.c-mediaElement--stack {
-    @include media('<mid') {
+    // stacks the elements (across all viewports)
+    .c-mediaElement--fullstack {
         flex-direction: column;
         align-items: center;
-    }
-}
-
-    .c-mediaElement-img {
-        line-height: 0;
-        margin-right: 5%;
-
-        &,
-        & > img {
-            width: $mediaElement-img-width;
-
-            @include media('>narrow') {
-                width: $mediaElement-img-width--mid;
-            }
-
-            @include media('>=wide') {
-                width: $mediaElement-img-width--wide;
-            }
-        }
-
-        // make sure we cut off the corners of the image and the container
-        &,
-        & > img {
-            border-radius: 3px;
-        }
-
-        // center the img when stacked
-        .c-mediaElement--fullstack & {
-            margin-right: 0;
-            flex-basis: auto;
-        }
-
-        .c-mediaElement--stack & {
-            flex-basis: auto;
-
-            @include media('<mid') {
-                margin-right: 0;
-                flex-grow: 1;
-            }
-
-            @include media('>=mid') {
-                margin-top: spacing(base) / 4;
-            }
-
-            @include media('>=wide') {
-                margin-top: 0;
-            }
-        }
+        justify-content: center;
     }
 
-    // apply an outline to the mediaElement img
-    .c-mediaElement-img--outlined {
-        border: solid 1px $color-border;
-        border-radius: $mediaElement-img-borderRadius;
-    }
-
-    .c-mediaElement-img--small {
-        max-width: 70px;
-        max-height: 70px;
-    }
-
-    // positions the image over the top edge of the media element
-    .c-mediaElement-img--negativeTop {
-        margin-top: 0;
-        position: absolute;
-        top: -24px;
-
-        @include media('>=narrow') {
-            top: -40px;
-        }
-    }
-
-    .c-mediaElement-heading {
-        margin: spacing(x6) 0 spacing(x2);
-    }
-
-    .c-mediaElement-content {
-        flex-basis: 0;
-        flex-grow: 1;
-
-        .c-mediaElement--fullstack & {
-            flex: auto;
-            margin-top: spacing(x0.5);
-        }
-
-        .c-mediaElement--fullstack--negativeTop & {
-            flex: auto;
-            margin-top: -#{spacing(x2)};
-        }
-
-        // some content uses br for content shaping – get rid of it on mobile devices
-        & br {
-            @include media('<mid') {
-                display: none;
-            }
-        }
-    }
-
-    .c-mediaElement-text {
-        margin-top: 0;
-        @include font-size(caption, false);
-    }
-
-    .c-mediaElement-text--large {
-        @include font-size(heading-m, false); // TODO – this should be updated with a more semantic font alias, as it's not a heading
-        line-height: 1.2;
-    }
-
-    .c-mediaElement-infoLink {
-        @include font-size($mediaElement-fontSize);
-        align-items: center;
-        color: $mediaElement-infoLinkColor;
-        display: flex;
-        position: absolute;
-        right: $mediaElement-spacing;
-        text-decoration: none;
-        top: $mediaElement-spacing;
-
+    // stacks the elements (only on narrow)
+    .c-mediaElement--stack {
         @include media('<mid') {
-            right: spacing(x2);
-            top: spacing(x2);
-        }
-
-        &:hover {
-            text-decoration: underline;
+            flex-direction: column;
+            align-items: center;
         }
     }
+
+        .c-mediaElement-img {
+            line-height: 0;
+            margin-right: 5%;
+
+            &,
+            & > img {
+                width: $mediaElement-img-width;
+
+                @include media('>narrow') {
+                    width: $mediaElement-img-width--mid;
+                }
+
+                @include media('>=wide') {
+                    width: $mediaElement-img-width--wide;
+                }
+            }
+
+            // make sure we cut off the corners of the image and the container
+            &,
+            & > img {
+                border-radius: 3px;
+            }
+
+            // center the img when stacked
+            .c-mediaElement--fullstack & {
+                margin-right: 0;
+                flex-basis: auto;
+            }
+
+            .c-mediaElement--stack & {
+                flex-basis: auto;
+
+                @include media('<mid') {
+                    margin-right: 0;
+                    flex-grow: 1;
+                }
+
+                @include media('>=mid') {
+                    margin-top: spacing(base) / 4;
+                }
+
+                @include media('>=wide') {
+                    margin-top: 0;
+                }
+            }
+        }
+
+        // apply an outline to the mediaElement img
+        .c-mediaElement-img--outlined {
+            border: solid 1px $color-border;
+            border-radius: $mediaElement-img-borderRadius;
+        }
+
+        .c-mediaElement-img--small {
+            max-width: 70px;
+            max-height: 70px;
+        }
+
+        // positions the image over the top edge of the media element
+        .c-mediaElement-img--negativeTop {
+            margin-top: 0;
+            position: absolute;
+            top: -24px;
+
+            @include media('>=narrow') {
+                top: -40px;
+            }
+        }
+
+        .c-mediaElement-heading {
+            margin: spacing(x6) 0 spacing(x2);
+        }
+
+        .c-mediaElement-content {
+            flex-basis: 0;
+            flex-grow: 1;
+
+            .c-mediaElement--fullstack & {
+                flex: auto;
+                margin-top: spacing(x0.5);
+            }
+
+            .c-mediaElement--fullstack--negativeTop & {
+                flex: auto;
+                margin-top: -#{spacing(x2)};
+            }
+
+            // some content uses br for content shaping – get rid of it on mobile devices
+            & br {
+                @include media('<mid') {
+                    display: none;
+                }
+            }
+        }
+
+        .c-mediaElement-text {
+            margin-top: 0;
+            @include font-size(caption, false);
+        }
+
+        .c-mediaElement-text--large {
+            @include font-size(heading-m, false); // TODO – this should be updated with a more semantic font alias, as it's not a heading
+            line-height: 1.2;
+        }
+
+        .c-mediaElement-infoLink {
+            @include font-size($mediaElement-fontSize);
+            align-items: center;
+            color: $mediaElement-infoLinkColor;
+            display: flex;
+            position: absolute;
+            right: $mediaElement-spacing;
+            text-decoration: none;
+            top: $mediaElement-spacing;
+
+            @include media('<mid') {
+                right: spacing(x2);
+                top: spacing(x2);
+            }
+
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+}

--- a/src/scss/components/_media-element.scss
+++ b/src/scss/components/_media-element.scss
@@ -99,7 +99,7 @@
 
         // apply an outline to the mediaElement img
         .c-mediaElement-img--outlined {
-            border: solid 1px $color-border;
+            border: solid 1px $color-border-strong;
             border-radius: $mediaElement-img-borderRadius;
         }
 

--- a/src/scss/components/_media-element.scss
+++ b/src/scss/components/_media-element.scss
@@ -16,7 +16,7 @@
     $mediaElement-img-width--mid    : 78px;
     $mediaElement-img-width--wide   : 67px;
     $mediaElement-img-borderRadius  : 2px;
-    $mediaElement-infoLinkColor     : $blue;
+    $mediaElement-infoLinkColor     : $color-blue;
     $mediaElement-fontSize          : body-l;
     $mediaElement-spacing           : spacing(x2);
 

--- a/src/scss/components/optional/_apps-banner.scss
+++ b/src/scss/components/optional/_apps-banner.scss
@@ -1,15 +1,16 @@
-/**
- * Apps Banner Component
- * =================================
- * Used to display app promo banner on the page.
- *
- * *The `c-appBaner` component is an optional mixin within Fozzie — if you'd like to use it in your project you can include it by adding `@include appsBanner();` into your SCSS dependencies file.*
- *
- * Documentation:
- * https://fozzie.just-eat.com/styleguide/ui-components/apps-banner
- */
-
 @mixin appsBanner() {
+    /**
+    * Apps Banner Component
+    * =================================
+    * Used to display app promo banner on the page.
+    *
+    * The `c-appsBanner` component is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include appsBanner();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * https://fozzie.just-eat.com/styleguide/ui-components/apps-banner
+    */
+
     @include media-context(('narrow-mid': 600px)) {
         /* autoprefixer grid: autoplace */
         .c-appsBanner {

--- a/src/scss/components/optional/_badges.scss
+++ b/src/scss/components/optional/_badges.scss
@@ -13,23 +13,23 @@
     * https://fozzie.just-eat.com/styleguide/ui-components/badges
     */
 
-    $badge-bgColor                  : $grey--offWhite;
-    $badge-light-bgColor            : $white;
-    $badge-info-color               : $green;
-    $badge-success-color            : $green;
-    $badge-success-bgColor          : $green--offWhite;
-    $badge-successAlt-color         : $white;
-    $badge-successAlt-bgColor       : $green;
-    $badge-warning-color            : $orange;
-    $badge-alert-color              : $red;
-    $badge-important-color          : $grey--dark;
-    $badge-important-bgColor        : $orange--offWhite;
-    $badge-award-color              : $purple;
-    $badge-award-bgColor            : $purple--light;
-    $badge-dark-color               : $white;
-    $badge-dark-bgColor             : $grey--darkest;
-    $badge-indicator-color          : $blue;
-    $badge-indicator-bgColor        : $white;
+    $badge-bgColor                  : $color-grey-10;
+    $badge-light-bgColor            : $color-white;
+    $badge-info-color               : $color-green;
+    $badge-success-color            : $color-green;
+    $badge-success-bgColor          : $color-green-10;
+    $badge-successAlt-color         : $color-white;
+    $badge-successAlt-bgColor       : $color-green;
+    $badge-warning-color            : $color-orange;
+    $badge-alert-color              : $color-red;
+    $badge-important-color          : $color-grey-50;
+    $badge-important-bgColor        : $color-orange-10;
+    $badge-award-color              : $color-external-bta-text;
+    $badge-award-bgColor            : $color-external-bta-background;
+    $badge-dark-color               : $color-white;
+    $badge-dark-bgColor             : $color-grey;
+    $badge-indicator-color          : $color-blue;
+    $badge-indicator-bgColor        : $color-white;
     $badge-padding                  : 1px 5px;
     $badge-rounded-radius           : 14px;
     $badge-rounded-padding          : spacing(x0.5) spacing(x2);
@@ -157,7 +157,7 @@
             &:after {
                 content: $badge-glyph-bullet;
                 display: inline-block;
-                color: $grey--light;
+                color: $color-grey-30;
             }
         }
 }

--- a/src/scss/components/optional/_badges.scss
+++ b/src/scss/components/optional/_badges.scss
@@ -1,42 +1,42 @@
-/**
- * Components > Badge
- * =================================
- * Used for styling small pieces of information.
- *
- * Examples: Menu – Restaurant delivery information and Search – listing labels
- *
- * The `c-badge` component is an optional mixin within Fozzie.
- * If you'd like to use it in your project you can include it by adding `@include badge();` into your SCSS dependencies file.
- *
- * Documentation:
- * https://fozzie.just-eat.com/styleguide/ui-components/badges
- */
-
-$badge-bgColor                  : $grey--offWhite;
-$badge-light-bgColor            : $white;
-$badge-info-color               : $green;
-$badge-success-color            : $green;
-$badge-success-bgColor          : $green--offWhite;
-$badge-successAlt-color         : $white;
-$badge-successAlt-bgColor       : $green;
-$badge-warning-color            : $orange;
-$badge-alert-color              : $red;
-$badge-important-color          : $grey--dark;
-$badge-important-bgColor        : $orange--offWhite;
-$badge-award-color              : $purple;
-$badge-award-bgColor            : $purple--light;
-$badge-dark-color               : $white;
-$badge-dark-bgColor             : $grey--darkest;
-$badge-indicator-color          : $blue;
-$badge-indicator-bgColor        : $white;
-$badge-padding                  : 1px 5px;
-$badge-rounded-radius           : 14px;
-$badge-rounded-padding          : spacing(x0.5) spacing(x2);
-$badge-rounded-small-radius     : 2px;
-$badge-rounded-small-padding    : 2px spacing(x0.5);
-$badge-angled-radius            : 2px;
-
 @mixin badge() {
+    /**
+    * Components > Badge
+    * =================================
+    * Used for styling small pieces of information.
+    *
+    * Examples: Menu – Restaurant delivery information and Search – listing labels
+    *
+    * The `c-badge` component is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include badge();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * https://fozzie.just-eat.com/styleguide/ui-components/badges
+    */
+
+    $badge-bgColor                  : $grey--offWhite;
+    $badge-light-bgColor            : $white;
+    $badge-info-color               : $green;
+    $badge-success-color            : $green;
+    $badge-success-bgColor          : $green--offWhite;
+    $badge-successAlt-color         : $white;
+    $badge-successAlt-bgColor       : $green;
+    $badge-warning-color            : $orange;
+    $badge-alert-color              : $red;
+    $badge-important-color          : $grey--dark;
+    $badge-important-bgColor        : $orange--offWhite;
+    $badge-award-color              : $purple;
+    $badge-award-bgColor            : $purple--light;
+    $badge-dark-color               : $white;
+    $badge-dark-bgColor             : $grey--darkest;
+    $badge-indicator-color          : $blue;
+    $badge-indicator-bgColor        : $white;
+    $badge-padding                  : 1px 5px;
+    $badge-rounded-radius           : 14px;
+    $badge-rounded-padding          : spacing(x0.5) spacing(x2);
+    $badge-rounded-small-radius     : 2px;
+    $badge-rounded-small-padding    : 2px spacing(x0.5);
+    $badge-angled-radius            : 2px;
+    $badge-glyph-bullet             : '\2022';
 
     .c-badge {
         background-color: $badge-bgColor;
@@ -155,7 +155,7 @@ $badge-angled-radius            : 2px;
         //The content '\2022' will output a bullet: •
         .c-badge-icon {
             &:after {
-                content: $bullet;
+                content: $badge-glyph-bullet;
                 display: inline-block;
                 color: $grey--light;
             }

--- a/src/scss/components/optional/_content-header.scss
+++ b/src/scss/components/optional/_content-header.scss
@@ -1,18 +1,17 @@
-/**
- * Components > Content Header
- * =================================
- * Used to display important contextual info at the top of a page
- *
- * Example: Restaurant count and location on search page
- *
- * The `c-contentHeader` component is an optional mixin within Fozzie.
- * If you'd like to use it in your project you can include it by adding `@include contentHeader();` into your SCSS dependencies file.
- *
- * Documentation:
- * TBC
- */
-
 @mixin contentHeader() {
+    /**
+    * Components > Content Header
+    * =================================
+    * Used to display important contextual info at the top of a page
+    *
+    * Example: Restaurant count and location on search page
+    *
+    * The `c-contentHeader` component is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include contentHeader();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * TBC
+    */
 
     .c-contentHeader {
         padding-top: spacing(x2);

--- a/src/scss/components/optional/_content-header.scss
+++ b/src/scss/components/optional/_content-header.scss
@@ -22,7 +22,7 @@
             padding: 0;
             display: inline-block;
             margin: 0 spacing(x2) 0 0;
-            font-weight: $font-weight-base;
+            font-weight: $font-weight-regular;
             @include font-size(body-l, false); // TODO – this should be updated with a more semantic font alias when it's ported to fozzie-components repo
         }
 
@@ -46,7 +46,7 @@
         .c-contentHeader-link {
             display: inline-block;
             text-decoration: none;
-            font-weight: $font-weight-base;
+            font-weight: $font-weight-regular;
 
             &:hover,
             &:focus {

--- a/src/scss/components/optional/_content-title.scss
+++ b/src/scss/components/optional/_content-title.scss
@@ -28,7 +28,7 @@
         .c-contentTitle-text {
             margin: 0;
             width: 100%;
-            font-weight: $font-weight-base;
+            font-weight: $font-weight-regular;
             @include font-size(body-l, false);
         }
 

--- a/src/scss/components/optional/_content-title.scss
+++ b/src/scss/components/optional/_content-title.scss
@@ -1,18 +1,17 @@
-/**
- * Components > Content title
- * =================================
- * Used for displaying a title with an associated action next to it
- *
- * Example: Filter titles (Search sidebar)
- *
- * The `c-contentTitle` component is an optional mixin within Fozzie.
- * If you'd like to use it in your project you can include it by adding `@include contentTitle();` into your SCSS dependencies file.
- *
- * Documentation:
- * TBC
- */
-
 @mixin contentTitle() {
+    /**
+    * Components > Content title
+    * =================================
+    * Used for displaying a title with an associated action next to it
+    *
+    * Example: Filter titles (Search sidebar)
+    *
+    * The `c-contentTitle` component is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include contentTitle();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * TBC
+    */
 
     .c-contentTitle {
         width: 100%;

--- a/src/scss/components/optional/_cookie-warning.scss
+++ b/src/scss/components/optional/_cookie-warning.scss
@@ -1,4 +1,14 @@
 @mixin cookieWarning() {
+    /**
+    * Components > Cookie Warning
+    * =================================
+    *
+    * The `c-cookieWarning` component is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include cookieWarning();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * TBC
+    */
     .c-cookieWarning {
         background-color: $grey--darkest;
         position: fixed;

--- a/src/scss/components/optional/_cookie-warning.scss
+++ b/src/scss/components/optional/_cookie-warning.scss
@@ -10,7 +10,7 @@
     * TBC
     */
     .c-cookieWarning {
-        background-color: $grey--darkest;
+        background-color: $color-grey;
         position: fixed;
         bottom: 0;
         width: 100%;
@@ -18,7 +18,7 @@
 
         & p {
             @include font-size(caption, false);
-            color: $white;
+            color: $color-white;
             text-align: center;
             margin: 0 auto;
         }
@@ -45,17 +45,17 @@
         &:hover,
         &:active,
         &:focus {
-            background-color: $grey--mid;
+            background-color: $color-grey-40;
             cursor: pointer;
         }
     }
 
     .c-cookieWarning-link {
-        color: $white;
+        color: $color-white;
         &:hover,
         &:active,
         &:focus {
-            color: $white;
+            color: $color-white;
         }
     }
 }

--- a/src/scss/components/optional/_cuisines-widget.scss
+++ b/src/scss/components/optional/_cuisines-widget.scss
@@ -1,26 +1,26 @@
-/**
-* Components > Cuisines Widget
-* =================================
-*
-* Example: Homepage – Popular cuisines.
-*
-* The `c-cuisinesWidget` component is an optional mixin within Fozzie.
-* If you'd like to use it in your project you can include it by adding `@include cuisinesWidget();` into your SCSS dependencies file.
-*
-* Documentation:
-* https://fozzie.just-eat.com/styleguide/ui-components/cuisines-widget
-*/
-
-//TODO: Improvement of this solution: WH-682 as suggested in https://github.com/justeat/fozzie/pull/188#issuecomment-442138750
-
-
-$cuisinesWidget-titleColour: $white;
-$cuisinesWidget-defaultBackground: $grey--lighter;
-$cuisinesWidget-boxShadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
-$cuisinesWidget-hoverBoxShadow: 0 2px 8px 0 rgba(0, 0, 0, 0.16), -2px -2px 4px 0 rgba(0, 0, 0, 0.04);
-$cuisinesWidget-gradient: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0));
-
 @mixin cuisinesWidget() {
+    /**
+    * Components > Cuisines Widget
+    * =================================
+    *
+    * Example: Homepage – Popular cuisines.
+    *
+    * The `c-cuisinesWidget` component is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include cuisinesWidget();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * https://fozzie.just-eat.com/styleguide/ui-components/cuisines-widget
+    */
+
+    //TODO: Improvement of this solution: WH-682 as suggested in https://github.com/justeat/fozzie/pull/188#issuecomment-442138750
+
+
+    $cuisinesWidget-titleColour: $white;
+    $cuisinesWidget-defaultBackground: $grey--lighter;
+    $cuisinesWidget-boxShadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
+    $cuisinesWidget-hoverBoxShadow: 0 2px 8px 0 rgba(0, 0, 0, 0.16), -2px -2px 4px 0 rgba(0, 0, 0, 0.04);
+    $cuisinesWidget-gradient: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0));
+
     @include media-context(('narrow-mid': 570px, 'mid-wide': 1240px)) {
 
        .c-cuisinesWidget {

--- a/src/scss/components/optional/_cuisines-widget.scss
+++ b/src/scss/components/optional/_cuisines-widget.scss
@@ -15,8 +15,8 @@
     //TODO: Improvement of this solution: WH-682 as suggested in https://github.com/justeat/fozzie/pull/188#issuecomment-442138750
 
 
-    $cuisinesWidget-titleColour: $white;
-    $cuisinesWidget-defaultBackground: $grey--lighter;
+    $cuisinesWidget-titleColour: $color-white;
+    $cuisinesWidget-defaultBackground: $color-grey-20;
     $cuisinesWidget-boxShadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
     $cuisinesWidget-hoverBoxShadow: 0 2px 8px 0 rgba(0, 0, 0, 0.16), -2px -2px 4px 0 rgba(0, 0, 0, 0.04);
     $cuisinesWidget-gradient: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0));

--- a/src/scss/components/optional/_fullscreen-pop-over.scss
+++ b/src/scss/components/optional/_fullscreen-pop-over.scss
@@ -104,7 +104,7 @@
         .c-fullScreenPopOver-header-title {
             margin-top: 0;
             text-align: center;
-            font-weight: $font-weight-base;
+            font-weight: $font-weight-regular;
         }
 
         .c-fullScreenPopOver-footer {

--- a/src/scss/components/optional/_fullscreen-pop-over.scss
+++ b/src/scss/components/optional/_fullscreen-pop-over.scss
@@ -17,7 +17,7 @@
     $fullScreenPopOver-action-background : $color-white;
     $fullScreenPopOver-padding           : spacing(x2);
     $fullScreenPopOver-border-color      : $color-grey-30;
-    $fullScreenPopOver-shadow-color      : rgba(color-black, 0.12);
+    $fullScreenPopOver-shadow-color      : rgba($color-black, 0.12);
 
     .c-fullScreenPopOver {
         @include media('<mid') {

--- a/src/scss/components/optional/_fullscreen-pop-over.scss
+++ b/src/scss/components/optional/_fullscreen-pop-over.scss
@@ -13,11 +13,11 @@
     * TBC
     */
 
-    $fullScreenPopOver-background        : $grey--offWhite;
-    $fullScreenPopOver-action-background : $white;
+    $fullScreenPopOver-background        : $color-grey-10;
+    $fullScreenPopOver-action-background : $color-white;
     $fullScreenPopOver-padding           : spacing(x2);
-    $fullScreenPopOver-border-color      : $grey--light;
-    $fullScreenPopOver-shadow-color      : rgba($black, 0.12);
+    $fullScreenPopOver-border-color      : $color-grey-30;
+    $fullScreenPopOver-shadow-color      : rgba(color-black, 0.12);
 
     .c-fullScreenPopOver {
         @include media('<mid') {
@@ -77,7 +77,7 @@
         .c-fullScreenPopOver-header {
             top: 0;
             z-index: zIndex(high);
-            box-shadow: 0 3px 4px 0 $grey--light;
+            box-shadow: 0 3px 4px 0 $color-grey-30;
         }
 
         .c-fullScreenPopOver-header-actionFirst,
@@ -109,7 +109,7 @@
 
         .c-fullScreenPopOver-footer {
             bottom: 0;
-            box-shadow: 0 -2px 2px 0 $grey--light;
+            box-shadow: 0 -2px 2px 0 $color-grey-30;
         }
 
         .c-fullScreenPopOver-content {

--- a/src/scss/components/optional/_fullscreen-pop-over.scss
+++ b/src/scss/components/optional/_fullscreen-pop-over.scss
@@ -1,24 +1,23 @@
-/**
- * Components > Fullscreen Popovers
- * =================================
- * Component that styles a full-page popover/takeover on top of the current content
- *
- * Example: Used for the mobile filters fullscreen popover on the Search Page
- *
- * The `c-fullScreenPopOver` component is an optional mixin within Fozzie.
- * If you'd like to use it in your project you can include it by adding `@include fullScreenPopOver();` into your SCSS dependencies file.
- *
- * Documentation:
- * TBC
- */
-
-$fullScreenPopOver-background        : $grey--offWhite;
-$fullScreenPopOver-action-background : $white;
-$fullScreenPopOver-padding           : spacing(x2);
-$fullScreenPopOver-border-color      : $grey--light;
-$fullScreenPopOver-shadow-color      : rgba($black, 0.12);
-
 @mixin fullScreenPopOver() {
+    /**
+    * Components > Fullscreen Popovers
+    * =================================
+    * Component that styles a full-page popover/takeover on top of the current content
+    *
+    * Example: Used for the mobile filters fullscreen popover on the Search Page
+    *
+    * The `c-fullScreenPopOver` component is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include fullScreenPopOver();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * TBC
+    */
+
+    $fullScreenPopOver-background        : $grey--offWhite;
+    $fullScreenPopOver-action-background : $white;
+    $fullScreenPopOver-padding           : spacing(x2);
+    $fullScreenPopOver-border-color      : $grey--light;
+    $fullScreenPopOver-shadow-color      : rgba($black, 0.12);
 
     .c-fullScreenPopOver {
         @include media('<mid') {

--- a/src/scss/components/optional/_listings-skeleton.scss
+++ b/src/scss/components/optional/_listings-skeleton.scss
@@ -15,7 +15,7 @@
 
     .c-listingSkeleton {
         position: relative;
-        background: $white;
+        background: $color-white;
         border-radius: spacing();
         padding: 85px spacing(x2) spacing(x2);
         margin-bottom: spacing(x2);
@@ -171,7 +171,7 @@
 
 @mixin anim() {
     border-radius: 2px;
-    background: linear-gradient(-45deg, $grey--offWhite, $grey--offWhite, $grey--lighter, $grey--offWhite, $grey--offWhite);
+    background: linear-gradient(-45deg, $color-grey-10, $color-grey-10, $color-grey-20, $color-grey-10, $color-grey-10);
     background-size: 2000px 600%;
     animation: skeletonGradient 2s ease infinite;
     animation-fill-mode: forwards;

--- a/src/scss/components/optional/_listings-skeleton.scss
+++ b/src/scss/components/optional/_listings-skeleton.scss
@@ -1,22 +1,17 @@
-
-@keyframes skeletonGradient {
-    0% {
-        background-position: 100% 50%;
-    }
-    100% {
-        background-position: 0% 50%;
-    }
-}
-
-@mixin anim() {
-    border-radius: 2px;
-    background: linear-gradient(-45deg, $grey--offWhite, $grey--offWhite, $grey--lighter, $grey--offWhite, $grey--offWhite);
-    background-size: 2000px 600%;
-    animation: skeletonGradient 2s ease infinite;
-    animation-fill-mode: forwards;
-}
-
 @mixin listingSkeleton() {
+    /**
+    * Components > Listing Skeleton
+    * =================================
+    * Shows a Skeleton listing layout.
+    *
+    * Example: Search listigns
+    *
+    * The `c-listingSkeleton` component is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include listingSkeleton();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * TBC
+    */
 
     .c-listingSkeleton {
         position: relative;
@@ -163,4 +158,21 @@
             right: spacing(x2);
         }
     }
+}
+
+@keyframes skeletonGradient {
+    0% {
+        background-position: 100% 50%;
+    }
+    100% {
+        background-position: 0% 50%;
+    }
+}
+
+@mixin anim() {
+    border-radius: 2px;
+    background: linear-gradient(-45deg, $grey--offWhite, $grey--offWhite, $grey--lighter, $grey--offWhite, $grey--offWhite);
+    background-size: 2000px 600%;
+    animation: skeletonGradient 2s ease infinite;
+    animation-fill-mode: forwards;
 }

--- a/src/scss/components/optional/_listings.scss
+++ b/src/scss/components/optional/_listings.scss
@@ -1,57 +1,41 @@
-/**
- * Components > Listing
- * ===================================
- * Component that styles lists of content
- *
- * Example: SERP Page – Restaurant Information Lists
- *
- * The `c-listing` component is an optional mixin within Fozzie.
- * If you'd like to use it in your project you can include it by adding `@include listing();` into your SCSS dependencies file.
- *
- * Documentation:
- * https://fozzie.just-eat.com/styleguide/ui-components/listings
- */
-
-$listing-bg                     : $white;
-$listing-borderColor            : $color-border;
-$listing-border-radius          : 4px;
-$listing-img-border-radius      : 2px;
-$listing-promoIcon-color        : $orange;
-
-$listing--subsequent-bg         : $grey--lighter;
-$listing--inactive-bg           : rgba($listing-bg, 0.5);
-
-/*
-    The mixins below are to help juggle the badge items between stacked and
-    inline and targets viewports inbetween mid and wide (landscape mobiles and very small desktops).
-
-    On narrow, mid and wide you will see:
-
-    item • item
-
-    between mid and wide you will see:
-
-    item
-    item
-
-    The mixins are used to stop code duplication as each chunk of
-    code needs to be within its own media mixin.
-*/
-@mixin inlineDivider() {
-    span {
-        display: block;
-        font-size: 0;
-    }
-}
-
-@mixin blockDivider() {
-    span {
-        display: inline-block;
-        font-size: 1em;
-    }
-}
-
 @mixin listing() {
+    /**
+    * Components > Listing
+    * ===================================
+    * Component that styles lists of content
+    *
+    * Example: SERP Page – Restaurant Information Lists
+    *
+    * The `c-listing` component is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include listing();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * https://fozzie.just-eat.com/styleguide/ui-components/listings
+    */
+
+    // The mixins below are to help juggle the badge items between stacked and
+    // inline and target viewports in-between mid and wide (landscape mobiles and very small desktops).
+    //
+    // On narrow, mid and wide you will see:
+    //
+    // item • item
+    //
+    // between mid and wide you will see:
+    //
+    // item
+    // item
+    //
+    // The mixins are used to stop code duplication as each chunk of
+    // code needs to be within its own media mixin.
+
+    $listing-bg                     : $white;
+    $listing-borderColor            : $color-border;
+    $listing-border-radius          : 4px;
+    $listing-img-border-radius      : 2px;
+    $listing-promoIcon-color        : $orange;
+
+    $listing--subsequent-bg         : $grey--lighter;
+    $listing--inactive-bg           : rgba($listing-bg, 0.5);
 
     .c-listing {
         border-radius: $listing-border-radius;
@@ -415,4 +399,18 @@ $listing--inactive-bg           : rgba($listing-bg, 0.5);
                     height: 32px;
                 }
             }
+}
+
+@mixin inlineDivider() {
+    span {
+        display: block;
+        font-size: 0;
+    }
+}
+
+@mixin blockDivider() {
+    span {
+        display: inline-block;
+        font-size: 1em;
+    }
 }

--- a/src/scss/components/optional/_listings.scss
+++ b/src/scss/components/optional/_listings.scss
@@ -28,13 +28,13 @@
     // The mixins are used to stop code duplication as each chunk of
     // code needs to be within its own media mixin.
 
-    $listing-bg                     : $white;
+    $listing-bg                     : $color-white;
     $listing-borderColor            : $color-border;
     $listing-border-radius          : 4px;
     $listing-img-border-radius      : 2px;
-    $listing-promoIcon-color        : $orange;
+    $listing-promoIcon-color        : $color-orange;
 
-    $listing--subsequent-bg         : $grey--lighter;
+    $listing--subsequent-bg         : $color-grey-20;
     $listing--inactive-bg           : rgba($listing-bg, 0.5);
 
     .c-listing {
@@ -78,7 +78,7 @@
 
         .c-listing-item {
             margin-bottom: spacing(x2);
-            box-shadow: 0 2px 4px 0 rgba($black, 0.1);
+            box-shadow: 0 2px 4px 0 rgba($color-black, 0.1);
             padding-bottom: spacing();
 
             @include media('>mid') {
@@ -130,7 +130,7 @@
                 }
 
                 &:not(.c-listing-item-header--noImage) {
-                    background: $grey--lighter;
+                    background: $color-grey-20;
                 }
             }
 
@@ -199,7 +199,7 @@
                 top: spacing(x2);
                 left: spacing(x2);
                 position: absolute;
-                border: 1px solid $grey--lighter;
+                border: 1px solid $color-border-subtle;
                 border-radius: $listing-img-border-radius;
 
                 @include media('>=wide') {
@@ -273,7 +273,7 @@
 
             .c-listing-item-new {
                 top: -4px;
-                color: $green;
+                color: $color-green;
                 position: relative;
                 margin-right: spacing(x0.5);
             }
@@ -302,7 +302,7 @@
             .c-listing-item-detailsRow-icon {
                 width: 20px;
                 height: 20px;
-                fill: $grey--dark;
+                fill: $color-grey-50;
             }
 
             .c-listing-item-detailsRow-text {
@@ -339,7 +339,7 @@
             }
 
             .c-listing-item-promo-text--earned {
-                color: $green;
+                color: $color-green;
             }
 
             .c-listing-item-rating {

--- a/src/scss/components/optional/_listings.scss
+++ b/src/scss/components/optional/_listings.scss
@@ -29,7 +29,7 @@
     // code needs to be within its own media mixin.
 
     $listing-bg                     : $color-white;
-    $listing-borderColor            : $color-border;
+    $listing-borderColor            : $color-border-strong;
     $listing-border-radius          : 4px;
     $listing-img-border-radius      : 2px;
     $listing-promoIcon-color        : $color-orange;
@@ -168,7 +168,7 @@
             // make sure it doesn’t underline everything (only the main title)
             .c-listing-item-link {
                 display: block;
-                color: $color-text;
+                color: $color-content-default;
                 text-decoration: none;
 
                 &:hover,
@@ -232,7 +232,7 @@
 
             .c-listing-item-info {
                 position: relative;
-                color: $color-text;
+                color: $color-content-default;
                 padding-left: 70px;
                 min-height: 60px;
 

--- a/src/scss/components/optional/_loading-indicator.scss
+++ b/src/scss/components/optional/_loading-indicator.scss
@@ -10,7 +10,7 @@
 
 $loading-indicator-size-medium: 20px;
 $loading-indicator-size-large: 48px;
-$loading-indicator-color: $orange;
+$loading-indicator-color: $color-orange;
 $loading-indicator-borderSize: 3px;
 $loading-indicator-borderColorOpaque: rgba(243, 109, 0, 0.2);
 $loading-indicator-spacing: 20px;

--- a/src/scss/components/optional/_loading-indicator.scss
+++ b/src/scss/components/optional/_loading-indicator.scss
@@ -8,35 +8,43 @@
 *
 */
 
-$loading-indicator-size                      : 20px;
-$loading-indicator-color                     : $orange;
-$loading-indicator-borderSize                : 3px;
-$loading-indicator-borderColorOpaque         : rgba(243, 109, 0, 0.2);
-$loading-indicator-spacing                   : 20px;
+$loading-indicator-size-medium: 20px;
+$loading-indicator-size-large: 48px;
+$loading-indicator-color: $orange;
+$loading-indicator-borderSize: 3px;
+$loading-indicator-borderColorOpaque: rgba(243, 109, 0, 0.2);
+$loading-indicator-spacing: 20px;
 
-@mixin loadingIndicator() {
-    @keyframes spin {
-        from {
-            transform: rotate(0);
-        }
-
-        to {
-            transform: rotate(359deg);
-        }
+@mixin loadingIndicator($loading-indicator-size: 'medium') {
+  @keyframes spin {
+    from {
+      transform: rotate(0);
     }
 
-    .c-spinner-wrapper {
-        position: absolute;
-        right: 0;
+    to {
+      transform: rotate(359deg);
     }
+  }
 
-    .c-spinner {
-        width: $loading-indicator-size;
-        height: $loading-indicator-size;
-        margin-right: $loading-indicator-spacing;
-        border: $loading-indicator-borderSize solid $loading-indicator-color;
-        border-top: $loading-indicator-borderSize solid $loading-indicator-borderColorOpaque;
-        border-radius: 50%;
-        animation: spin 1s linear 0s infinite;
+  .c-spinner-wrapper {
+    position: absolute;
+    right: 0;
+  }
+
+  .c-spinner {
+    margin-right: $loading-indicator-spacing;
+    border: $loading-indicator-borderSize solid $loading-indicator-color;
+    border-top: $loading-indicator-borderSize solid
+      $loading-indicator-borderColorOpaque;
+    border-radius: 50%;
+    animation: spin 1s linear 0s infinite;
+
+    @if $loading-indicator-size == 'large' {
+      width: $loading-indicator-size-large;
+      height: $loading-indicator-size-large;
+    } @else {
+      width: $loading-indicator-size-medium;
+      height: $loading-indicator-size-medium;
     }
+  }
 }

--- a/src/scss/components/optional/_loading-indicator.scss
+++ b/src/scss/components/optional/_loading-indicator.scss
@@ -10,12 +10,20 @@
 
 $loading-indicator-size-medium: 20px;
 $loading-indicator-size-large: 48px;
-$loading-indicator-color: $color-orange;
+$loading-indicator-color-default: $color-orange;
 $loading-indicator-borderSize: 3px;
-$loading-indicator-borderColorOpaque: rgba(243, 109, 0, 0.2);
+$loading-indicator-borderColorOpaque-default: rgba(243, 109, 0, 0.2);
 $loading-indicator-spacing: 20px;
 
-@mixin loadingIndicator($loading-indicator-size: 'medium') {
+@mixin spinnerColor($loading-indicator-color: $loading-indicator-color-default, $loading-indicator-borderColorOpaque: $loading-indicator-borderColorOpaque-default) {
+  .c-spinner {
+    border: $loading-indicator-borderSize solid $loading-indicator-color;
+    border-top: $loading-indicator-borderSize solid $loading-indicator-borderColorOpaque;
+    border-right: $loading-indicator-borderSize solid $loading-indicator-borderColorOpaque;
+  }
+}
+
+@mixin loadingIndicator($loading-indicator-size: 'medium', $loading-indicator-color: $loading-indicator-color-default, $loading-indicator-borderColorOpaque: $loading-indicator-borderColorOpaque-default) {
   @keyframes spin {
     from {
       transform: rotate(0);
@@ -33,16 +41,17 @@ $loading-indicator-spacing: 20px;
 
   .c-spinner {
     margin-right: $loading-indicator-spacing;
-    border: $loading-indicator-borderSize solid $loading-indicator-color;
-    border-top: $loading-indicator-borderSize solid
-      $loading-indicator-borderColorOpaque;
     border-radius: 50%;
     animation: spin 1s linear 0s infinite;
 
-    @if $loading-indicator-size == 'large' {
+    @include spinnerColor();
+
+    @if $loading-indicator-size=='large' {
       width: $loading-indicator-size-large;
       height: $loading-indicator-size-large;
-    } @else {
+    }
+
+    @else {
       width: $loading-indicator-size-medium;
       height: $loading-indicator-size-medium;
     }

--- a/src/scss/components/optional/_menu.scss
+++ b/src/scss/components/optional/_menu.scss
@@ -1,32 +1,32 @@
-/**
- * Components > Menu
- * =================================
- * Used for styling small pieces of information.
- *
- * Example: Menu – Categories list.
- *
- * *The `c-menu` component is an optional mixin within Fozzie — if you'd like to use it in your project you can include it by adding `@include menu();` into your SCSS dependencies file.*
- *
- * Documentation:
- * https://fozzie.just-eat.com/styleguide/ui-components/menus
- */
-
-$menu-headerHeight                      : 57px;
-$menu-fontSize                          : body-l;
-$menu-border-color                      : $color-border;
-$menu-border-color--active              : $grey--dark;
-$menu-border-width                      : 1px;
-$menu-border-width--active              : 2px;
-$menu-link-color                        : $color-text;
-$menu-link-padding                      : spacing() spacing(x2);
-$menu-positionTop                       : $menu-headerHeight + spacing(x2);
-$menu--condensed-link-padding           : spacing(x0.5);
-$menu--expandable-bgColor               : $white !default;
-$menu--expandable-borderBottom          : $color-border !default;
-$menu--expandable-linkFontSize          : body-s !default;
-$menu--expandable-linkActiveFontSize    : body-l !default;
-
 @mixin menu() {
+    /**
+    * Components > Menu
+    * =================================
+    * Used for styling small pieces of information.
+    *
+    * Example: Menu – Categories list.
+    *
+    * The `c-menu` component is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include menu();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * https://fozzie.just-eat.com/styleguide/ui-components/menus
+    */
+
+    $menu-headerHeight                      : 57px;
+    $menu-fontSize                          : body-l;
+    $menu-border-color                      : $color-border;
+    $menu-border-color--active              : $grey--dark;
+    $menu-border-width                      : 1px;
+    $menu-border-width--active              : 2px;
+    $menu-link-color                        : $color-text;
+    $menu-link-padding                      : spacing() spacing(x2);
+    $menu-positionTop                       : $menu-headerHeight + spacing(x2);
+    $menu--condensed-link-padding           : spacing(x0.5);
+    $menu--expandable-bgColor               : $white;
+    $menu--expandable-borderBottom          : $color-border;
+    $menu--expandable-linkFontSize          : body-s;
+    $menu--expandable-linkActiveFontSize    : body-l;
 
     .c-menu {
         @extend %u-unstyled;

--- a/src/scss/components/optional/_menu.scss
+++ b/src/scss/components/optional/_menu.scss
@@ -60,7 +60,7 @@
             .c-menu-item--active {
                 border-left: none;
                 border-bottom: solid $menu-border-width--active $menu-border-color--active;
-                font-weight: $font-weight-base;
+                font-weight: $font-weight-regular;
                 margin-left: 0;
             }
         }
@@ -156,7 +156,7 @@
                     &:focus,
                     &:hover {
                         border: 0;
-                        font-weight: $font-weight-base;
+                        font-weight: $font-weight-regular;
                     }
                 }
 

--- a/src/scss/components/optional/_menu.scss
+++ b/src/scss/components/optional/_menu.scss
@@ -15,16 +15,16 @@
 
     $menu-headerHeight                      : 57px;
     $menu-fontSize                          : body-l;
-    $menu-border-color                      : $color-border;
+    $menu-border-color                      : $color-border-strong;
     $menu-border-color--active              : $color-grey-50;
     $menu-border-width                      : 1px;
     $menu-border-width--active              : 2px;
-    $menu-link-color                        : $color-text;
+    $menu-link-color                        : $color-content-default;
     $menu-link-padding                      : spacing() spacing(x2);
     $menu-positionTop                       : $menu-headerHeight + spacing(x2);
     $menu--condensed-link-padding           : spacing(x0.5);
     $menu--expandable-bgColor               : $color-white;
-    $menu--expandable-borderBottom          : $color-border;
+    $menu--expandable-borderBottom          : $color-border-strong;
     $menu--expandable-linkFontSize          : body-s;
     $menu--expandable-linkActiveFontSize    : body-l;
 

--- a/src/scss/components/optional/_menu.scss
+++ b/src/scss/components/optional/_menu.scss
@@ -16,14 +16,14 @@
     $menu-headerHeight                      : 57px;
     $menu-fontSize                          : body-l;
     $menu-border-color                      : $color-border;
-    $menu-border-color--active              : $grey--dark;
+    $menu-border-color--active              : $color-grey-50;
     $menu-border-width                      : 1px;
     $menu-border-width--active              : 2px;
     $menu-link-color                        : $color-text;
     $menu-link-padding                      : spacing() spacing(x2);
     $menu-positionTop                       : $menu-headerHeight + spacing(x2);
     $menu--condensed-link-padding           : spacing(x0.5);
-    $menu--expandable-bgColor               : $white;
+    $menu--expandable-bgColor               : $color-white;
     $menu--expandable-borderBottom          : $color-border;
     $menu--expandable-linkFontSize          : body-s;
     $menu--expandable-linkActiveFontSize    : body-l;

--- a/src/scss/components/optional/_modal.scss
+++ b/src/scss/components/optional/_modal.scss
@@ -1,21 +1,20 @@
-/**
- * Components > Item Selector
- * =================================
- * Used on menu pages to display a modal to the user.
- *
- * Example: Menu – When selecting an item.
- *
- * The `c-modal` component is an optional mixin within Fozzie.
- * If you'd like to use it in your project you can include it by adding `@include modal();` into your SCSS dependencies file.
- *
- * Documentation:
- * TBC
- */
-
-$modal-titleFontSize    : body-l !default;
-$modal-borderRadius     : 4px;
-
 @mixin modal() {
+    /**
+    * Components > Item Selector
+    * =================================
+    * Used on menu pages to display a modal to the user.
+    *
+    * Example: Menu – When selecting an item.
+    *
+    * The `c-modal` component is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include modal();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * TBC
+    */
+
+    $modal-titleFontSize    : body-l !default;
+    $modal-borderRadius     : 4px;
 
     .c-modal {
         z-index: zIndex(high);

--- a/src/scss/components/optional/_modal.scss
+++ b/src/scss/components/optional/_modal.scss
@@ -100,13 +100,13 @@
     }
 
         .c-modal-closeBtn--rounded {
-            border: solid 1px $white;
-            background-color: $white;
+            border: solid 1px $color-white;
+            background-color: $color-white;
             border-radius: 50%;
             opacity: 0.9;
 
             &:hover {
-                background-color: $white;
+                background-color: $color-white;
             }
         }
 
@@ -132,7 +132,7 @@
         }
 
     .c-modal-content {
-        background-color: $white;
+        background-color: $color-white;
         border-radius: $modal-borderRadius;
         box-shadow: 0 3px 4px 0 rgba(0, 0, 0, 0.12);
         display: none;
@@ -208,7 +208,7 @@
     }
 
     .c-modal-actions {
-        background-color: $white;
+        background-color: $color-white;
         box-shadow: 0 -2px 4px 0 rgba(0, 0, 0, 0.12);
         bottom: 0;
         padding: spacing(x3);

--- a/src/scss/components/optional/_order-card.scss
+++ b/src/scss/components/optional/_order-card.scss
@@ -20,7 +20,7 @@
         flex-direction: column;
         border-radius: 1px;
         box-shadow: $previousOrder-boxShadow;
-        background-color: $white;
+        background-color: $color-white;
         overflow: hidden;
         text-decoration: none;
         width: 280px;
@@ -37,7 +37,7 @@
         &:focus {
             box-shadow: $previousOrder-hoverBoxShadow;
             text-decoration: none;
-            color: $grey--mid;
+            color: $color-grey-40;
         }
     }
 
@@ -63,7 +63,7 @@
         }
 
         .c-orderCard-image {
-            background-color: $grey--lighter;
+            background-color: $color-grey-20;
         }
     }
 
@@ -102,12 +102,12 @@
         width: 64px;
         height: 64px;
         border-radius: 50%;
-        background-color: $white;
+        background-color: $color-white;
 
         svg {
             width: 40px;
             height: 40px;
-            fill: $brand--orange;
+            fill: $color-orange-30;
         }
     }
 
@@ -116,11 +116,11 @@
         line-height: line-height(16px, 24px);
         font-weight: $font-weight-base;
         @include font-size(22px);
-        color: $blue;
+        color: $color-blue;
         text-align: center;
         margin-top: spacing();
         padding: 2px spacing(x1.5) spacing(x1.5);
-        border-top: 1px solid $grey--offWhite;
+        border-top: 1px solid $color-grey-10;
     }
 
     .c-orderCard-title {
@@ -134,7 +134,7 @@
     .c-orderCard-date {
         margin-top: 0;
         margin-bottom: spacing();
-        color: $grey--mid;
+        color: $color-grey-40;
         display: block;
     }
 
@@ -158,7 +158,7 @@
 
     .c-orderCard-content {
         padding: spacing() spacing(x2) 0;
-        color: $grey--darkest;
+        color: $color-grey;
         flex: 1 0 auto;
         display: flex;
         flex-direction: column;
@@ -174,7 +174,7 @@
     }
 
     .c-orderCard-cuisines {
-        color: $grey--mid;
+        color: $color-grey-40;
         margin-top: 0;
         text-transform: capitalize;
         @include font-size(body-l, false);

--- a/src/scss/components/optional/_order-card.scss
+++ b/src/scss/components/optional/_order-card.scss
@@ -114,7 +114,7 @@
     .c-orderCard-order {
         @include font-size(body-l, false);
         line-height: line-height(16px, 24px);
-        font-weight: $font-weight-base;
+        font-weight: $font-weight-regular;
         @include font-size(22px);
         color: $color-blue;
         text-align: center;

--- a/src/scss/components/optional/_order-card.scss
+++ b/src/scss/components/optional/_order-card.scss
@@ -1,20 +1,20 @@
-/**
-* Components > Order Card
-* =================================
-*
-* Example: Homepage – "Order it Again" block.
-*
-* The `c-orderCard` component is an optional mixin within Fozzie.
-* If you'd like to use it in your project you can include it by adding `@include orderCard();` into your SCSS dependencies file.
-*
-* Documentation:
-* https://fozzie.just-eat.com/styleguide/ui-components/order-card
-*/
-
-$previousOrder-boxShadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
-$previousOrder-hoverBoxShadow: 0 2px 8px 0 rgba(0, 0, 0, 0.16), -2px -2px 4px 0 rgba(0, 0, 0, 0.04), 0 1px 3px 0 rgba(0, 0, 0, 0.12);
-
 @mixin orderCard() {
+    /**
+    * Components > Order Card
+    * =================================
+    *
+    * Example: Homepage – "Order it Again" block.
+    *
+    * The `c-orderCard` component is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include orderCard();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * https://fozzie.just-eat.com/styleguide/ui-components/order-card
+    */
+
+    $previousOrder-boxShadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
+    $previousOrder-hoverBoxShadow: 0 2px 8px 0 rgba(0, 0, 0, 0.16), -2px -2px 4px 0 rgba(0, 0, 0, 0.04), 0 1px 3px 0 rgba(0, 0, 0, 0.12);
+
     .c-orderCard {
         display: flex;
         flex-direction: column;

--- a/src/scss/components/optional/_overflow-carousel.scss
+++ b/src/scss/components/optional/_overflow-carousel.scss
@@ -1,32 +1,17 @@
-/**
- * Components > Overflow Carousel
- * --------------------------------
- * Allows a list of content to be scrolled horizontally
- *
- * Example: Used for mobile filter carousel on the Search Page
- *
- * The `c-overflowCarousel` component is an optional mixin within Fozzie.
- * If you'd like to use it in your project you can include it by adding `@include overflowCarousel();` into your SCSS dependencies file.
- *
- * Documentation:
- * TBC
- */
-
-@mixin overflowCarouselInner() {
-    overflow-x: scroll;
-    overflow-y: hidden;
-    -webkit-overflow-scrolling: touch;
-    width: 100%;
-}
-
-@mixin overflowCarouselContent() {
-    display: inline-flex;
-    white-space: nowrap;
-    padding-left: spacing(x2);
-    padding-right: spacing(x2);
-}
-
 @mixin overflowCarousel() {
+    /**
+    * Components > Overflow Carousel
+    * --------------------------------
+    * Allows a list of content to be scrolled horizontally
+    *
+    * Example: Used for mobile filter carousel on the Search Page
+    *
+    * The `c-overflowCarousel` component is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include overflowCarousel();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * TBC
+    */
 
     .c-overflowCarousel {
         @include media('<mid') {
@@ -97,8 +82,7 @@
 
     .c-overflowCarousel--hideScroll {
         @include media('>=wide') {
-            /* stylelint-disable-next-line property-no-unknown */
-            scrollbar-width: none;
+            scrollbar-width: none; /* stylelint-disable-line property-no-unknown */
         }
     }
 
@@ -108,5 +92,16 @@
     }
 }
 
+@mixin overflowCarouselInner() {
+    overflow-x: scroll;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    width: 100%;
+}
 
-
+@mixin overflowCarouselContent() {
+    display: inline-flex;
+    white-space: nowrap;
+    padding-left: spacing(x2);
+    padding-right: spacing(x2);
+}

--- a/src/scss/components/optional/_page-banner.scss
+++ b/src/scss/components/optional/_page-banner.scss
@@ -1,27 +1,27 @@
-/**
-* Components > Page Banner
-* =================================
-* Page Banners stretch to the full width of their container and contain banner images which typically use a `picture` element.
-* Optionally they can display a white or coloured version of the Just Eat rays at the bottom.
-*
-* Example: Menu – Cuisine image at top of page.
-*
-* The `c-pageBanner` component is an optional mixin within Fozzie.
-* If you'd like to use it in your project you can include it by adding `@include pageBanner();` into your SCSS dependencies file.
-*
-* Documentation:
-* https://fozzie.just-eat.com/styleguide/ui-components/page-banner
-*/
-
-$pageBanner-bg: $white;
-//Vars to use for IE homepage banner rays positioning fix
-$rays--coloured-spacing: 60px;
-$rays--coloured-spacing--mid: 164px;
-$rays--coloured-spacing--wide: 148px;
-$rays--coloured-spacing--huge: 230px;
-
-
 @mixin pageBanner() {
+    /**
+    * Components > Page Banner
+    * =================================
+    * Page Banners stretch to the full width of their container and contain banner images which typically use a `picture` element.
+    * Optionally they can display a white or coloured version of the Just Eat rays at the bottom.
+    *
+    * Example: Menu – Cuisine image at top of page.
+    *
+    * The `c-pageBanner` component is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include pageBanner();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * https://fozzie.just-eat.com/styleguide/ui-components/page-banner
+    */
+
+    $pageBanner-bg: $white;
+    //Vars to use for IE homepage banner rays positioning fix
+    $rays--coloured-spacing: 60px;
+    $rays--coloured-spacing--mid: 164px;
+    $rays--coloured-spacing--wide: 148px;
+    $rays--coloured-spacing--huge: 230px;
+
+
     .c-pageBanner {
         background-color: $pageBanner-bg;
         max-height: 300px;

--- a/src/scss/components/optional/_page-banner.scss
+++ b/src/scss/components/optional/_page-banner.scss
@@ -14,7 +14,7 @@
     * https://fozzie.just-eat.com/styleguide/ui-components/page-banner
     */
 
-    $pageBanner-bg: $white;
+    $pageBanner-bg: $color-white;
     //Vars to use for IE homepage banner rays positioning fix
     $rays--coloured-spacing: 60px;
     $rays--coloured-spacing--mid: 164px;

--- a/src/scss/components/optional/_ratings.scss
+++ b/src/scss/components/optional/_ratings.scss
@@ -1,24 +1,23 @@
-/**
- * Components > Rating
- * =================================
- * Used for displaying restuarant rating stars
- *
- * The `c-rating` component is an optional mixin within Fozzie
- * If you'd like to use it in your project you can include it by adding `@include rating();` into your SCSS dependencies file.
- *
- * Documentation:
- * https://fozzie.just-eat.com/styleguide/ui-components/custom/star-ratings
- */
-
-$star-count                 : 6;
-$star-size--small           : 12px;
-$star-size--default         : 16px;
-$star-size--default--scaleUp: 22px;
-$star-size--medium          : 28px;
-$star-size--large           : 42px;
-
-
 @mixin rating() {
+    /**
+    * Components > Rating
+    * =================================
+    * Used for displaying restuarant rating stars
+    *
+    * The `c-rating` component is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include rating();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * https://fozzie.just-eat.com/styleguide/ui-components/custom/star-ratings
+    */
+
+    $star-count                 : 6;
+    $star-size--small           : 12px;
+    $star-size--default         : 16px;
+    $star-size--default--scaleUp: 22px;
+    $star-size--medium          : 28px;
+    $star-size--large           : 42px;
+
 
     .c-rating {
         @extend %c-icon--star--empty !optional;

--- a/src/scss/components/optional/_toast.scss
+++ b/src/scss/components/optional/_toast.scss
@@ -12,9 +12,9 @@
     */
 
     $toast-radius                           : 8px;
-    $toast-textColor                        : $white;
-    $toast-bgColor--default                 : $grey--darkest;
-    $toast-bgColor--alert                   : $orange--aa;
+    $toast-textColor                        : $color-white;
+    $toast-bgColor--default                 : $color-grey;
+    $toast-bgColor--alert                   : $color-orange-60;
     $toast-animation-duration               : 0.5s;
     $toast-height                           : 95px;
     $toast-translateY                       : -#{$toast-height - 5px};

--- a/src/scss/components/optional/_toast.scss
+++ b/src/scss/components/optional/_toast.scss
@@ -1,90 +1,90 @@
-/**
- * Toast Component
- * =================================
- * Used to display text in a pop-up style notification.
- *
- * *The `c-toast` component is an optional mixin within Fozzie — if you'd like to use it in your project you can include it by adding `@include toast();` into your SCSS dependencies file.*
- *
- * Documentation:
- * https://fozzie.just-eat.com/styleguide/ui-components/toast
- */
-
-$toast-radius                           : 8px;
-$toast-textColor                        : $white;
-$toast-bgColor--default                 : $grey--darkest;
-$toast-bgColor--alert                   : $orange--aa;
-$toast-animation-duration               : 0.5s;
-$toast-height                           : 95px;
-$toast-translateY                       : -#{$toast-height - 5px};
-$toast-height--aboveNarrow              : 115px;
-$toast-translateY--aboveNarrow          : -#{$toast-height--aboveNarrow - 5px};
-$toast-height--aboveMid                 : 115px;
-$toast-translateY--aboveMid             : -#{$toast-height--aboveMid - 5px};
-
 @mixin toast() {
+    /**
+    * Toast Component
+    * =================================
+    * Used to display text in a pop-up style notification.
+    *
+    * The `c-toast` component is an optional mixin within Fozzie.
+    If you'd like to use it in your project you can include it by adding `@include toast();` into your SCSS dependencies file.*
+    *
+    * Documentation:
+    * https://fozzie.just-eat.com/styleguide/ui-components/toast
+    */
 
-        @keyframes toastSlideUp {
-            0% {
-                transform: translateY(0);
-            }
-            100% {
-                transform: translateY($toast-translateY);
-            }
+    $toast-radius                           : 8px;
+    $toast-textColor                        : $white;
+    $toast-bgColor--default                 : $grey--darkest;
+    $toast-bgColor--alert                   : $orange--aa;
+    $toast-animation-duration               : 0.5s;
+    $toast-height                           : 95px;
+    $toast-translateY                       : -#{$toast-height - 5px};
+    $toast-height--aboveNarrow              : 115px;
+    $toast-translateY--aboveNarrow          : -#{$toast-height--aboveNarrow - 5px};
+    $toast-height--aboveMid                 : 115px;
+    $toast-translateY--aboveMid             : -#{$toast-height--aboveMid - 5px};
+
+
+    @keyframes toastSlideUp {
+        0% {
+            transform: translateY(0);
         }
-
-        @keyframes toastSlideUp--aboveNarrow {
-            0% {
-                transform: translateY(0);
-            }
-            100% {
-                transform: translateY($toast-translateY--aboveNarrow);
-            }
-        }
-
-        @keyframes toastSlideUp--aboveMid {
-            0% {
-                transform: translateY(0);
-            }
-            100% {
-                transform: translateY($toast-translateY--aboveMid);
-            }
-        }
-
-        .c-toast {
-            animation: toastSlideUp $toast-animation-duration;
-            background-color: $toast-bgColor--default;
-            border-top-left-radius: $toast-radius;
-            border-top-right-radius: $toast-radius;
-            box-shadow: 0 -3px 4px 0 rgba(0, 0, 0, 0.12);
-            color: $toast-textColor;
-            height: $toast-height;
-            opacity: 0.9;
-            padding: spacing();
-            position: absolute;
-            text-align: center;
+        100% {
             transform: translateY($toast-translateY);
-            width: calc(100% - 16px);
-            z-index: zIndex(low);
+        }
+    }
 
-            @include media('>=narrow') {
-                animation: toastSlideUp--aboveNarrow $toast-animation-duration;
-                height: $toast-height--aboveNarrow;
-                transform: translateY($toast-translateY--aboveNarrow);
-            }
+    @keyframes toastSlideUp--aboveNarrow {
+        0% {
+            transform: translateY(0);
+        }
+        100% {
+            transform: translateY($toast-translateY--aboveNarrow);
+        }
+    }
 
-            @include media('>=mid') {
-                animation: toastSlideUp--aboveMid $toast-animation-duration;
-                height: $toast-height--aboveMid;
-                transform: translateY($toast-translateY--aboveMid);
-            }
+    @keyframes toastSlideUp--aboveMid {
+        0% {
+            transform: translateY(0);
+        }
+        100% {
+            transform: translateY($toast-translateY--aboveMid);
+        }
+    }
 
-            p {
-                margin: 0;
-            }
+    .c-toast {
+        animation: toastSlideUp $toast-animation-duration;
+        background-color: $toast-bgColor--default;
+        border-top-left-radius: $toast-radius;
+        border-top-right-radius: $toast-radius;
+        box-shadow: 0 -3px 4px 0 rgba(0, 0, 0, 0.12);
+        color: $toast-textColor;
+        height: $toast-height;
+        opacity: 0.9;
+        padding: spacing();
+        position: absolute;
+        text-align: center;
+        transform: translateY($toast-translateY);
+        width: calc(100% - 16px);
+        z-index: zIndex(low);
+
+        @include media('>=narrow') {
+            animation: toastSlideUp--aboveNarrow $toast-animation-duration;
+            height: $toast-height--aboveNarrow;
+            transform: translateY($toast-translateY--aboveNarrow);
         }
 
-        .c-toast--alert {
-            background-color: $toast-bgColor--alert;
+        @include media('>=mid') {
+            animation: toastSlideUp--aboveMid $toast-animation-duration;
+            height: $toast-height--aboveMid;
+            transform: translateY($toast-translateY--aboveMid);
         }
 
+        p {
+            margin: 0;
+        }
+    }
+
+    .c-toast--alert {
+        background-color: $toast-bgColor--alert;
+    }
 }

--- a/src/scss/components/optional/_user-message.scss
+++ b/src/scss/components/optional/_user-message.scss
@@ -9,8 +9,8 @@
     */
 
     .c-userMessage {
-        color: $white;
-        background-color: $orange;
+        color: $color-white;
+        background-color: $color-orange;
         max-width: 100%;
         margin-top: spacing(x2);
     }

--- a/src/scss/components/optional/_user-message.scss
+++ b/src/scss/components/optional/_user-message.scss
@@ -1,12 +1,13 @@
-/**
- * User Message Component
- * =================================
- * Used to display the user message banner on the page.
- *
- * *The `c-userMessage` component is an optional mixin within Fozzie — if you'd like to use it in your project you can include it by adding `@include userMessage();` into your SCSS dependencies file.*
- */
-
 @mixin userMessage() {
+    /**
+    * User Message Component
+    * =================================
+    * Used to display the user message banner on the page.
+    *
+    * The `c-userMessage` component is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include userMessage();` into your SCSS dependencies file.
+    */
+
     .c-userMessage {
         color: $white;
         background-color: $orange;

--- a/src/scss/fozzie.scss
+++ b/src/scss/fozzie.scss
@@ -2,5 +2,17 @@
 // fozzie.scss – © JUST EAT
 //
 
+/**
+ * Setting $includeBaseFramework to `true` includes the base styles that were included
+ * as part of Fozzie v4 (useful for anyone upgrading that wants to keep things as-is)
+ **/
+$includeBaseFramework: false !default;
+
+/**
+ * Setting $includeMinimalFramework to `true` includes a recommended base set of styles
+ * that provides styling for most use-cases (links, lists, buttons, grid)
+ **/
+$includeMinimalFramework: false !default;
+
 //import our scss file dependencies
 @import 'dependencies';

--- a/src/scss/objects/_body.scss
+++ b/src/scss/objects/_body.scss
@@ -12,14 +12,14 @@
     */
 
     .o-body--bgWhite {
-        background-color: $white;
+        background-color: $color-white;
     }
 
         .o-body--bgWhite--belowMid {
             background-color: $color-bg;
 
             @include media('<mid') {
-                background-color: $white;
+                background-color: $color-white;
             }
         }
 }

--- a/src/scss/objects/_body.scss
+++ b/src/scss/objects/_body.scss
@@ -1,20 +1,25 @@
-/**
- * Objects > Body styles
- * ===================================
- * Body styles to control the background-color of a page
- *
- * Documentation:
- * TBC
- */
+@mixin bodyStyles() {
+    /**
+    * Objects > Body styles
+    * ===================================
+    * Body styles to control the background-color of a page
+    *
+    * This is an optional component within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include bodyStyles();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * TBC
+    */
 
-.o-body--bgWhite {
-    background-color: $white;
-}
-
-    .o-body--bgWhite--belowMid {
-        background-color: $color-bg;
-
-        @include media('<mid') {
-            background-color: $white;
-        }
+    .o-body--bgWhite {
+        background-color: $white;
     }
+
+        .o-body--bgWhite--belowMid {
+            background-color: $color-bg;
+
+            @include media('<mid') {
+                background-color: $white;
+            }
+        }
+}

--- a/src/scss/objects/_body.scss
+++ b/src/scss/objects/_body.scss
@@ -16,7 +16,7 @@
     }
 
         .o-body--bgWhite--belowMid {
-            background-color: $color-bg;
+            background-color: $color-background-default;
 
             @include media('<mid') {
                 background-color: $color-white;

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -10,49 +10,49 @@
     * https://fozzie.just-eat.com/styleguide/ui-components/buttons
     */
 
-    $btn-default-bgColor                : $grey--lighter;
+    $btn-default-bgColor                : $color-grey-20;
     $btn-default-weight                 : 600;
     $btn-default-height                 : 2.6;
     $btn-default-font-size              : 18;
     $btn-default-font-family            : $font-family-base;
-    $btn-default-bgColor--hover         : $grey--light;
+    $btn-default-bgColor--hover         : $color-grey-30;
     $btn-default-borderRadius           : 2px;
     $btn-default-hozPadding             : 1em;
     $btn-default-vertPadding            : 11px;
 
-    $btn-primary-bgColor                : $orange;
-    $btn-primary-bgColor--hover         : $orange--dark;
-    $btn-primary-bgColor--focus         : $orange--darkest;
-    $btn-primary-textColor              : $white;
+    $btn-primary-bgColor                : $color-orange;
+    $btn-primary-bgColor--hover         : darken($color-orange, $color-hover-01);
+    $btn-primary-bgColor--focus         : darken($color-orange, $color-active-01);
+    $btn-primary-textColor              : $color-white;
 
-    $btn-secondary-bgColor              : $blue--offWhite;
-    $btn-secondary-bgColor--hover       : $blue--offWhite--dark;
-    $btn-secondary-bgColor--active      : $blue--offWhite--darkest;
-    $btn-secondary-textColor            : $blue;
-    $btn-secondary-textColor--hover     : $blue;
-    $btn-secondary-textColor--active    : $blue;
+    $btn-secondary-bgColor              : $color-blue-10;
+    $btn-secondary-bgColor--hover       : darken($color-blue-10, $color-hover-01);
+    $btn-secondary-bgColor--active      : darken($color-blue-10, $color-active-01);
+    $btn-secondary-textColor            : $color-blue;
+    $btn-secondary-textColor--hover     : $color-blue;
+    $btn-secondary-textColor--active    : $color-blue;
 
-    $btn-tertiary-bgColor              : $white;
-    $btn-tertiary-bgColor--hover       : $grey--light;
-    $btn-tertiary-bgColor--active      : $grey--mid;
-    $btn-tertiary-textColor            : $blue;
-    $btn-tertiary-textColor--hover     : $blue;
-    $btn-tertiary-textColor--active    : $blue;
+    $btn-tertiary-bgColor              : $color-white;
+    $btn-tertiary-bgColor--hover       : $color-grey-30;
+    $btn-tertiary-bgColor--active      : $color-grey-40;
+    $btn-tertiary-textColor            : $color-blue;
+    $btn-tertiary-textColor--hover     : $color-blue;
+    $btn-tertiary-textColor--active    : $color-blue;
 
     $btn-wide-hozPadding                : 2em;
 
-    $btn-disabled-bgColor               : $grey--light;
+    $btn-disabled-bgColor               : $color-grey-30;
 
-    $btn-transparent-color              : $red;
-    $btn-transparent-color--hover       : $grey--mid;
+    $btn-transparent-color              : $color-red;
+    $btn-transparent-color--hover       : $color-grey-40;
 
-    $btnGroup-outline-textColor         : $grey--dark;
-    $btnGroup-outline-border            : $grey--light;
+    $btnGroup-outline-textColor         : $color-grey-50;
+    $btnGroup-outline-border            : $color-grey-30;
     $btnGroup-outline-active-border     : $color-secondary;
     $btnGroup-outline-active-text-color : $color-secondary;
 
-    $btnToggle-bg                       : $grey--lighter;
-    $btnToggle-bg--active               : $white;
+    $btnToggle-bg                       : $color-grey-20;
+    $btnToggle-bg--active               : $color-white;
     $btnToggle-padding                  : 5px;
 
     $btn-icon-dimension                 : 36px;
@@ -92,7 +92,7 @@
         border: 1px solid transparent;
         user-select: none;
 
-        color: $grey--dark;
+        color: $color-grey-50;
         text-decoration: none;
 
         &:hover,

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -48,8 +48,8 @@
 
     $btnGroup-outline-textColor         : $color-grey-50;
     $btnGroup-outline-border            : $color-grey-30;
-    $btnGroup-outline-active-border     : $color-secondary;
-    $btnGroup-outline-active-text-color : $color-secondary;
+    $btnGroup-outline-active-border     : $color-blue;
+    $btnGroup-outline-active-text-color : $color-blue;
 
     $btnToggle-bg                       : $color-grey-20;
     $btnToggle-bg--active               : $color-white;

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -315,18 +315,18 @@
         background-color: transparent;
         padding: 0;
         margin: 0;
-        color: $color-link-default;
+        color: $color-content-link;
         font-weight: 500;
         text-decoration: underline;
 
         &:hover {
             cursor: pointer;
-            color: $color-link-hover;
+            color: darken($color-content-link, $color-hover-01);
             background-color: transparent;
         }
         &:active,
         &:focus {
-            color: $color-link-active;
+            color: darken($color-content-link, $color-active-02);
             background-color: transparent;
         }
     }

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -48,7 +48,7 @@
 
     $btnGroup-outline-textColor         : $color-grey-50;
     $btnGroup-outline-border            : $color-grey-30;
-    $btnGroup-outline-active-border     : $color-blue;
+    $btnGroup-outline-active-border     : $color-interactive-primary;
     $btnGroup-outline-active-text-color : $color-blue;
 
     $btnToggle-bg                       : $color-grey-20;

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -1,334 +1,333 @@
-/**
- * Objects > Buttons
- * =================================
- *
- * Documentation:
- * https://fozzie.just-eat.com/styleguide/ui-components/buttons
- */
+@mixin buttons() {
+    /**
+    * Objects > Buttons
+    * =================================
+    *
+    * This is an optional component within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include buttons();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * https://fozzie.just-eat.com/styleguide/ui-components/buttons
+    */
 
+    $btn-default-bgColor                : $grey--lighter;
+    $btn-default-weight                 : 600;
+    $btn-default-height                 : 2.6;
+    $btn-default-font-size              : 18;
+    $btn-default-font-family            : $font-family-base;
+    $btn-default-bgColor--hover         : $grey--light;
+    $btn-default-borderRadius           : 2px;
+    $btn-default-hozPadding             : 1em;
+    $btn-default-vertPadding            : 11px;
 
-/**
- * Define associated Button variables
- */
+    $btn-primary-bgColor                : $orange;
+    $btn-primary-bgColor--hover         : $orange--dark;
+    $btn-primary-bgColor--focus         : $orange--darkest;
+    $btn-primary-textColor              : $white;
 
-$btn-default-bgColor                : $grey--lighter;
-$btn-default-weight                 : 600;
-$btn-default-height                 : 2.6;
-$btn-default-font-size              : 18;
-$btn-default-font-family            : $font-family-base;
-$btn-default-bgColor--hover         : $grey--light;
-$btn-default-borderRadius           : 2px;
-$btn-default-hozPadding             : 1em;
-$btn-default-vertPadding            : 11px;
+    $btn-secondary-bgColor              : $blue--offWhite;
+    $btn-secondary-bgColor--hover       : $blue--offWhite--dark;
+    $btn-secondary-bgColor--active      : $blue--offWhite--darkest;
+    $btn-secondary-textColor            : $blue;
+    $btn-secondary-textColor--hover     : $blue;
+    $btn-secondary-textColor--active    : $blue;
 
-$btn-primary-bgColor                : $orange;
-$btn-primary-bgColor--hover         : $orange--dark;
-$btn-primary-bgColor--focus         : $orange--darkest;
-$btn-primary-textColor              : $white;
+    $btn-tertiary-bgColor              : $white;
+    $btn-tertiary-bgColor--hover       : $grey--light;
+    $btn-tertiary-bgColor--active      : $grey--mid;
+    $btn-tertiary-textColor            : $blue;
+    $btn-tertiary-textColor--hover     : $blue;
+    $btn-tertiary-textColor--active    : $blue;
 
-$btn-secondary-bgColor              : $blue--offWhite;
-$btn-secondary-bgColor--hover       : $blue--offWhite--dark;
-$btn-secondary-bgColor--active      : $blue--offWhite--darkest;
-$btn-secondary-textColor            : $blue;
-$btn-secondary-textColor--hover     : $blue;
-$btn-secondary-textColor--active    : $blue;
+    $btn-wide-hozPadding                : 2em;
 
-$btn-tertiary-bgColor              : $white;
-$btn-tertiary-bgColor--hover       : $grey--light;
-$btn-tertiary-bgColor--active      : $grey--mid;
-$btn-tertiary-textColor            : $blue;
-$btn-tertiary-textColor--hover     : $blue;
-$btn-tertiary-textColor--active    : $blue;
+    $btn-disabled-bgColor               : $grey--light;
 
-$btn-wide-hozPadding                : 2em;
+    $btn-transparent-color              : $red;
+    $btn-transparent-color--hover       : $grey--mid;
 
-$btn-disabled-bgColor               : $grey--light;
+    $btnGroup-outline-textColor         : $grey--dark;
+    $btnGroup-outline-border            : $grey--light;
+    $btnGroup-outline-active-border     : $color-secondary;
+    $btnGroup-outline-active-text-color : $color-secondary;
 
-$btn-transparent-color              : $red;
-$btn-transparent-color--hover       : $grey--mid;
+    $btnToggle-bg                       : $grey--lighter;
+    $btnToggle-bg--active               : $white;
+    $btnToggle-padding                  : 5px;
 
-$btnGroup-outline-textColor         : $grey--dark;
-$btnGroup-outline-border            : $grey--light;
-$btnGroup-outline-active-border     : $color-secondary;
-$btnGroup-outline-active-text-color : $color-secondary;
+    $btn-icon-dimension                 : 36px;
+    $btn-icon-dimension--small          : 20px;
+    $btn-rounded-width                  : 38px;
 
-$btnToggle-bg                       : $grey--lighter;
-$btnToggle-bg--active               : $white;
-$btnToggle-padding                  : 5px;
+    /**
+    * Base button styles – Based on csswizardry.com/beautons
+    *
+    * 1. Allow us to better style box model properties.
+    * 2. Line different sized buttons up a little nicer.
+    * 3. Make buttons inherit font styles.
+    * 4. Force all elements using beautons to appear clickable.
+    * 5. Normalise box model styles.
+    * 6. If the button’s text is 1em, and the button is (3 * font-size) tall, then
+    *    there is 1em of space above and below that text. We therefore apply 1em
+    *    of space to the left and right, as padding, to keep consistent spacing.
+    * 7. Fixes odd inner spacing in IE7.
+    */
 
-$btn-icon-dimension                 : 36px;
-$btn-icon-dimension--small          : 20px;
-$btn-rounded-width                  : 38px;
+    .o-btn {
+        display: inline-block;                      /* [1] */
+        vertical-align: middle;                     /* [2] */
+        font-family: $btn-default-font-family;      /* [3] */
+        @include font-size($btn-default-font-size); /* [3] */
+        cursor: pointer;                            /* [4] */
+        margin: 0;                                  /* [5] */
+        padding: $btn-default-vertPadding $btn-default-hozPadding; /* [5, 6] */
+        overflow: visible;                          /* [7] */
+        text-align: center;
+        font-weight: $btn-default-weight;
+        line-height: 1;
 
+        // You may want to change this
+        background-color: $btn-default-bgColor;
+        border-radius: $btn-default-borderRadius;
+        border: 1px solid transparent;
+        user-select: none;
 
-/**
- * Base button styles – Based on csswizardry.com/beautons
- *
- * 1. Allow us to better style box model properties.
- * 2. Line different sized buttons up a little nicer.
- * 3. Make buttons inherit font styles.
- * 4. Force all elements using beautons to appear clickable.
- * 5. Normalise box model styles.
- * 6. If the button’s text is 1em, and the button is (3 * font-size) tall, then
- *    there is 1em of space above and below that text. We therefore apply 1em
- *    of space to the left and right, as padding, to keep consistent spacing.
- * 7. Fixes odd inner spacing in IE7.
- */
+        color: $grey--dark;
+        text-decoration: none;
 
-.o-btn {
-    display: inline-block;                      /* [1] */
-    vertical-align: middle;                     /* [2] */
-    font-family: $btn-default-font-family;      /* [3] */
-    @include font-size($btn-default-font-size); /* [3] */
-    cursor: pointer;                            /* [4] */
-    margin: 0;                                  /* [5] */
-    padding: $btn-default-vertPadding $btn-default-hozPadding; /* [5, 6] */
-    overflow: visible;                          /* [7] */
-    text-align: center;
-    font-weight: $btn-default-weight;
-    line-height: 1;
+        &:hover,
+        &:active,
+        &:focus {
+            background-color: $btn-default-bgColor--hover;
 
-    // You may want to change this
-    background-color: $btn-default-bgColor;
-    border-radius: $btn-default-borderRadius;
-    border: 1px solid transparent;
-    user-select: none;
+            &:not(.o-btnLink) {
+                outline: none; // no need as already has a focus/active state
+            }
+        }
 
-    color: $grey--dark;
-    text-decoration: none;
+        &,
+        &:hover,
+        &:active,
+        &:focus,
+        &:visited {
+            text-decoration: none;
+        }
 
-    &:hover,
-    &:active,
-    &:focus {
-        background-color: $btn-default-bgColor--hover;
+        // Disabled state
+        &.disabled,
+        &[disabled] {
+            cursor: default;
 
-        &:not(.o-btnLink) {
-            outline: none; // no need as already has a focus/active state
+            &,
+            &:hover {
+                background-color: $btn-disabled-bgColor;
+            }
+        }
+
+        p + & {
+            margin-top: spacing(x2);
+        }
+
+        & .note {
+            display: none;
+
+            @include media('>=mid') {
+                display: block;
+            }
+        }
+        &[type='submit'] {
+            margin-top: spacing(x2);
         }
     }
 
-    &,
-    &:hover,
-    &:active,
-    &:focus,
-    &:visited {
-        text-decoration: none;
+    /**
+    * ==========================================================================
+    * Btn Background Colour modifiers
+    * ==========================================================================
+    */
+
+    /**
+    * Modifier – .o-btn--primary
+    *
+    * Sets the btn colour to site primary colour
+    */
+
+    .o-btn--primary {
+        background-color: $btn-primary-bgColor;
+
+        &,
+        &:link,
+        &:visited {
+            color: $btn-primary-textColor;
+        }
+
+        &:hover,
+        &:active,
+        &:focus {
+            color: $btn-primary-textColor;
+        }
+
+        &:hover {
+            background-color: $btn-primary-bgColor--hover;
+        }
+
+        &:active,
+        &:focus {
+            background-color: $btn-primary-bgColor--focus;
+        }
     }
 
-    // Disabled state
-    &.disabled,
-    &[disabled] {
+    /**
+    * Modifier – .o-btn--secondary
+    *
+    * Accompanying secondary style button (knocked back slightly from the primary button)
+    */
+
+    .o-btn--secondary {
+        background-color: $btn-secondary-bgColor;
+        color: $btn-secondary-textColor;
+
+        &:hover {
+            background-color: $btn-secondary-bgColor--hover;
+            color: $btn-secondary-textColor--hover;
+        }
+
+        &:active,
+        &:focus {
+            background-color: $btn-secondary-bgColor--active;
+            color: $btn-secondary-textColor--active;
+            outline: none;
+        }
+    }
+
+    /**
+    * Modifier – .o-btn--tertiary
+    *
+    * Accompanying button that can be used on solid background colours (such as grey)
+    */
+
+    .o-btn--tertiary {
+        background-color: $btn-tertiary-bgColor;
+        color: $btn-tertiary-textColor;
+
+        &:hover {
+            background-color: $btn-tertiary-bgColor--hover;
+            color: $btn-tertiary-textColor--hover;
+        }
+
+        &:active,
+        &:focus {
+            background-color: $btn-tertiary-bgColor--active;
+            color: $btn-tertiary-textColor--active;
+            outline: none;
+        }
+    }
+
+
+    /**
+    * ==========================================================================
+    * Btn Layout Modifiers
+    * ==========================================================================
+    */
+
+    /**
+    * Modifier – btn-block
+    *
+    * Makes the btn full width
+    */
+
+    .o-btn--block {
+        display: block;
+        width: 100%;
+        padding-left: 0;
+        padding-right: 0;
+
+        // Vertically space out multiple block buttons
+        // same as .o-btn--block + .o-btn--block
+        & + & {
+            margin-top: 10px;
+        }
+    }
+
+    .o-btn--wide {
+        padding-left: $btn-wide-hozPadding;
+        padding-right: $btn-wide-hozPadding;
+    }
+
+    //remove uneeded styles (like colours) from a button when only an icon is on it (like a close button)
+    .o-btn--icon {
+        @extend %u-ir;
+        background-color: transparent;
+        padding: 0;
+
+        &:hover { background-color: transparent; }
+    }
+
+
+    // Specificity overrides
+    input[type='submit'],
+    input[type='reset'],
+    input[type='button'] {
+        &.o-btn--block {
+            width: 100%;
+        }
+    }
+
+
+    /**
+    * Disabled button
+    */
+
+    .o-btn--disabled {
         cursor: default;
 
         &,
-        &:hover {
+        &:hover,
+        &:active,
+        &:focus {
             background-color: $btn-disabled-bgColor;
+            color: inherit;
         }
     }
 
-    p + & {
-        margin-top: spacing(x2);
+    /**
+    * Loading state
+    */
+
+    .o-btn.is-loading {
+    background: url('//dy3erx8o0a6nh.cloudfront.net/images/icon_loader_arrow.gif') 50% 50% / 20px 20px no-repeat border-box $btn-disabled-bgColor;
+    color: transparent !important;
+    border-radius: 0; /* Fixes rendering bug in Chrome for Android */
     }
 
-    & .note {
-        display: none;
 
-        @include media('>=mid') {
-            display: block;
+    /**
+    * btnLink
+    *
+    * Make a button visually look like a default link
+    * Useful when we semantically want a button but don’t want all the default styling
+    *
+    * Should only be applied to buttons
+    */
+
+    .o-btnLink {
+        border: 0;
+        background-color: transparent;
+        padding: 0;
+        margin: 0;
+        color: $color-link-default;
+        font-weight: 500;
+        text-decoration: underline;
+
+        &:hover {
+            cursor: pointer;
+            color: $color-link-hover;
+            background-color: transparent;
+        }
+        &:active,
+        &:focus {
+            color: $color-link-active;
+            background-color: transparent;
         }
     }
-    &[type='submit'] {
-        margin-top: spacing(x2);
-    }
-}
-
-/**
- * ==========================================================================
- * Btn Background Colour modifiers
- * ==========================================================================
- */
-
-/**
- * Modifier – .o-btn--primary
- *
- * Sets the btn colour to site primary colour
- */
-
-.o-btn--primary {
-    background-color: $btn-primary-bgColor;
-
-    &,
-    &:link,
-    &:visited {
-        color: $btn-primary-textColor;
-    }
-
-    &:hover,
-    &:active,
-    &:focus {
-        color: $btn-primary-textColor;
-    }
-
-    &:hover {
-        background-color: $btn-primary-bgColor--hover;
-    }
-
-    &:active,
-    &:focus {
-        background-color: $btn-primary-bgColor--focus;
-    }
-}
-
-/**
- * Modifier – .o-btn--secondary
- *
- * Accompanying secondary style button (knocked back slightly from the primary button)
- */
-
-.o-btn--secondary {
-    background-color: $btn-secondary-bgColor;
-    color: $btn-secondary-textColor;
-
-    &:hover {
-        background-color: $btn-secondary-bgColor--hover;
-        color: $btn-secondary-textColor--hover;
-    }
-
-    &:active,
-    &:focus {
-        background-color: $btn-secondary-bgColor--active;
-        color: $btn-secondary-textColor--active;
-        outline: none;
-    }
-}
-
-/**
- * Modifier – .o-btn--tertiary
- *
- * Accompanying button that can be used on solid background colours (such as grey)
- */
-
-.o-btn--tertiary {
-    background-color: $btn-tertiary-bgColor;
-    color: $btn-tertiary-textColor;
-
-    &:hover {
-        background-color: $btn-tertiary-bgColor--hover;
-        color: $btn-tertiary-textColor--hover;
-    }
-
-    &:active,
-    &:focus {
-        background-color: $btn-tertiary-bgColor--active;
-        color: $btn-tertiary-textColor--active;
-        outline: none;
-    }
-}
-
-
-/**
- * ==========================================================================
- * Btn Layout Modifiers
- * ==========================================================================
- */
-
-/**
- * Modifier – btn-block
- *
- * Makes the btn full width
- */
-
-.o-btn--block {
-    display: block;
-    width: 100%;
-    padding-left: 0;
-    padding-right: 0;
-
-    // Vertically space out multiple block buttons
-    // same as .o-btn--block + .o-btn--block
-    & + & {
-        margin-top: 10px;
-    }
-}
-
-.o-btn--wide {
-    padding-left: $btn-wide-hozPadding;
-    padding-right: $btn-wide-hozPadding;
-}
-
-//remove uneeded styles (like colours) from a button when only an icon is on it (like a close button)
-.o-btn--icon {
-    @extend %u-ir;
-    background-color: transparent;
-    padding: 0;
-
-    &:hover { background-color: transparent; }
-}
-
-
-// Specificity overrides
-input[type='submit'],
-input[type='reset'],
-input[type='button'] {
-    &.o-btn--block {
-        width: 100%;
-    }
-}
-
-
-/**
- * Disabled button
- */
-
-.o-btn--disabled {
-    cursor: default;
-
-    &,
-    &:hover,
-    &:active,
-    &:focus {
-        background-color: $btn-disabled-bgColor;
-        color: inherit;
-    }
-}
-
-/**
- * Loading state
- */
-
-.o-btn.is-loading {
-  background: url('//dy3erx8o0a6nh.cloudfront.net/images/icon_loader_arrow.gif') 50% 50% / 20px 20px no-repeat border-box $btn-disabled-bgColor;
-  color: transparent !important;
-  border-radius: 0; /* Fixes rendering bug in Chrome for Android */
-}
-
-
-/**
- * btnLink
- *
- * Make a button visually look like a default link
- * Useful when we semantically want a button but don’t want all the default styling
- *
- * Should only be applied to buttons
- */
-
-.o-btnLink {
-    border: 0;
-    background-color: transparent;
-    padding: 0;
-    margin: 0;
-    color: $color-link-default;
-    font-weight: 500;
-    text-decoration: underline;
-
-    &:hover {
-        cursor: pointer;
-        color: $color-link-hover;
-        background-color: transparent;
-    }
-    &:active,
-    &:focus {
-        color: $color-link-active;
-        background-color: transparent;
-    }
-}
+ }

--- a/src/scss/objects/_form-controls.scss
+++ b/src/scss/objects/_form-controls.scss
@@ -1,240 +1,245 @@
-/**
- * Objects > Checkboxes and radios
- * =================================
- * Custom Checkbox and Radio button styling
- *
- * Documentation:
- * https://fozzie.just-eat.com/styleguide/ui-components/forms/checkboxes
- * https://fozzie.just-eat.com/styleguide/ui-components/forms/radio-buttons
- * --------------------------------
- *
- * Checkbox button example HTML
- *
- *    <label class="o-formControl-label" for="checkbox1">
- *        <input class="o-formControl-input" type="checkbox" id="checkbox1" name="myCheckbox" value="A value"/>
- *        <span class="o-formControl-indicator o-formControl-indicator--checkbox"></span>
- *        My Checkbox Label Text
- *    </label>
- *
- * -------------------------------
- *
- * Radio button example HTML
- *
- *    <label class="o-formControl-label" for="radio1">
- *        <input class="o-formControl-input" type="radio" id="radio1" name="myRadioBtn" value="A value"/>
- *        <span class="o-formControl-indicator o-formControl-indicator--radio"></span>
- *        My Radio Button Label Text
- *     </label>
- *
- */
+@mixin formControls() {
+    /**
+    * Objects > Checkboxes and radios
+    * =================================
+    * Custom Checkbox and Radio button styling
+    *
+    * This is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include formControls();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * https://fozzie.just-eat.com/styleguide/ui-components/forms/checkboxes
+    * https://fozzie.just-eat.com/styleguide/ui-components/forms/radio-buttons
+    * --------------------------------
+    *
+    * Checkbox button example HTML
+    *
+    *    <label class="o-formControl-label" for="checkbox1">
+    *        <input class="o-formControl-input" type="checkbox" id="checkbox1" name="myCheckbox" value="A value"/>
+    *        <span class="o-formControl-indicator o-formControl-indicator--checkbox"></span>
+    *        My Checkbox Label Text
+    *    </label>
+    *
+    * -------------------------------
+    *
+    * Radio button example HTML
+    *
+    *    <label class="o-formControl-label" for="radio1">
+    *        <input class="o-formControl-input" type="radio" id="radio1" name="myRadioBtn" value="A value"/>
+    *        <span class="o-formControl-indicator o-formControl-indicator--radio"></span>
+    *        My Radio Button Label Text
+    *     </label>
+    *
+    */
 
- $formControl-bgColor            : $white !default;
- $formControl-bgColor--disabled  : $color-disabled !default;
- $formControl-borderColor        : $color-border !default;
- $formControl-borderColor--hover : $orange !default;
- $formControl-color              : $orange !default;
- $formControl-color--hover       : $orange--dark !default;
- $formControl-background-color   : $color-bg !default;
- $formControl-margin-left        : 0 !default;
- $formControl-padding-left       : spacing(x4) !default;
- $formControl-width              : 24px !default;
- $formControl-width--wide        : 20px !default;
- $formControl-height             : 24px !default;
- $formControl-height--wide       : 20px !default;
- $formControl-border-width       : 1px;
-
-
- .o-formControl-label {
-     position: relative;
-     display: block;
-     cursor: pointer;
-     user-select: none;
-     padding: spacing();
-     padding-left: $formControl-padding-left;
-
-     &:hover .o-formControl-indicator {
-         border-color: $formControl-borderColor--hover;
-     }
-
-     &:hover .o-formControl-input:disabled ~ .o-formControl-indicator {
-         border-color: $formControl-borderColor;
-         cursor: not-allowed;
-     }
-
-     .o-formControl-input:disabled ~ .o-formControl-indicator {
-        background-color: $formControl-bgColor--disabled;
-     }
- }
-
- // Give inline elements some space to the right
- .o-formControl-label--inline {
-     display: inline-block;
-     padding-right: 2em;
- }
-
-     // Hide the input element from view
-     .o-formControl-input {
-         position: absolute;
-         opacity: 0;
-         z-index: zIndex(lowest); // Put the input behind the label so it doesn't overlay text
-
-         &:focus {
-             & + .o-formControl-indicator { @extend %u-elementFocus; }
-             & ~ .o-formControl-text { @extend %u-elementFocus; }
-         }
-     }
-
-     // The new checkbox/radio
-     .o-formControl-indicator {
-         position: absolute;
-         left: 0;
-         display: inline-block;
-         width: $formControl-width;
-         height: $formControl-height;
-         border: $formControl-border-width solid $grey--light;
-         background-color: $formControl-bgColor;
-         vertical-align: middle;
-         margin-left: $formControl-margin-left;
-         margin-top: 0;
-         box-shadow: 0 0 0 2px transparent, 0 0 0 0 transparent; // Used to animate from when element is in :focus
-
-         @include media('>=mid') {
-             width: $formControl-width--wide;
-             height: $formControl-height--wide;
-         }
-     }
-
-     // Checkbox modifiers
-     .o-formControl-indicator--checkbox,
-     .o-formControl-indicator--tickbox {
-         border-radius: 0.2em; // Change to 50% to make them circular
-
-         &:before,
-         &:after {
-             content: '';
-             position: absolute;
-             top: 50%;
-             left: 50%;
-             width: 90%;
-             display: block;
-             opacity: 0; // indicator will be faded out when deselected
-             transition: all 250ms ease-in-out;
-         }
-     }
-
-     .o-formControl-indicator--checkbox {
-         &:before,
-         &:after {
-             top: 50%;
-             width: 90%;
-             height: 0.1em;
-             background-color: $formControl-background-color;
-         }
-
-         &:before {
-             transform: translate(-50%, -50%) rotate(45deg) scale(0);
-         }
-
-         &:after {
-             transform: translate(-50%, -50%) rotate(-45deg) scale(0);
-         }
-     }
-
-     .o-formControl-icon {
-         background-position: center 0;
-         left: spacing();
-         min-width: spacing(x1.5);
-         position: absolute;
-     }
-
-     .o-formControl-indicator--tickbox {
-         &:before {
-             top: 0;
-             transform: translateX(-50%) rotate(45deg) scale(0);
-             border: 2px solid $formControl-background-color;
-             background-color: transparent;
-             width: 40%;
-             height: 80%;
-             border-top: 0;
-             border-left: 0;
-         }
-
-         &:after {
-             display: none;
-         }
-     }
-
-     .o-formControl-input:checked ~ .o-formControl-indicator--checkbox,
-     .o-formControl-input:checked ~ .o-formControl-indicator--tickbox,
-     .o-formControl-input:checked ~ .o-formControl-indicator--radio {
-
-         label:hover & {
-             background-color: $formControl-color--hover;
-             border-color: $formControl-color--hover;
-         }
-     }
-
-     .o-formControl-input:checked ~ .o-formControl-indicator--checkbox,
-     .o-formControl-input:checked ~ .o-formControl-indicator--tickbox {
-         background-color: $formControl-color;
-         border: 3px solid $formControl-color;
-
-         &:before,
-         &:after {
-             opacity: 1;
-         }
-     }
-
-     .o-formControl-input:checked ~ .o-formControl-indicator--tickbox {
-         &:before,
-         &:after {
-             transform: translateX(-50%) rotate(45deg) scale(1);
-         }
-     }
-
-     .o-formControl-input:checked ~ .o-formControl-indicator--checkbox {
-         &:before {
-             transform: translate(-50%, -50%) rotate(45deg) scale(1);
-         }
-
-         &:after {
-             transform: translate(-50%, -50%) rotate(-45deg) scale(1);
-         }
-     }
+    $formControl-bgColor            : $white !default;
+    $formControl-bgColor--disabled  : $color-disabled !default;
+    $formControl-borderColor        : $color-border !default;
+    $formControl-borderColor--hover : $orange !default;
+    $formControl-color              : $orange !default;
+    $formControl-color--hover       : $orange--dark !default;
+    $formControl-background-color   : $color-bg !default;
+    $formControl-margin-left        : 0 !default;
+    $formControl-padding-left       : spacing(x4) !default;
+    $formControl-width              : 24px !default;
+    $formControl-width--wide        : 20px !default;
+    $formControl-height             : 24px !default;
+    $formControl-height--wide       : 20px !default;
+    $formControl-border-width       : 1px;
 
 
-     // Radio modifiers
-     .o-formControl-indicator--radio {
-         border-radius: 50%;
+    .o-formControl-label {
+        position: relative;
+        display: block;
+        cursor: pointer;
+        user-select: none;
+        padding: spacing();
+        padding-left: $formControl-padding-left;
 
-         // add a margin to align the radio where the line height is 1.6 as opposed to 1.2
-         @include media('<wide') {
-             margin-top: 2px;
-         }
+        &:hover .o-formControl-indicator {
+            border-color: $formControl-borderColor--hover;
+        }
 
-         @include media('<=mid') {
-            margin-top: -2px;
-         }
-     }
+        &:hover .o-formControl-input:disabled ~ .o-formControl-indicator {
+            border-color: $formControl-borderColor;
+            cursor: not-allowed;
+        }
 
-     .o-formControl-input:checked ~ .o-formControl-indicator--radio {
-         background-color: $formControl-color;
-         border: 6px solid $formControl-borderColor;
+        .o-formControl-input:disabled ~ .o-formControl-indicator {
+            background-color: $formControl-bgColor--disabled;
+        }
+    }
 
-         &:before {
-             content: '';
-             background-color: $formControl-color;
-             border: 3px solid $grey--lighter;
-             border-radius: 50%;
-             width: $formControl-width - 2;
-             height: $formControl-height - 2;
-             position: absolute;
-             top: -5px;
-             left: -5px;
+    // Give inline elements some space to the right
+    .o-formControl-label--inline {
+        display: inline-block;
+        padding-right: 2em;
+    }
 
-             @include media('>=mid') {
-                 width: $formControl-width--wide - 2;
-                 height: $formControl-height--wide - 2;
-             }
-         }
-     }
+        // Hide the input element from view
+        .o-formControl-input {
+            position: absolute;
+            opacity: 0;
+            z-index: zIndex(lowest); // Put the input behind the label so it doesn't overlay text
+
+            &:focus {
+                & + .o-formControl-indicator { @extend %u-elementFocus; }
+                & ~ .o-formControl-text { @extend %u-elementFocus; }
+            }
+        }
+
+        // The new checkbox/radio
+        .o-formControl-indicator {
+            position: absolute;
+            left: 0;
+            display: inline-block;
+            width: $formControl-width;
+            height: $formControl-height;
+            border: $formControl-border-width solid $grey--light;
+            background-color: $formControl-bgColor;
+            vertical-align: middle;
+            margin-left: $formControl-margin-left;
+            margin-top: 0;
+            box-shadow: 0 0 0 2px transparent, 0 0 0 0 transparent; // Used to animate from when element is in :focus
+
+            @include media('>=mid') {
+                width: $formControl-width--wide;
+                height: $formControl-height--wide;
+            }
+        }
+
+        // Checkbox modifiers
+        .o-formControl-indicator--checkbox,
+        .o-formControl-indicator--tickbox {
+            border-radius: 0.2em; // Change to 50% to make them circular
+
+            &:before,
+            &:after {
+                content: '';
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                width: 90%;
+                display: block;
+                opacity: 0; // indicator will be faded out when deselected
+                transition: all 250ms ease-in-out;
+            }
+        }
+
+        .o-formControl-indicator--checkbox {
+            &:before,
+            &:after {
+                top: 50%;
+                width: 90%;
+                height: 0.1em;
+                background-color: $formControl-background-color;
+            }
+
+            &:before {
+                transform: translate(-50%, -50%) rotate(45deg) scale(0);
+            }
+
+            &:after {
+                transform: translate(-50%, -50%) rotate(-45deg) scale(0);
+            }
+        }
+
+        .o-formControl-icon {
+            background-position: center 0;
+            left: spacing();
+            min-width: spacing(x1.5);
+            position: absolute;
+        }
+
+        .o-formControl-indicator--tickbox {
+            &:before {
+                top: 0;
+                transform: translateX(-50%) rotate(45deg) scale(0);
+                border: 2px solid $formControl-background-color;
+                background-color: transparent;
+                width: 40%;
+                height: 80%;
+                border-top: 0;
+                border-left: 0;
+            }
+
+            &:after {
+                display: none;
+            }
+        }
+
+        .o-formControl-input:checked ~ .o-formControl-indicator--checkbox,
+        .o-formControl-input:checked ~ .o-formControl-indicator--tickbox,
+        .o-formControl-input:checked ~ .o-formControl-indicator--radio {
+
+            label:hover & {
+                background-color: $formControl-color--hover;
+                border-color: $formControl-color--hover;
+            }
+        }
+
+        .o-formControl-input:checked ~ .o-formControl-indicator--checkbox,
+        .o-formControl-input:checked ~ .o-formControl-indicator--tickbox {
+            background-color: $formControl-color;
+            border: 3px solid $formControl-color;
+
+            &:before,
+            &:after {
+                opacity: 1;
+            }
+        }
+
+        .o-formControl-input:checked ~ .o-formControl-indicator--tickbox {
+            &:before,
+            &:after {
+                transform: translateX(-50%) rotate(45deg) scale(1);
+            }
+        }
+
+        .o-formControl-input:checked ~ .o-formControl-indicator--checkbox {
+            &:before {
+                transform: translate(-50%, -50%) rotate(45deg) scale(1);
+            }
+
+            &:after {
+                transform: translate(-50%, -50%) rotate(-45deg) scale(1);
+            }
+        }
+
+
+        // Radio modifiers
+        .o-formControl-indicator--radio {
+            border-radius: 50%;
+
+            // add a margin to align the radio where the line height is 1.6 as opposed to 1.2
+            @include media('<wide') {
+                margin-top: 2px;
+            }
+
+            @include media('<=mid') {
+                margin-top: -2px;
+            }
+        }
+
+        .o-formControl-input:checked ~ .o-formControl-indicator--radio {
+            background-color: $formControl-color;
+            border: 6px solid $formControl-borderColor;
+
+            &:before {
+                content: '';
+                background-color: $formControl-color;
+                border: 3px solid $grey--lighter;
+                border-radius: 50%;
+                width: $formControl-width - 2;
+                height: $formControl-height - 2;
+                position: absolute;
+                top: -5px;
+                left: -5px;
+
+                @include media('>=mid') {
+                    width: $formControl-width--wide - 2;
+                    height: $formControl-height--wide - 2;
+                }
+            }
+        }
+    }

--- a/src/scss/objects/_form-controls.scss
+++ b/src/scss/objects/_form-controls.scss
@@ -32,19 +32,19 @@
     *
     */
 
-    $formControl-bgColor            : $white !default;
-    $formControl-bgColor--disabled  : $color-disabled !default;
-    $formControl-borderColor        : $color-border !default;
-    $formControl-borderColor--hover : $orange !default;
-    $formControl-color              : $orange !default;
-    $formControl-color--hover       : $orange--dark !default;
-    $formControl-background-color   : $color-bg !default;
-    $formControl-margin-left        : 0 !default;
-    $formControl-padding-left       : spacing(x4) !default;
-    $formControl-width              : 24px !default;
-    $formControl-width--wide        : 20px !default;
-    $formControl-height             : 24px !default;
-    $formControl-height--wide       : 20px !default;
+    $formControl-bgColor            : $color-white;
+    $formControl-bgColor--disabled  : $color-disabled;
+    $formControl-borderColor        : $color-border;
+    $formControl-borderColor--hover : $color-orange;
+    $formControl-color              : $color-orange;
+    $formControl-color--hover       : darken($color-orange, 4%); // TODO update to include hover alias token
+    $formControl-background-color   : $color-bg;
+    $formControl-margin-left        : 0;
+    $formControl-padding-left       : spacing(x4);
+    $formControl-width              : 24px;
+    $formControl-width--wide        : 20px;
+    $formControl-height             : 24px;
+    $formControl-height--wide       : 20px;
     $formControl-border-width       : 1px;
 
 
@@ -95,7 +95,7 @@
             display: inline-block;
             width: $formControl-width;
             height: $formControl-height;
-            border: $formControl-border-width solid $grey--light;
+            border: $formControl-border-width solid $color-grey-30;
             background-color: $formControl-bgColor;
             vertical-align: middle;
             margin-left: $formControl-margin-left;
@@ -228,7 +228,7 @@
             &:before {
                 content: '';
                 background-color: $formControl-color;
-                border: 3px solid $grey--lighter;
+                border: 3px solid $color-grey-20;
                 border-radius: 50%;
                 width: $formControl-width - 2;
                 height: $formControl-height - 2;

--- a/src/scss/objects/_form-controls.scss
+++ b/src/scss/objects/_form-controls.scss
@@ -34,11 +34,11 @@
 
     $formControl-bgColor            : $color-white;
     $formControl-bgColor--disabled  : $color-disabled;
-    $formControl-borderColor        : $color-border;
+    $formControl-borderColor        : $color-border-strong;
     $formControl-borderColor--hover : $color-orange;
     $formControl-color              : $color-orange;
-    $formControl-color--hover       : darken($color-orange, 4%); // TODO update to include hover alias token
-    $formControl-background-color   : $color-bg;
+    $formControl-color--hover       : darken($color-orange, $color-hover-01);
+    $formControl-background-color   : $color-background-default;
     $formControl-margin-left        : 0;
     $formControl-padding-left       : spacing(x4);
     $formControl-width              : 24px;

--- a/src/scss/objects/_form-controls.scss
+++ b/src/scss/objects/_form-controls.scss
@@ -33,7 +33,7 @@
     */
 
     $formControl-bgColor            : $color-white;
-    $formControl-bgColor--disabled  : $color-disabled;
+    $formControl-bgColor--disabled  : $color-disabled-01;
     $formControl-borderColor        : $color-border-strong;
     $formControl-borderColor--hover : $color-orange;
     $formControl-color              : $color-orange;

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -1,17 +1,17 @@
 $formToggle-padding                 : spacing() !default;
-$formToggle-border-color            : $grey--light;
-$formToggle-border-color--interact  : $grey--mid;
-$formToggle-border-color--checked   : $green;
+$formToggle-border-color            : $color-grey-30;
+$formToggle-border-color--interact  : $color-grey-40;
+$formToggle-border-color--checked   : $color-green;
 $formToggle-border-width            : 1px;
 $formToggle-border-radius           : 8px;
-$formToggle-icon-background         : $green;
-$formToggle-icon-background--hover  : $grey--light;
-$formToggle-background              : $white;
+$formToggle-icon-background         : $color-green;
+$formToggle-icon-background--hover  : $color-grey-30;
+$formToggle-background              : $color-white;
 $formToggle-large-size              : 48px;
-$formToggle-button-color            : $blue;
-$formToggle-button-background       : $blue--offWhite;
-$formToggle-text--disabled          : $grey--light;
-$formToggle-text--checked           : $green;
+$formToggle-button-color            : $color-blue;
+$formToggle-button-background       : $color-blue-10;
+$formToggle-text--disabled          : $color-grey-30;
+$formToggle-text--checked           : $color-green;
 
 @mixin formToggle() {
     /**

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -1,17 +1,3 @@
-/**
- * Objects > Form Toggle
- * =================================
- * Styles a button on top of a checkbox, to toggle inputs to a form
- *
- * Example: Search page filters (sidebat)
- *
- * The `o-formToggle` object is an optional mixin within Fozzie.
- * If you'd like to use it in your project you can include it by adding `@include formToggle();` into your SCSS dependencies file.
- *
- * Documentation:
- * TBC
- */
-
 $formToggle-padding                 : spacing() !default;
 $formToggle-border-color            : $grey--light;
 $formToggle-border-color--interact  : $grey--mid;
@@ -27,84 +13,20 @@ $formToggle-button-background       : $blue--offWhite;
 $formToggle-text--disabled          : $grey--light;
 $formToggle-text--checked           : $green;
 
-// associated form toggle mixins
-@mixin formToggle-large() {
-    width: calc(50% - 4px);
-
-    &:nth-child(2n) {
-        margin-left: spacing();
-    }
-}
-
-@mixin formToggle-largeInputSize() {
-    height: 40px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-}
-
-@mixin formToggle-checkedSpacing() {
-    padding-left: 20px;
-    font-weight: $font-weight-bold;
-}
-
-@mixin formToggle-border() {
-    cursor: pointer;
-    //the &:after is to create a border that sits over the top of the parents,
-    // it creates a visual state on the parent without the need for a JS class toggle
-    &:after {
-        content: '';
-        top: -1px;
-        left: -1px;
-        display: block;
-        position: absolute;
-    }
-}
-
-// `formToggle-hoverState` is used only when a formToggle has a user interaction :hover
-@mixin formToggle-hoverState() {
-    @include formToggle-border();
-    &:after {
-        width: calc(100% + 2px);
-        height: calc(100% + 2px);
-        border-radius: $formToggle-border-radius;
-        border: $formToggle-border-width solid $formToggle-border-color--interact;
-    }
-}
-
-// `formToggle-hoverState` is used only when a formToggle has a user interaction: :focus
-@mixin formToggle-focusState() {
-    @include formToggle-border();
-    &:after {
-        @extend %u-elementFocus;
-        left: 1px;
-        top: 1px;
-        width: calc(100% - 2px);
-        height: calc(100% - 2px);
-        border-radius: $formToggle-border-radius;
-        border: $formToggle-border-width solid $formToggle-border-color--interact;
-    }
-}
-
-@mixin formToggle-checkedState() {
-    @include formToggle-border();
-    // for `formToggle-checkedState` we double the size of the element and scale by
-    // 0.5 to make a 0.5px border render for the checked state
-    &:after {
-        width: calc(200% + 4px);
-        height: calc(200% + 4px);
-        border-radius: ($formToggle-border-radius * 2);
-        border: $formToggle-border-width solid $formToggle-border-color--checked;
-        transform: scale(0.5) translate(-50%, -50%);
-    }
-}
-
-@mixin formToggle-iconActive() {
-    opacity: 1;
-    transform: rotate(0) scale(1);
-}
-
 @mixin formToggle() {
+    /**
+    * Objects > Form Toggle
+    * =================================
+    * Styles a button on top of a checkbox, to toggle inputs to a form
+    *
+    * Example: Search page filters (sidebat)
+    *
+    * The `o-formToggle` object is an optional mixin within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include formToggle();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * TBC
+    */
 
     .o-formToggle {
         position: relative;
@@ -319,4 +241,81 @@ $formToggle-text--checked           : $green;
             background: none;
             color: $formToggle-text--disabled;
         }
+}
+
+// associated form toggle mixins
+@mixin formToggle-large() {
+    width: calc(50% - 4px);
+
+    &:nth-child(2n) {
+        margin-left: spacing();
+    }
+}
+
+@mixin formToggle-largeInputSize() {
+    height: 40px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+@mixin formToggle-checkedSpacing() {
+    padding-left: 20px;
+    font-weight: $font-weight-bold;
+}
+
+@mixin formToggle-border() {
+    cursor: pointer;
+    //the &:after is to create a border that sits over the top of the parents,
+    // it creates a visual state on the parent without the need for a JS class toggle
+    &:after {
+        content: '';
+        top: -1px;
+        left: -1px;
+        display: block;
+        position: absolute;
+    }
+}
+
+// `formToggle-hoverState` is used only when a formToggle has a user interaction :hover
+@mixin formToggle-hoverState() {
+    @include formToggle-border();
+    &:after {
+        width: calc(100% + 2px);
+        height: calc(100% + 2px);
+        border-radius: $formToggle-border-radius;
+        border: $formToggle-border-width solid $formToggle-border-color--interact;
+    }
+}
+
+// `formToggle-hoverState` is used only when a formToggle has a user interaction: :focus
+@mixin formToggle-focusState() {
+    @include formToggle-border();
+    &:after {
+        @extend %u-elementFocus;
+        left: 1px;
+        top: 1px;
+        width: calc(100% - 2px);
+        height: calc(100% - 2px);
+        border-radius: $formToggle-border-radius;
+        border: $formToggle-border-width solid $formToggle-border-color--interact;
+    }
+}
+
+@mixin formToggle-checkedState() {
+    @include formToggle-border();
+    // for `formToggle-checkedState` we double the size of the element and scale by
+    // 0.5 to make a 0.5px border render for the checked state
+    &:after {
+        width: calc(200% + 4px);
+        height: calc(200% + 4px);
+        border-radius: ($formToggle-border-radius * 2);
+        border: $formToggle-border-width solid $formToggle-border-color--checked;
+        transform: scale(0.5) translate(-50%, -50%);
+    }
+}
+
+@mixin formToggle-iconActive() {
+    opacity: 1;
+    transform: rotate(0) scale(1);
 }

--- a/src/scss/objects/_images.scss
+++ b/src/scss/objects/_images.scss
@@ -1,7 +1,0 @@
-/**
- * Objects > Images
- * =================================
- *
- * Documentation:
- * TBC
- */

--- a/src/scss/objects/_links.scss
+++ b/src/scss/objects/_links.scss
@@ -1,40 +1,45 @@
-/**
- * Objects > Links
- * =================================
- * Default Link Styling
- *
- * Documentation:
- * TBC
- */
+@mixin links() {
+    /**
+    * Objects > Links
+    * =================================
+    * Default Link Styling
+    *
+    * This is an optional component within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include links();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * TBC
+    */
 
-a {
-    & {
-        color: $color-link-default;
+    a {
+        & {
+            color: $color-link-default;
+        }
+
+        &:hover, &:focus {
+            color: $color-link-hover;
+        }
+
+        &:active {
+            color: $color-link-active;
+        }
+        // have left in in case we want to use eventually
+        // &:visited {
+        //     color: $color-link-visited;
+        //     text-decoration: none;
+        // }
     }
 
-    &:hover, &:focus {
-        color: $color-link-hover;
+    .o-link--full {
+        width: 100%;
+        display: block;
     }
 
-    &:active {
-        color: $color-link-active;
+    .o-link--noDecoration {
+        text-decoration: none;
     }
-    // have left in in case we want to use eventually
-    // &:visited {
-    //     color: $color-link-visited;
-    //     text-decoration: none;
-    // }
-}
 
-.o-link--full {
-    width: 100%;
-    display: block;
-}
-
-.o-link--noDecoration {
-    text-decoration: none;
-}
-
-.o-link--bold {
-    font-weight: $font-weight-bold;
+    .o-link--bold {
+        font-weight: $font-weight-bold;
+    }
 }

--- a/src/scss/objects/_links.scss
+++ b/src/scss/objects/_links.scss
@@ -13,15 +13,16 @@
 
     a {
         & {
-            color: $color-link-default;
+            color: $color-content-link;
         }
 
-        &:hover, &:focus {
-            color: $color-link-hover;
+        &:hover,
+        &:focus {
+            color: darken($color-content-link, $color-hover-01);
         }
 
         &:active {
-            color: $color-link-active;
+            color: darken($color-content-link, $color-active-02);
         }
         // have left in in case we want to use eventually
         // &:visited {
@@ -37,6 +38,13 @@
 
     .o-link--noDecoration {
         text-decoration: none;
+
+        // for accessibility reasons we are leaving
+        // text-decoration on hover and focus
+        &:hover,
+        &:focus {
+            text-decoration: underline;
+        }
     }
 
     .o-link--bold {

--- a/src/scss/objects/_lists.scss
+++ b/src/scss/objects/_lists.scss
@@ -11,7 +11,7 @@
     * TBC
     */
 
-    $list-bullet-color: $orange;
+    $list-bullet-color: $color-orange;
 
 
     ul,

--- a/src/scss/objects/_lists.scss
+++ b/src/scss/objects/_lists.scss
@@ -1,65 +1,67 @@
-/**
- * Objects > Lists
- * =================================
- * Default list styles (for unordered and ordered lists)
- *
- * Documentation:
- * TBC
- */
+@mixin lists() {
+    /**
+    * Objects > Lists
+    * =================================
+    * Default list styles (for unordered and ordered lists)
+    *
+    * This is an optional component within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include lists();` into your SCSS dependencies file.
+    *
+    * Documentation:
+    * TBC
+    */
 
-$list-bullet-color: $orange;
+    $list-bullet-color: $orange;
 
-
-ul,
-ol {
-    padding: 0;
-    margin: spacing(x2) 0 0 spacing(x2);
-
-    li {
-        margin-bottom: spacing();
-    }
 
     ul,
     ol {
-        margin-top: spacing();
+        padding: 0;
+        margin: spacing(x2) 0 0 spacing(x2);
+
+        li {
+            margin-bottom: spacing();
+        }
+
+        ul,
+        ol {
+            margin-top: spacing();
+        }
     }
-}
 
-ul {
-    margin-left: 1.5rem;
-    list-style: none;
+    ul {
+        margin-left: 1.5rem;
+        list-style: none;
 
-    // Adds a coloured circle before list-items
-    > li:before,
-    > li ul > li:before {
-        color: $list-bullet-color;
-        content: '\2022'; /* Unicode for circle character */
-        font-size: 1.8em;
-        padding-right: spacing();
-        position: relative;
-        top: 0.15em;
-        margin-left: -1.5rem;
+        // Adds a coloured circle before list-items
+        > li:before,
+        > li ul > li:before {
+            color: $list-bullet-color;
+            content: '\2022'; /* Unicode for circle character */
+            font-size: 1.8em;
+            padding-right: spacing();
+            position: relative;
+            top: 0.15em;
+            margin-left: -1.5rem;
+        }
     }
-}
 
-ol {
-    > li {
-        padding-left: spacing();
+    ol {
+        > li {
+            padding-left: spacing();
+        }
     }
-}
 
-.c-list-ordered {
-    > li {
-        font-weight: $font-weight-bold;
-        @include font-size(heading-s); // TODO – this should be updated with a more semantic font alias specific to lists
-        margin-bottom: spacing(x4);
+    .c-list-ordered {
+        > li {
+            font-weight: $font-weight-bold;
+            @include font-size(heading-s); // TODO – this should be updated with a more semantic font alias specific to lists
+            margin-bottom: spacing(x4);
 
-        > div {
-            font-weight: $font-weight-base;
-            @include font-size(body-s);
+            > div {
+                font-weight: $font-weight-base;
+                @include font-size(body-s);
+            }
         }
     }
 }
-
-
-

--- a/src/scss/objects/_lists.scss
+++ b/src/scss/objects/_lists.scss
@@ -59,7 +59,7 @@
             margin-bottom: spacing(x4);
 
             > div {
-                font-weight: $font-weight-base;
+                font-weight: $font-weight-regular;
                 @include font-size(body-s);
             }
         }

--- a/src/scss/objects/_tables.scss
+++ b/src/scss/objects/_tables.scss
@@ -22,8 +22,8 @@
     $table-bgColor--accent        : $color-grey-10 !global; // Background color used for `.table-striped`.
     $table-border--color          : $color-grey-10 !global; // Border color for table and cell borders.
     $table-border--width          : 2px !global; // Border width for table border.
-    $table-innerBorder--color     : $color-border !global;
-    $table-verticalBorder--color  : $color-border--interactive !global;
+    $table-innerBorder--color     : $color-grey-40 !global;
+    $table-verticalBorder--color  : $color-grey-50 !global;
 
 
     /**

--- a/src/scss/objects/_tables.scss
+++ b/src/scss/objects/_tables.scss
@@ -1,97 +1,102 @@
-/**
- * Objects > Tables
- * =================================
- * Default Table styles
- *
- * File Index:
- * - Table specific variables
- * - Default table styles
- *
- * Documentation:
- * TBC
- */
+ @mixin tables() {
+    /**
+    * Objects > Tables
+    * =================================
+    * Default Table styles
+    *
+    * This is an optional component within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include tables();` into your SCSS dependencies file.
+    *
+    * File Index:
+    * - Table specific variables
+    * - Default table styles
+    *
+    * Documentation:
+    * TBC
+    */
 
-/**
- * Define associated Table variables
- */
-$table-bgColor                : $color-bg--component !default; // Default background color used for all tables.
-$table-bgColor--accent        : $grey--offWhite !default; // Background color used for `.table-striped`.
-$table-border--color          : $grey--offWhite !default; // Border color for table and cell borders.
-$table-border--width          : 2px !default; // Border width for table border.
-$table-innerBorder--color     : $color-border !default;
-$table-verticalBorder--color  : $color-border--interactive !default;
+    /**
+    * Define associated Table variables
+    */
+    $table-bgColor                : $color-bg--component !global; // Default background color used for all tables.
+    $table-bgColor--accent        : $grey--offWhite !global; // Background color used for `.table-striped`.
+    $table-border--color          : $grey--offWhite !global; // Border color for table and cell borders.
+    $table-border--width          : 2px !global; // Border width for table border.
+    $table-innerBorder--color     : $color-border !global;
+    $table-verticalBorder--color  : $color-border--interactive !global;
 
 
-/**
- * Customizes the `.table` component with basic values, each used across all table variations.
- */
-$table-cell-padding           : 14px !default; // Padding for `<th>`s and `<td>`s.
+    /**
+    * Customizes the `.table` component with basic values, each used across all table variations.
+    */
+    $table-cell-padding           : 14px !default; // Padding for `<th>`s and `<td>`s.
 
-// Baseline styles
-table,
-.table {
-    width: 100%;
-    max-width: 100%;
-    margin-top: spacing(x4);
-    margin-bottom: spacing(x4);
-    border-spacing: 0;
-    background-color: $table-bgColor;
-    border: $table-border--width solid $table-border--color;
-    border-radius: $border-radius;
+    // Baseline styles
+    table,
+    .table {
+        width: 100%;
+        max-width: 100%;
+        margin-top: spacing(x4);
+        margin-bottom: spacing(x4);
+        border-spacing: 0;
+        background-color: $table-bgColor;
+        border: $table-border--width solid $table-border--color;
+        border-radius: $border-radius;
 
-    // Cells
-    & > thead,
-    & > tbody,
-    & > tfoot {
-        th,
-        td {
-            padding: $table-cell-padding;
-            line-height: $line-height-base;
-            vertical-align: top;
-            border-right: 1px solid $table-verticalBorder--color;
+        // Cells
+        & > thead,
+        & > tbody,
+        & > tfoot {
+            th,
+            td {
+                padding: $table-cell-padding;
+                line-height: $line-height-base;
+                vertical-align: top;
+                border-right: 1px solid $table-verticalBorder--color;
+            }
+            th {
+                text-align: left;
+                border-top: 1px solid $table-innerBorder--color;
+
+                &:first-child {
+                    border-left: 1px solid $table-innerBorder--color;
+                    border-radius: 4px 0 0;
+                }
+                &:last-child {
+                    border-right: 1px solid $table-innerBorder--color;
+                    border-radius: 0 4px 0 0;
+                }
+            }
+            td {
+                &:last-child {
+                    border-right: none;
+                }
+            }
         }
-        th {
-            text-align: left;
+
+        // Bottom align for column headings
+        & > thead th,
+        & > thead td {
+            vertical-align: bottom;
+            border-bottom: 1px solid $table-innerBorder--color;
+        }
+
+        // Account for multiple tbody instances
+        > tbody + tbody {
             border-top: 1px solid $table-innerBorder--color;
-
-            &:first-child {
-                border-left: 1px solid $table-innerBorder--color;
-                border-radius: 4px 0 0;
-            }
-            &:last-child {
-                border-right: 1px solid $table-innerBorder--color;
-                border-radius: 0 4px 0 0;
-            }
         }
-        td {
-            &:last-child {
-                border-right: none;
-            }
+
+        // Nesting
+        & table,
+        & .table {
+            background-color: $color-bg;
+        }
+
+        &:not(.not-striped) {
+        tbody :nth-child(odd) th,
+        tbody :nth-child(odd) td {
+            background-color: $table-bgColor--accent;
+        }
         }
     }
-
-    // Bottom align for column headings
-    & > thead th,
-    & > thead td {
-        vertical-align: bottom;
-        border-bottom: 1px solid $table-innerBorder--color;
-    }
-
-    // Account for multiple tbody instances
-    > tbody + tbody {
-        border-top: 1px solid $table-innerBorder--color;
-    }
-
-    // Nesting
-    & table,
-    & .table {
-        background-color: $color-bg;
-    }
-
-    &:not(.not-striped) {
-      tbody :nth-child(odd) th,
-      tbody :nth-child(odd) td {
-        background-color: $table-bgColor--accent;
-      }
-    }
-}
+ }

--- a/src/scss/objects/_tables.scss
+++ b/src/scss/objects/_tables.scss
@@ -19,8 +19,8 @@
     * Define associated Table variables
     */
     $table-bgColor                : $color-bg--component !global; // Default background color used for all tables.
-    $table-bgColor--accent        : $grey--offWhite !global; // Background color used for `.table-striped`.
-    $table-border--color          : $grey--offWhite !global; // Border color for table and cell borders.
+    $table-bgColor--accent        : $color-grey-10 !global; // Background color used for `.table-striped`.
+    $table-border--color          : $color-grey-10 !global; // Border color for table and cell borders.
     $table-border--width          : 2px !global; // Border width for table border.
     $table-innerBorder--color     : $color-border !global;
     $table-verticalBorder--color  : $color-border--interactive !global;

--- a/src/scss/objects/_tables.scss
+++ b/src/scss/objects/_tables.scss
@@ -18,7 +18,7 @@
     /**
     * Define associated Table variables
     */
-    $table-bgColor                : $color-bg--component !global; // Default background color used for all tables.
+    $table-bgColor                : $color-container-default !global; // Default background color used for all tables.
     $table-bgColor--accent        : $color-grey-10 !global; // Background color used for `.table-striped`.
     $table-border--color          : $color-grey-10 !global; // Border color for table and cell borders.
     $table-border--width          : 2px !global; // Border width for table border.
@@ -89,7 +89,7 @@
         // Nesting
         & table,
         & .table {
-            background-color: $color-bg;
+            background-color: $color-background-default;
         }
 
         &:not(.not-striped) {

--- a/src/scss/settings/_glyphs.scss
+++ b/src/scss/settings/_glyphs.scss
@@ -1,7 +1,0 @@
-/* stylelint-disable indentation */
-// =================================
-// Glyphs
-// The below glyphs are to be used in CSS pseudo elements content property
-// =================================
-
-$bullet: '\2022';

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -9,57 +9,55 @@
 // Set this in pixels (but do not add px),
 // the font-size mixin will convert to REMS
 
-$font-size-base             : 14;
+$font-size-base             : $font-paragraph-02;
 $font-size-base-px          : $font-size-base * 1px;
 
 // Type map – these are our global font-sizes and line-heights across the site
 $type: (
     caption: (
-        default: (12, 16)
+        default: ($font-size-a)
     ),
     body-s: (
-        default: (14, 20)
+        default: ($font-size-b)
     ),
     body-l: (
-        default: (16, 24)
+        default: ($font-size-c)
     ),
     subheading-s: (
-        default: (20, 28),
-        narrow: (16, 24)
+        default: ($font-size-d),
+        narrow: ($font-size-c)
     ),
     subheading-l: (
-        default: (24, 32),
-        narrow: (20, 28)
+        default: ($font-size-e),
+        narrow: ($font-size-d)
     ),
     heading-s: (
-        default: (20, 28),
-        narrow: (16, 24)
+        default: ($font-size-d),
+        narrow: ($font-size-c)
     ),
     heading-m: (
-        default: (24, 32),
-        narrow: (20, 28)
+        default: ($font-size-e),
+        narrow: ($font-size-d)
     ),
     heading-l: (
-        default: (28, 36),
-        narrow: (24, 32)
+        default: ($font-size-f),
+        narrow: ($font-size-e)
     ),
     heading-xl: (
-        default: (32, 40),
-        narrow: (28, 36)
+        default: ($font-size-g),
+        narrow: ($font-size-f)
     ),
     heading-xxl: (
-        default: (48, 56),
-        narrow: (32, 40)
+        default: ($font-size-h),
+        narrow: ($font-size-g)
     )
 ) !default;
 
-$font-weight-base           : 400;
-$font-weight-bold           : 600;
-$font-weight-headings       : 600;
+$font-weight-headings       : $font-weight-bold;
 $line-height-base           : line-height();
 
 // Font stacks
-$font-family-base           : 'JustEatBasis', Arial, sans-serif;
+$font-family-base           : $font-family-primary, Arial, sans-serif;
 $font-family-mono           : Menlo, Monaco, 'Courier New', monospace;
 
 

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -95,6 +95,7 @@ $grid-column-count            : 12 !default; // Total column count
 $grid-gutter-width            : 16 !default; // [in pixels]
 
 $responsive-grid-sizes        : true !default; // Disable this if you don't want grid sizes for each breakpoint
+$responsive-gutters           : true !default; // Disable this if you don't want gutters for each breakpoint
 $use-legacy-grid              : true !default;
 
 
@@ -121,7 +122,7 @@ $spacing: (
 
 $baseline: spacing(x2); // default spacing between blocks
 
-$border-radius: 4px;
+$border-radius: 2px;
 
 //  z-indexes
 // ==========================================================================

--- a/src/scss/trumps/_rwd.scss
+++ b/src/scss/trumps/_rwd.scss
@@ -1,62 +1,64 @@
-/**
- * Responsive Trumps
- * ===================================
- */
+@mixin trumps-rwd() {
+    /**
+    * Responsive Trumps
+    * ===================================
+    */
 
-//
-// Responsive helper classes to show/hide content based on our media-queries
-// =================================================================================
-.u-showBelowNarrow {
-    @include media('>=narrow') {
-        display: none !important;
+    //
+    // Responsive helper classes to show/hide content based on our media-queries
+    // =================================================================================
+    .u-showBelowNarrow {
+        @include media('>=narrow') {
+            display: none !important;
+        }
     }
-}
 
-.u-showBelowMid {
-    @include media('>=mid') {
-        display: none !important;
+    .u-showBelowMid {
+        @include media('>=mid') {
+            display: none !important;
+        }
     }
-}
 
-.u-showBelowWide {
-    @include media('>=wide') {
-        display: none !important;
+    .u-showBelowWide {
+        @include media('>=wide') {
+            display: none !important;
+        }
     }
-}
 
-.u-showBelowHuge {
-    @include media('>=huge') {
-        display: none !important;
+    .u-showBelowHuge {
+        @include media('>=huge') {
+            display: none !important;
+        }
     }
-}
 
-.u-showAboveNarrow {
-    @include media('<=narrow') {
-        display: none !important;
+    .u-showAboveNarrow {
+        @include media('<=narrow') {
+            display: none !important;
+        }
     }
-}
 
-.u-showAboveTiny {
-    @include media('<=tiny') {
-        display: none !important;
+    .u-showAboveTiny {
+        @include media('<=tiny') {
+            display: none !important;
+        }
     }
-}
 
-.u-showAboveMid,
-.no-js .u-showAboveMid--noJS {
-    @include media('<mid') {
-        display: none !important;
+    .u-showAboveMid,
+    .no-js .u-showAboveMid--noJS {
+        @include media('<mid') {
+            display: none !important;
+        }
     }
-}
 
-.u-showAboveWide {
-    @include media('<wide') {
-        display: none !important;
+    .u-showAboveWide {
+        @include media('<wide') {
+            display: none !important;
+        }
     }
-}
 
-.u-showAboveHuge {
-    @include media('<huge') {
-        display: none !important;
+    .u-showAboveHuge {
+        @include media('<huge') {
+            display: none !important;
+        }
     }
 }

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -175,11 +175,11 @@
     // ==========================================================================
 
     .u-color-text {
-        color: $color-text;
+        color: $color-content-default;
     }
 
     .u-color-link {
-        color: $color-link-default;
+        color: $color-content-link;
     }
 
     .u-color-secondary {

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -1,409 +1,411 @@
-/**
- * Utilities
- * ===================================
- * Non-semantic helper classes
- */
+@mixin trumps-utilities() {
+    /**
+    * Utilities
+    * ===================================
+    * Non-semantic helper classes
+    */
 
-//
-// Clearfix
-// http://www.cssmojo.com/latest_new_clearfix_so_far/
-// See mixins/_utility.scss for a mixin version of this
-// ==========================================================================
-.u-clearfix {
-    &:after {
-        content: ' ';
-        display: table;
-        clear: both;
+    //
+    // Clearfix
+    // http://www.cssmojo.com/latest_new_clearfix_so_far/
+    // See mixins/_utility.scss for a mixin version of this
+    // ==========================================================================
+    .u-clearfix {
+        &:after {
+            content: ' ';
+            display: table;
+            clear: both;
+        }
     }
-}
 
-//
-// Colour Utilities
-// ==========================================================================
+    //
+    // Colour Utilities
+    // ==========================================================================
 
-.u-lightenBg {
-    background-color: $white;
-}
+    .u-lightenBg {
+        background-color: $white;
+    }
 
-.u-bordered,
-%u-bordered {
-    @include bordered();
-}
-
-.u-bordered--mid {
-    @include media('>mid') {
+    .u-bordered,
+    %u-bordered {
         @include bordered();
     }
-}
 
-
-//
-// Display Utilities
-// ==========================================================================
-
-// Hide from both screenreaders and browsers: h5bp.com/u
-.is-hidden,
-.no-js .is-hidden--noJS {
-    display: none !important;
-    visibility: hidden !important;
-}
-
-.is-shown,
-.no-js .is-shown--noJS {
-    display: block !important;
-    visibility: visible !important;
-}
-
-// Hide only visually, but have it available for screenreaders: h5bp.com/v
-.is-visuallyHidden {
-    border: 0;
-    clip: rect(0 0 0 0);
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    width: 1px;
-
-    // Extends the .is-visuallyhidden class to allow the element to be focusable when navigated to via the keyboard: h5bp.com/p
-    &.focusable:active,
-    &.focusable:focus {
-        clip: auto;
-        height: auto;
-        margin: 0;
-        overflow: visible;
-        position: static;
-        width: auto;
-    }
-}
-
-// Hide visually and from screenreaders, but maintain layout
-.is-invisible { visibility: hidden; }
-
-.u-pointer {
-    cursor: pointer;
-}
-
-//
-// Position Utilities
-// ==========================================================================
-
-.is-sticky {
-    width: 100%;
-    z-index: zIndex(mid);
-    position: fixed;
-    transition: top 0.2s ease;
-}
-
-.u-sticky {
-    position: sticky !important;
-    top: spacing(x2);
-}
-
-.u-absolutelyCentered {
-    position: absolute;
-    top: 50%;
-    right: 50%;
-    transform: translate(50%, -50%);
-}
-
-//
-// Typographic Helpers
-// ==========================================================================
-
-// ensures text inside helper never wraps
-.u-noWrap {
-    white-space: nowrap;
-}
-
-.u-uppercase {
-    text-transform: uppercase;
-}
-
-.u-textPad {
-    padding-left: spacing(x4) !important;
-}
-
-.u-text-truncate {
-    @include truncate();
-}
-
-.u-noUnderline {
-    text-decoration: none;
-
-    &:hover,
-    &:active,
-    &:focus {
-        text-decoration: underline;
-    }
-}
-
-.u-text-centre, // British or US English spellings..
-.u-text-center {
-    text-align: center;
-}
-
-.u-text-left {
-    text-align: left;
-}
-
-.u-text-right {
-    text-align: right;
-}
-
-.u-text-highlight {
-    color: $red;
-
-    @at-root em#{&} {
-        font-style: normal;
-    }
-}
-
-.u-text-indent {
-    margin-left: spacing(x2);
-}
-
-//
-// Typographic Colour Helpers
-//
-// Each colour util class is relative to a Fozzie colour within the
-// Fozzie colour pallette.
-//
-// Our current colour pallete can be found here:
-// https://fozzie.just-eat.com/styleguide/design-elements/colours
-// ==========================================================================
-
-.u-color-text {
-    color: $color-text;
-}
-
-.u-color-link {
-    color: $color-link-default;
-}
-
-.u-color-secondary {
-    color: $color-secondary;
-}
-
-.u-color-text--hint {
-    color: $color-text--hint;
-}
-
-.u-color-text--success {
-    color: $color-text--success;
-}
-
-.u-color-text--danger {
-    color: $color-text--danger;
-}
-
-.u-color-text--warning {
-    color: $color-text--warning;
-}
-
-//
-// Spacing Utilities
-// ==========================================================================
-
-.u-noSpacing {
-    margin: 0 !important;
-}
-
-.u-spacingTop {
-    margin-top: spacing() !important;
-}
-
-    .u-spacingTop--small {
-        margin-top: spacing(x0.5) !important;
-    }
-
-    .u-spacingTop--large {
-        margin-top: spacing(x2) !important;
-    }
-
-.u-spacingRight {
-    margin-right: spacing() !important;
-}
-
-.u-spacingBottom {
-    margin-bottom: spacing() !important;
-}
-
-    .u-spacingBottom--large {
-        margin-bottom: spacing(x2) !important;
-    }
-
-    .u-spacingBottom--large--aboveMid {
-        @include media('>=mid') {
-            margin-bottom: spacing(x2);
+    .u-bordered--mid {
+        @include media('>mid') {
+            @include bordered();
         }
     }
 
-.u-spacingLeft {
-    margin-left: spacing() !important;
-}
 
-//
-// Padding Utilities
-// ==========================================================================
+    //
+    // Display Utilities
+    // ==========================================================================
 
-.u-noPad {
-    padding: 0 !important;
-}
-
-.u-padTop {
-    padding-top: spacing() !important;
-}
-
-    .u-padTop--large {
-        padding-top: spacing(x2) !important;
+    // Hide from both screenreaders and browsers: h5bp.com/u
+    .is-hidden,
+    .no-js .is-hidden--noJS {
+        display: none !important;
+        visibility: hidden !important;
     }
 
-    .u-padTop--large--aboveMid {
-        @include media('>=mid') {
+    .is-shown,
+    .no-js .is-shown--noJS {
+        display: block !important;
+        visibility: visible !important;
+    }
+
+    // Hide only visually, but have it available for screenreaders: h5bp.com/v
+    .is-visuallyHidden {
+        border: 0;
+        clip: rect(0 0 0 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+
+        // Extends the .is-visuallyhidden class to allow the element to be focusable when navigated to via the keyboard: h5bp.com/p
+        &.focusable:active,
+        &.focusable:focus {
+            clip: auto;
+            height: auto;
+            margin: 0;
+            overflow: visible;
+            position: static;
+            width: auto;
+        }
+    }
+
+    // Hide visually and from screenreaders, but maintain layout
+    .is-invisible { visibility: hidden; }
+
+    .u-pointer {
+        cursor: pointer;
+    }
+
+    //
+    // Position Utilities
+    // ==========================================================================
+
+    .is-sticky {
+        width: 100%;
+        z-index: zIndex(mid);
+        position: fixed;
+        transition: top 0.2s ease;
+    }
+
+    .u-sticky {
+        position: sticky !important;
+        top: spacing(x2);
+    }
+
+    .u-absolutelyCentered {
+        position: absolute;
+        top: 50%;
+        right: 50%;
+        transform: translate(50%, -50%);
+    }
+
+    //
+    // Typographic Helpers
+    // ==========================================================================
+
+    // ensures text inside helper never wraps
+    .u-noWrap {
+        white-space: nowrap;
+    }
+
+    .u-uppercase {
+        text-transform: uppercase;
+    }
+
+    .u-textPad {
+        padding-left: spacing(x4) !important;
+    }
+
+    .u-text-truncate {
+        @include truncate();
+    }
+
+    .u-noUnderline {
+        text-decoration: none;
+
+        &:hover,
+        &:active,
+        &:focus {
+            text-decoration: underline;
+        }
+    }
+
+    .u-text-centre, // British or US English spellings..
+    .u-text-center {
+        text-align: center;
+    }
+
+    .u-text-left {
+        text-align: left;
+    }
+
+    .u-text-right {
+        text-align: right;
+    }
+
+    .u-text-highlight {
+        color: $red;
+
+        @at-root em#{&} {
+            font-style: normal;
+        }
+    }
+
+    .u-text-indent {
+        margin-left: spacing(x2);
+    }
+
+    //
+    // Typographic Colour Helpers
+    //
+    // Each colour util class is relative to a Fozzie colour within the
+    // Fozzie colour pallette.
+    //
+    // Our current colour pallete can be found here:
+    // https://fozzie.just-eat.com/styleguide/design-elements/colours
+    // ==========================================================================
+
+    .u-color-text {
+        color: $color-text;
+    }
+
+    .u-color-link {
+        color: $color-link-default;
+    }
+
+    .u-color-secondary {
+        color: $color-secondary;
+    }
+
+    .u-color-text--hint {
+        color: $color-text--hint;
+    }
+
+    .u-color-text--success {
+        color: $color-text--success;
+    }
+
+    .u-color-text--danger {
+        color: $color-text--danger;
+    }
+
+    .u-color-text--warning {
+        color: $color-text--warning;
+    }
+
+    //
+    // Spacing Utilities
+    // ==========================================================================
+
+    .u-noSpacing {
+        margin: 0 !important;
+    }
+
+    .u-spacingTop {
+        margin-top: spacing() !important;
+    }
+
+        .u-spacingTop--small {
+            margin-top: spacing(x0.5) !important;
+        }
+
+        .u-spacingTop--large {
+            margin-top: spacing(x2) !important;
+        }
+
+    .u-spacingRight {
+        margin-right: spacing() !important;
+    }
+
+    .u-spacingBottom {
+        margin-bottom: spacing() !important;
+    }
+
+        .u-spacingBottom--large {
+            margin-bottom: spacing(x2) !important;
+        }
+
+        .u-spacingBottom--large--aboveMid {
+            @include media('>=mid') {
+                margin-bottom: spacing(x2);
+            }
+        }
+
+    .u-spacingLeft {
+        margin-left: spacing() !important;
+    }
+
+    //
+    // Padding Utilities
+    // ==========================================================================
+
+    .u-noPad {
+        padding: 0 !important;
+    }
+
+    .u-padTop {
+        padding-top: spacing() !important;
+    }
+
+        .u-padTop--large {
             padding-top: spacing(x2) !important;
         }
+
+        .u-padTop--large--aboveMid {
+            @include media('>=mid') {
+                padding-top: spacing(x2) !important;
+            }
+        }
+
+
+    //
+    // Overlay Utilities
+    // ==========================================================================
+
+    .u-overlay {
+        background-color: rgba(0, 0, 0, 0.5);
+        bottom: 0;
+        left: 0;
+        position: fixed;
+        right: 0;
+        top: 0;
     }
 
+        .u-overlay--after {
+            &:after {
+                background-color: rgba(0, 0, 0, 0.5);
+                bottom: 0;
+                content: '';
+                left: 0;
+                position: fixed;
+                right: 0;
+                top: 0;
+                z-index: zIndex(low);
+            }
+        }
 
-//
-// Overlay Utilities
-// ==========================================================================
+    .u-preventScroll {
+        overflow: hidden;
+    }
 
-.u-overlay {
-    background-color: rgba(0, 0, 0, 0.5);
-    bottom: 0;
-    left: 0;
-    position: fixed;
-    right: 0;
-    top: 0;
-}
+    //
+    // Image Replacement Techniques
+    // ==========================================================================
 
-    .u-overlay--after {
-        &:after {
-            background-color: rgba(0, 0, 0, 0.5);
-            bottom: 0;
-            content: '';
-            left: 0;
-            position: fixed;
-            right: 0;
-            top: 0;
-            z-index: zIndex(low);
+    [data-lazy-image-src] {
+        display: block;
+
+        .no-js & {
+            display: none;
         }
     }
 
-.u-preventScroll {
-    overflow: hidden;
-}
 
-//
-// Image Replacement Techniques
-// ==========================================================================
+    // For background image replacement
+    %u-ir,
+    .u-ir {
+        background-color: transparent;
+        background-repeat: no-repeat;
+        border: 0;
+        direction: ltr;
+        display: block;
+        overflow: hidden;
+        text-align: left;
+        text-indent: -999em;
 
-[data-lazy-image-src] {
-    display: block;
-
-    .no-js & {
-        display: none;
-    }
-}
-
-
-// For background image replacement
-%u-ir,
-.u-ir {
-    background-color: transparent;
-    background-repeat: no-repeat;
-    border: 0;
-    direction: ltr;
-    display: block;
-    overflow: hidden;
-    text-align: left;
-    text-indent: -999em;
-
-    br {
-        display: none;
-    }
-}
-
-// Alternative image replacement technique
-.u-hideText,
-%u-hideText {
-    text-indent: 110%;
-    white-space: nowrap;
-    overflow: hidden;
-}
-
-//
-// List Helper
-// ==========================================================================
-
-.u-unstyled,
-%u-unstyled {
-    margin-top: 0;
-    margin-left: 0;
-    padding: 0;
-    list-style: none;
-    list-style-image: none;
-
-    & > li {
-        margin-bottom: 0;
-
-        &:before {
-            content: none;
+        br {
+            display: none;
         }
     }
-}
 
-//
-// Helper classes for focus accessibility
-// =================================================================================
+    // Alternative image replacement technique
+    .u-hideText,
+    %u-hideText {
+        text-indent: 110%;
+        white-space: nowrap;
+        overflow: hidden;
+    }
 
-/* Custom outline styling for elements that have a focus state */
-%u-elementFocus,
-.u-elementFocus {
-    outline: 2px solid $color-focus-outline;
-}
+    //
+    // List Helper
+    // ==========================================================================
 
-/* Custom visual outline emulation for better appearance on elements with rounded corners */
-%u-elementFocus--boxShadow,
-.u-elementFocus--boxShadow {
-  outline: none;
-  box-shadow: 0 0 0 2px $color-focus-outline;
-}
+    .u-unstyled,
+    %u-unstyled {
+        margin-top: 0;
+        margin-left: 0;
+        padding: 0;
+        list-style: none;
+        list-style-image: none;
 
-/*
- * Clever hack to have focus on an element but only when keyboard focused (not click)
- * https://stackoverflow.com/questions/31402576/enable-focus-only-on-keyboard-use-or-tab-press
- */
-%u-focusShadow,
-.u-focusShadow:focus,
-.u-focusShadow-content:focus {
+        & > li {
+            margin-bottom: 0;
+
+            &:before {
+                content: none;
+            }
+        }
+    }
+
+    //
+    // Helper classes for focus accessibility
+    // =================================================================================
+
+    /* Custom outline styling for elements that have a focus state */
+    %u-elementFocus,
+    .u-elementFocus {
+        outline: 2px solid $color-focus-outline;
+    }
+
+    /* Custom visual outline emulation for better appearance on elements with rounded corners */
+    %u-elementFocus--boxShadow,
+    .u-elementFocus--boxShadow {
     outline: none;
-}
-%u-focusShadow-content,
-.u-focusShadow:focus > .u-focusShadow-content {
-    box-shadow: 0 0 2px 2px $color-focus-outline; /* keyboard-only focus styles */
-}
+    box-shadow: 0 0 0 2px $color-focus-outline;
+    }
+
+    /*
+    * Clever hack to have focus on an element but only when keyboard focused (not click)
+    * https://stackoverflow.com/questions/31402576/enable-focus-only-on-keyboard-use-or-tab-press
+    */
+    %u-focusShadow,
+    .u-focusShadow:focus,
+    .u-focusShadow-content:focus {
+        outline: none;
+    }
+    %u-focusShadow-content,
+    .u-focusShadow:focus > .u-focusShadow-content {
+        box-shadow: 0 0 2px 2px $color-focus-outline; /* keyboard-only focus styles */
+    }
 
 
-//
-// Misc classes
-// ==========================================================================
-.u-shadowBottom--belowMid {
-    padding-bottom: spacing(x7);
+    //
+    // Misc classes
+    // ==========================================================================
+    .u-shadowBottom--belowMid {
+        padding-bottom: spacing(x7);
 
-    @include media('<mid') {
-        &:after {
-            background-color: $grey--lighter;
-            border: 0;
-            box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, 0.1);
-            content: '';
-            display: block;
-            height: spacing(x7);
-            left: -#{spacing()};
-            position: absolute;
-            width: 100vw;
+        @include media('<mid') {
+            &:after {
+                background-color: $grey--lighter;
+                border: 0;
+                box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, 0.1);
+                content: '';
+                display: block;
+                height: spacing(x7);
+                left: -#{spacing()};
+                position: absolute;
+                width: 100vw;
+            }
         }
     }
 }

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -183,23 +183,23 @@
     }
 
     .u-color-secondary {
-        color: $color-secondary;
+        color: $color-blue;
     }
 
     .u-color-text--hint {
-        color: $color-text--hint;
+        color: $color-grey-40;
     }
 
     .u-color-text--success {
-        color: $color-text--success;
+        color: $color-content-positive;
     }
 
     .u-color-text--danger {
-        color: $color-text--danger;
+        color: $color-content-error;
     }
 
     .u-color-text--warning {
-        color: $color-text--warning;
+        color: $color-content-brand-strong;
     }
 
     //
@@ -363,14 +363,14 @@
     /* Custom outline styling for elements that have a focus state */
     %u-elementFocus,
     .u-elementFocus {
-        outline: 2px solid $color-focus-outline;
+        outline: 2px solid $color-focus;
     }
 
     /* Custom visual outline emulation for better appearance on elements with rounded corners */
     %u-elementFocus--boxShadow,
     .u-elementFocus--boxShadow {
     outline: none;
-    box-shadow: 0 0 0 2px $color-focus-outline;
+    box-shadow: 0 0 0 2px $color-focus;
     }
 
     /*
@@ -384,7 +384,7 @@
     }
     %u-focusShadow-content,
     .u-focusShadow:focus > .u-focusShadow-content {
-        box-shadow: 0 0 2px 2px $color-focus-outline; /* keyboard-only focus styles */
+        box-shadow: 0 0 2px 2px $color-focus; /* keyboard-only focus styles */
     }
 
 

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -187,7 +187,7 @@
     }
 
     .u-color-text--hint {
-        color: $color-grey-40;
+        color: $color-content-subdued;
     }
 
     .u-color-text--success {

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -23,7 +23,7 @@
     // ==========================================================================
 
     .u-lightenBg {
-        background-color: $white;
+        background-color: $color-white;
     }
 
     .u-bordered,
@@ -153,7 +153,7 @@
     }
 
     .u-text-highlight {
-        color: $red;
+        color: $color-red;
 
         @at-root em#{&} {
             font-style: normal;
@@ -396,7 +396,7 @@
 
         @include media('<mid') {
             &:after {
-                background-color: $grey--lighter;
+                background-color: $color-grey-20;
                 border: 0;
                 box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, 0.1);
                 content: '';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,10 +1149,10 @@
   dependencies:
     "@justeat/dom-buddy" "2.4.3"
 
-"@justeat/pie-design-tokens@0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@justeat/pie-design-tokens/-/pie-design-tokens-0.18.0.tgz#0f88859ddf31e6be05f86e42e0c0f7d7b39ed41b"
-  integrity sha512-vxUuc4mdSU8ojIjuE7TtotSmastITeZ5WlUWmvjVl1tvbXzHdr6cJCSJV1WaQ4N2hjjrEpL9FfPAV5kPzGKxwA==
+"@justeat/pie-design-tokens@0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@justeat/pie-design-tokens/-/pie-design-tokens-0.19.0.tgz#5110e0a607eb215353de4313ba457dab7dd6d459"
+  integrity sha512-YfQ2GkKaq36ZzgShkcKxZx1tefAr2I/19RY0G1aUhf7meq5fSkzkViHWlhGQHFO5t9syLgJ1oCHiwk2LPdaWZw==
   dependencies:
     jsonc-parser "2.2.0"
     lodash.merge "4.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4108,14 +4108,14 @@ concat-with-sourcemaps@*:
   dependencies:
     source-map "^0.6.1"
 
-concurrently@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-6.0.0.tgz#c1a876dd99390979c71f8c6fe6796882f3a13199"
-  integrity sha512-Ik9Igqnef2ONLjN2o/OVx1Ow5tymVvvEwQeYCQdD/oV+CN9oWhxLk7ibcBdOtv0UzBqHCEKRwbKceYoTK8t3fQ==
+concurrently@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-6.2.1.tgz#d880fc1d77559084732fa514092a3d5109a0d5bf"
+  integrity sha512-emgwhH+ezkuYKSHZQ+AkgEpoUZZlbpPVYCVv7YZx0r+T7fny1H03r2nYRebpi2DudHR4n1Rgbo2YTxKOxVJ4+g==
   dependencies:
     chalk "^4.1.0"
     date-fns "^2.16.1"
-    lodash "^4.17.20"
+    lodash "^4.17.21"
     read-pkg "^5.2.0"
     rxjs "^6.6.3"
     spawn-command "^0.0.2-1"
@@ -4264,10 +4264,10 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-coveralls@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.1.0.tgz#13c754d5e7a2dd8b44fe5269e21ca394fb4d615b"
-  integrity sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==
+coveralls@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.1.1.tgz#f5d4431d8b5ae69c5079c8f8ca00d64ac77cf081"
+  integrity sha512-+dxnG2NHncSD1NrqbSM3dn/lE57O6Qf/koe9+I7c+wzkqRmEvcp0kgJdxKInzYzkICKkFMZsX3Vct3++tsF9ww==
   dependencies:
     js-yaml "^3.13.1"
     lcov-parse "^1.0.0"
@@ -4575,10 +4575,10 @@ d@1, d@^1.0.1:
     es5-ext "^0.10.50"
     type "^1.0.1"
 
-danger@10.6.3:
-  version "10.6.3"
-  resolved "https://registry.yarnpkg.com/danger/-/danger-10.6.3.tgz#a312893991a7ceb3376b177a6643b1185a9cf34b"
-  integrity sha512-9aLh21tdJGb1CNuuk0xostg2jix8jFQ+CZuC4h38832Wbcaznj+hA8i7E1VPM5d797SIGURdemLvYBlLcgZ4YQ==
+danger@10.6.6:
+  version "10.6.6"
+  resolved "https://registry.yarnpkg.com/danger/-/danger-10.6.6.tgz#d9861506dc70eb98c5f00754b520f32e86400dcc"
+  integrity sha512-RBqANs6xbWSCqZMy3+/eIYuC9kd7g5NqJ8PqDJKylPhvBoJEDkDrHQvExYHiP2UquvaZcPWsKohmOQXrosrpdw==
   dependencies:
     "@babel/polyfill" "^7.2.5"
     "@octokit/rest" "^16.43.1"
@@ -8097,10 +8097,10 @@ in-publish@^2.0.0:
   resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.1.tgz#948b1a535c8030561cea522f73f78f4be357e00c"
   integrity sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==
 
-include-media@1.4.9:
-  version "1.4.9"
-  resolved "https://registry.yarnpkg.com/include-media/-/include-media-1.4.9.tgz#d0020b7be3eb2d54868a20943595ce380e0bc43b"
-  integrity sha1-0AILe+PrLVSGiiCUNZXOOA4LxDs=
+include-media@1.4.10:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/include-media/-/include-media-1.4.10.tgz#7a311c92c396c808504ec6a5365115d30571f259"
+  integrity sha512-TymQzKF7oWHbItEcEHOCponZ90lRr1I9QbYeD+qCxXy4Z0/pSpS4Ocz2bq3FMOERlXXrY9Sawsh9GjiObVQA6A==
 
 indent-string@^2.1.0:
   version "2.1.0"
@@ -10260,7 +10260,7 @@ lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
-lodash@^4.17.20:
+lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1057,10 +1057,10 @@
     handlebars-helper-i18n "^0.1.0"
     handlebars-helper-inlinesvg "^1.0.4"
 
-"@justeat/f-utils@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-1.1.0.tgz#7407d0accec0de8c542478f63e0a015ec9098877"
-  integrity sha512-5nR77wCUngMfrBlPsM+nQJiOEh+I/DZWZiqO3cxZaOg9seanKBZnXMwyWnNAfx3ICzhJ3ejkMj2PSrAz2CxNYw==
+"@justeat/f-utils@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-2.0.0.tgz#34e34870f20ec85b5d0aca8a87e2bc2225e2f597"
+  integrity sha512-fFkNH39Qe6sg6e2YZmbh4l4g4qegvpsaEKnj1grCDRspQQvzpmBQBifx6nkHsdaEhetZTJC3LqwOXybmlVJI/g==
 
 "@justeat/gulp-build-fozzie@10.2.1":
   version "10.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1539,14 +1539,6 @@ after@0.8.2:
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
   integrity sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=
 
-agent-base@2:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-2.1.1.tgz#d6de10d5af6132d5bd692427d46fc538539094c7"
-  integrity sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=
-  dependencies:
-    extend "~3.0.0"
-    semver "~5.0.1"
-
 agent-base@4, agent-base@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
@@ -1762,7 +1754,7 @@ ansi-dim@^0.1.1:
   dependencies:
     ansi-wrap "0.1.0"
 
-ansi-escapes@^1.1.0, ansi-escapes@^1.1.1:
+ansi-escapes@^1.1.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
   integrity sha1-06ioOzGapneTZisT52HHkRQiMG4=
@@ -3535,15 +3527,6 @@ camelcase-keys@^2.0.0:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
 
-camelcase-keys@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz#a2aa5fb1af688758259c32c141426d78923b9b77"
-  integrity sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=
-  dependencies:
-    camelcase "^4.1.0"
-    map-obj "^2.0.0"
-    quick-lru "^1.0.0"
-
 camelcase-keys@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
@@ -3563,7 +3546,7 @@ camelcase@^3.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
   integrity sha1-MvxLn82vhF/N9+c7uXysImHwqwo=
 
-camelcase@^4.0.0, camelcase@^4.1.0:
+camelcase@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
@@ -3620,7 +3603,7 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.5.tgz#ac82a944905a65ce204eb03023157edf29425c17"
   integrity sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==
 
-chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
@@ -3675,11 +3658,6 @@ character-reference-invalid@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
   integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
-
-chardet@^0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
-  integrity sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -3765,19 +3743,12 @@ cli-boxes@^1.0.0:
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
   integrity sha1-T6kXw+WclKAEzWH47lCdplFocUM=
 
-cli-cursor@^1.0.1, cli-cursor@^1.0.2:
+cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
   integrity sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=
   dependencies:
     restore-cursor "^1.0.1"
-
-cli-cursor@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
-  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
-  dependencies:
-    restore-cursor "^2.0.0"
 
 cli-cursor@^3.1.0:
   version "3.1.0"
@@ -3790,11 +3761,6 @@ cli-width@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-1.1.1.tgz#a4d293ef67ebb7b88d4a4d42c0ccf00c4d1e366d"
   integrity sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=
-
-cli-width@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
-  integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
 
 cli-width@^3.0.0:
   version "3.0.0"
@@ -4014,11 +3980,6 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-0.6.1.tgz#fa68a14f6a945d54dbbe50d8cdb3320e9e3b1a06"
-  integrity sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=
-
 commander@^2.18.0, commander@^2.2.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -4117,7 +4078,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.4.1, concat-stream@^1.4.7, concat-stream@^1.6.0, concat-stream@^1.6.1, concat-stream@~1.6.0:
+concat-stream@^1.4.1, concat-stream@^1.6.0, concat-stream@^1.6.1, concat-stream@~1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -4717,7 +4678,7 @@ debug-fabulous@1.X:
     memoizee "0.4.X"
     object-assign "4.X"
 
-debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.4.1, debug@^2.6.0, debug@^2.6.2, debug@^2.6.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.4.1, debug@^2.6.0, debug@^2.6.2, debug@^2.6.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -4745,7 +4706,7 @@ debug@4.1.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.0:
   dependencies:
     ms "^2.1.1"
 
-decamelize-keys@^1.0.0, decamelize-keys@^1.1.0:
+decamelize-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
   integrity sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=
@@ -5153,26 +5114,6 @@ download@^7.1.0:
     make-dir "^1.2.0"
     p-event "^2.1.0"
     pify "^3.0.0"
-
-dox@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/dox/-/dox-0.6.1.tgz#8247075ad4b275fe88fbbae02fe12f3c5480a7fd"
-  integrity sha1-gkcHWtSydf6I+7rgL+EvPFSAp/0=
-  dependencies:
-    commander "0.6.1"
-    jsdoctypeparser "^1.1.1"
-    marked ">=0.3.1"
-
-doxme@^1.8.1:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/doxme/-/doxme-1.8.2.tgz#8dc3c4a38682a4e96a72e0029eaad5c1a3546442"
-  integrity sha1-jcPEo4aCpOlqcuACnqrVwaNUZEI=
-  dependencies:
-    concat-stream "^1.4.7"
-    markdown-table "^0.3.1"
-    minimist "^1.1.0"
-    repo-path-parse "^1.0.1"
-    striptags "^2.0.0"
 
 duplexer2@0.0.2:
   version "0.0.2"
@@ -6086,28 +6027,10 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@3, extend@^3.0.0, extend@~3.0.0, extend@~3.0.2:
+extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
-
-external-editor@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-1.1.1.tgz#12d7b0db850f7ff7e7081baf4005700060c4600b"
-  integrity sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=
-  dependencies:
-    extend "^3.0.0"
-    spawn-sync "^1.0.15"
-    tmp "^0.0.29"
-
-external-editor@^2.0.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
-  integrity sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==
-  dependencies:
-    chardet "^0.4.0"
-    iconv-lite "^0.4.17"
-    tmp "^0.0.33"
 
 external-editor@^3.0.3:
   version "3.1.0"
@@ -6153,24 +6076,6 @@ eyeglass@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/eyeglass/-/eyeglass-1.4.1.tgz#641591720df59291690cea7c45afa64d04840838"
   integrity sha512-StYCyE+gClI+/dw7HyujkxHZozEAVE6pYgEKfSudY9kpVrcbS9k885KZlfSQ5s6U9DESgCXd9xRAVK072/XFSA==
-  dependencies:
-    archy "^1.0.0"
-    deasync "^0.1.4"
-    debug "^2.2.0"
-    ensure-symlink "^1.0.0"
-    fs-extra "^0.30.0"
-    glob "^7.1.0"
-    json-stable-stringify "^1.0.1"
-    lodash.includes "^4.3.0"
-    lodash.merge "^4.6.0"
-    node-sass "^4.0.0 || ^3.10.1"
-    node-sass-utils "^1.1.2"
-    semver "^5.0.3"
-
-eyeglass@^1.1.2:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/eyeglass/-/eyeglass-1.6.0.tgz#7e3f045614f12cbb32813b5413eca1c588d8a1c5"
-  integrity sha512-X7BOWRxX6C4jlOXCWxRXKfQ2PAKQiV80ChvGIS8vRF7O7puBz9IAcX9nJBz1/jqgEEgssaJjA2rfC3wtorD3vw==
   dependencies:
     archy "^1.0.0"
     deasync "^0.1.4"
@@ -6267,13 +6172,6 @@ figures@^1.0.1, figures@^1.3.5, figures@^1.4.0:
   dependencies:
     escape-string-regexp "^1.0.5"
     object-assign "^4.1.0"
-
-figures@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
-  integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
-  dependencies:
-    escape-string-regexp "^1.0.5"
 
 figures@^3.0.0:
   version "3.2.0"
@@ -6559,14 +6457,6 @@ flush-write-stream@^1.0.2:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
-
-follow-redirects@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-0.0.7.tgz#34b90bab2a911aa347571da90f22bd36ecd8a919"
-  integrity sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=
-  dependencies:
-    debug "^2.2.0"
-    stream-consume "^0.1.0"
 
 follow-redirects@1.5.10:
   version "1.5.10"
@@ -6913,23 +6803,6 @@ git-repo-name@^0.6.0:
     lazy-cache "^1.0.4"
     remote-origin-url "^0.5.1"
 
-github@9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/github/-/github-9.2.0.tgz#8a886dc40dd63636707dcaf99df3df26c59f16fc"
-  integrity sha1-iohtxA3WNjZwfcr5nfPfJsWfFvw=
-  dependencies:
-    follow-redirects "0.0.7"
-    https-proxy-agent "^1.0.0"
-    mime "^1.2.11"
-    netrc "^0.1.4"
-
-github@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/github/-/github-0.2.4.tgz#24fa7f0e13fa11b946af91134c51982a91ce538b"
-  integrity sha1-JPp/DhP6EblGr5ETTFGYKpHOU4s=
-  dependencies:
-    mime "^1.2.11"
-
 gitlab@^10.0.1:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/gitlab/-/gitlab-10.2.1.tgz#1f5fb2c2bad08f95b7c7d91dd41805ab5eea3960"
@@ -7015,18 +6888,6 @@ glob-watcher@^5.0.3:
     just-debounce "^1.0.0"
     normalize-path "^3.0.0"
     object.defaults "^1.1.0"
-
-glob@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
-  integrity sha1-gFIR3wT6rxxjo2ADBs31reULLsg=
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
 
 glob@7.1.2:
   version "7.1.2"
@@ -7250,12 +7111,7 @@ got@^8.3.1:
     url-parse-lax "^3.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@4.1.11:
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-  integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
-
-graceful-fs@4.X, graceful-fs@^4.0.0, graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
+graceful-fs@4.X, graceful-fs@^4.0.0, graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -8062,15 +7918,6 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-https-proxy-agent@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz#35f7da6c48ce4ddbfa264891ac593ee5ff8671e6"
-  integrity sha1-NffabEjOTdv6JkiRrFk+5f+GceY=
-  dependencies:
-    agent-base "2"
-    debug "2"
-    extend "3"
-
 https-proxy-agent@^2.2.1:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
@@ -8094,7 +7941,7 @@ hyperlinker@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
   integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24:
+iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -8232,7 +8079,7 @@ in-publish@^2.0.0:
   resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.1.tgz#948b1a535c8030561cea522f73f78f4be357e00c"
   integrity sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==
 
-include-media@1.4.9, include-media@^1.4.8:
+include-media@1.4.9:
   version "1.4.9"
   resolved "https://registry.yarnpkg.com/include-media/-/include-media-1.4.9.tgz#d0020b7be3eb2d54868a20943595ce380e0bc43b"
   integrity sha1-0AILe+PrLVSGiiCUNZXOOA4LxDs=
@@ -8243,11 +8090,6 @@ indent-string@^2.1.0:
   integrity sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=
   dependencies:
     repeating "^2.0.0"
-
-indent-string@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
-  integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
 
 indent-string@^4.0.0:
   version "4.0.0"
@@ -8334,45 +8176,6 @@ inquirer2@^0.1.1:
     strip-color "^0.1.0"
     through2 "^2.0.0"
 
-inquirer@3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.0.6.tgz#e04aaa9d05b7a3cb9b0f407d04375f0447190347"
-  integrity sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=
-  dependencies:
-    ansi-escapes "^1.1.0"
-    chalk "^1.0.0"
-    cli-cursor "^2.1.0"
-    cli-width "^2.0.0"
-    external-editor "^2.0.1"
-    figures "^2.0.0"
-    lodash "^4.3.0"
-    mute-stream "0.0.7"
-    run-async "^2.2.0"
-    rx "^4.1.0"
-    string-width "^2.0.0"
-    strip-ansi "^3.0.0"
-    through "^2.3.6"
-
-inquirer@^1.0.2:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-1.2.3.tgz#4dec6f32f37ef7bb0b2ed3f1d1a5c3f545074918"
-  integrity sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=
-  dependencies:
-    ansi-escapes "^1.1.0"
-    chalk "^1.0.0"
-    cli-cursor "^1.0.1"
-    cli-width "^2.0.0"
-    external-editor "^1.1.0"
-    figures "^1.3.5"
-    lodash "^4.3.0"
-    mute-stream "0.0.6"
-    pinkie-promise "^2.0.0"
-    run-async "^2.2.0"
-    rx "^4.1.0"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.0"
-    through "^2.3.6"
-
 inquirer@^7.0.0:
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
@@ -8408,7 +8211,7 @@ insert-module-globals@^7.0.0:
     undeclared-identifiers "^1.1.2"
     xtend "^4.0.0"
 
-interpret@^1.0.0, interpret@^1.4.0:
+interpret@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
@@ -9568,13 +9371,6 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jsdoctypeparser@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/jsdoctypeparser/-/jsdoctypeparser-1.2.0.tgz#e7dedc153a11849ffc5141144ae86a7ef0c25392"
-  integrity sha1-597cFToRhJ/8UUEUSuhqfvDCU5I=
-  dependencies:
-    lodash "^3.7.0"
-
 jsdom@^15.2.1:
   version "15.2.1"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-15.2.1.tgz#d2feb1aef7183f86be521b8c6833ff5296d07ec5"
@@ -9761,25 +9557,6 @@ keyv@3.0.0:
   integrity sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==
   dependencies:
     json-buffer "3.0.0"
-
-kickoff-grid.css@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/kickoff-grid.css/-/kickoff-grid.css-1.2.0.tgz#1765f12b4ffd2bafbe358ad0823c58c419f3f9c3"
-  integrity sha512-QmN7zJqyY83FMsy/yM/NjJCE++cJSA5K2VBL9aIMYkfWq2GKflShVyJAb7dvP2i8l4YUziQA3t3s7o4iWojtwg==
-  dependencies:
-    eyeglass "^1.1.2"
-    include-media "^1.4.8"
-    kickoff-utils.scss "^2.0.1"
-  optionalDependencies:
-    npm-scripts-info "^0.3.6"
-    release-it "2.4.0"
-
-kickoff-utils.scss@^2.0.1:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/kickoff-utils.scss/-/kickoff-utils.scss-2.0.6.tgz#4a19666b709fc6d9c0c9f4046e3ae5a901e2fdf7"
-  integrity sha1-Shlma3CfxtnAyfQEbjrlqQHi/fc=
-  optionalDependencies:
-    release-it "^2.7.1"
 
 kind-of@^1.1.0:
   version "1.1.0"
@@ -10003,16 +9780,6 @@ load-json-file@^2.0.0:
     graceful-fs "^4.1.2"
     parse-json "^2.2.0"
     pify "^2.0.0"
-    strip-bom "^3.0.0"
-
-load-json-file@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
-  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
-  dependencies:
-    graceful-fs "^4.1.2"
-    parse-json "^4.0.0"
-    pify "^3.0.0"
     strip-bom "^3.0.0"
 
 load-pkg@^3.0.1:
@@ -10465,17 +10232,7 @@ lodash.where@^3.1.0:
     lodash._basematches "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash@4.17.4:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-  integrity sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=
-
-lodash@^3.7.0:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-  integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
-
-lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.3.0, lodash@^4.6.1, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@~4.17.10:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -10687,11 +10444,6 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
   integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
 
-map-obj@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
-  integrity sha1-plzSkIepJZi4eRJXpSPgISIqwfk=
-
 map-obj@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.1.0.tgz#b91221b542734b9f14256c0132c897c5d7256fd5"
@@ -10748,20 +10500,10 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
-markdown-table@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-0.3.2.tgz#ab0501425117218c498754d57e244dcd4a80232e"
-  integrity sha1-qwUBQlEXIYxJh1TVfiRNzUqAIy4=
-
 markdown-table@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
   integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
-
-marked@>=0.3.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.1.1.tgz#e5d61b69842210d5df57b05856e0c91572703e6a"
-  integrity sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw==
 
 match-file@^0.2.1:
   version "0.2.2"
@@ -10881,21 +10623,6 @@ meow@^3.1.0, meow@^3.3.0, meow@^3.7.0:
     read-pkg-up "^1.0.1"
     redent "^1.0.0"
     trim-newlines "^1.0.0"
-
-meow@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-4.0.1.tgz#d48598f6f4b1472f35bf6317a95945ace347f975"
-  integrity sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==
-  dependencies:
-    camelcase-keys "^4.0.0"
-    decamelize-keys "^1.0.0"
-    loud-rejection "^1.0.0"
-    minimist "^1.1.3"
-    minimist-options "^3.0.1"
-    normalize-package-data "^2.3.4"
-    read-pkg-up "^3.0.0"
-    redent "^2.0.0"
-    trim-newlines "^2.0.0"
 
 meow@^6.0.0:
   version "6.1.1"
@@ -11028,20 +10755,10 @@ mime@1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
   integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
 
-mime@^1.2.11:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
-  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
-
 mime@^2.4.0:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
   integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
-
-mimic-fn@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
-  integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -11075,14 +10792,6 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist-options@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-3.0.2.tgz#fba4c8191339e13ecf4d61beb03f070103f3d954"
-  integrity sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==
-  dependencies:
-    arrify "^1.0.1"
-    is-plain-obj "^1.1.0"
-
 minimist-options@^4.0.2:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
@@ -11101,11 +10810,6 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
 minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
@@ -11222,16 +10926,6 @@ mute-stream@0.0.5:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
   integrity sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=
 
-mute-stream@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.6.tgz#48962b19e169fd1dfc240b3f1e7317627bbc47db"
-  integrity sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=
-
-mute-stream@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
-  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
-
 mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
@@ -11278,11 +10972,6 @@ neo-async@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
-
-netrc@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
-  integrity sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ=
 
 next-tick@1:
   version "1.1.0"
@@ -11533,15 +11222,6 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npm-scripts-info@^0.3.6:
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/npm-scripts-info/-/npm-scripts-info-0.3.9.tgz#464e4178218e454564adca7ba71925bc71a4973d"
-  integrity sha512-r3kftwUxThTxQoZ+RoR8xVIL1FOmqpCM6+7BH6jR4HPdigNbBs9Bg1nt3Qrqn2b8jj4NrE69+kWE3EkmNxkmkg==
-  dependencies:
-    chalk "^2.3.0"
-    meow "^4.0.0"
-    unquote "^1.1.0"
-
 "npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
@@ -11770,13 +11450,6 @@ onetime@^1.0.0:
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
   integrity sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=
 
-onetime@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
-  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
-  dependencies:
-    mimic-fn "^1.0.0"
-
 onetime@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
@@ -11879,12 +11552,7 @@ os-name@^3.1.0:
     macos-release "^2.2.0"
     windows-release "^3.1.0"
 
-os-shim@^0.1.2:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
-  integrity sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=
-
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -12004,13 +11672,6 @@ p-reduce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
   integrity sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=
-
-p-retry@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-1.0.0.tgz#3927332a4b7d70269b535515117fc547da1a6968"
-  integrity sha1-OSczKkt9cCabU1UVEX/FR9oaaWg=
-  dependencies:
-    retry "^0.10.0"
 
 p-timeout@^1.1.1:
   version "1.2.1"
@@ -12206,11 +11867,6 @@ parse-passwd@^1.0.0:
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
   integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
-parse-repo@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parse-repo/-/parse-repo-1.0.1.tgz#b8a81ef4746064c7d89dcb60b3c74a9ad6700720"
-  integrity sha1-uKge9HRgZMfYnctgs8dKmtZwByA=
-
 parse5@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
@@ -12344,13 +12000,6 @@ path-type@^2.0.0:
   integrity sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=
   dependencies:
     pify "^2.0.0"
-
-path-type@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
-  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
-  dependencies:
-    pify "^3.0.0"
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -13173,11 +12822,6 @@ question-store@^0.13.0:
     project-name "^0.2.6"
     question-cache "^0.7.0"
 
-quick-lru@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
-  integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
-
 quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
@@ -13270,14 +12914,6 @@ read-pkg-up@^2.0.0:
     find-up "^2.0.0"
     read-pkg "^2.0.0"
 
-read-pkg-up@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-3.0.0.tgz#3ed496685dba0f8fe118d0691dc51f4a1ff96f07"
-  integrity sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=
-  dependencies:
-    find-up "^2.0.0"
-    read-pkg "^3.0.0"
-
 read-pkg-up@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
@@ -13304,15 +12940,6 @@ read-pkg@^2.0.0:
     load-json-file "^2.0.0"
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
-
-read-pkg@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
-  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
-  dependencies:
-    load-json-file "^4.0.0"
-    normalize-package-data "^2.3.2"
-    path-type "^3.0.0"
 
 read-pkg@^4.0.1:
   version "4.0.1"
@@ -13417,14 +13044,6 @@ redent@^1.0.0:
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
-
-redent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
-  integrity sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=
-  dependencies:
-    indent-string "^3.0.0"
-    strip-indent "^2.0.0"
 
 redent@^3.0.0:
   version "3.0.0"
@@ -13537,44 +13156,6 @@ relative@^3.0.2:
   integrity sha1-Dc2OxUpdNaPBXhBFA9ZTdbWlNn8=
   dependencies:
     isobject "^2.0.0"
-
-release-it@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/release-it/-/release-it-2.4.0.tgz#e75e2eff9f113681862f231c46904439cbd19a36"
-  integrity sha1-514u/58RNoGGLyMcRpBEOcvRmjY=
-  dependencies:
-    chalk "^1.1.1"
-    github "^0.2.4"
-    glob "^7.0.3"
-    graceful-fs "^4.1.3"
-    inquirer "^1.0.2"
-    lodash "^4.6.1"
-    minimist "^1.2.0"
-    mkdirp "^0.5.1"
-    repo-path-parse "^1.0.1"
-    semver "^5.1.0"
-    shelljs "^0.7.0"
-    when "^3.7.7"
-
-release-it@^2.7.1:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/release-it/-/release-it-2.9.0.tgz#fe1efd70132ae5640efdde4194760d0f2a7dea2c"
-  integrity sha512-B0WO4NZ1Dunm06Y4dJWnmT9iFMdXWu9L4pfjJAdFzIsnQB6ErCHVkdT0OJAtpY7gsP9g6nhBS9epxr5n2kiRkQ==
-  dependencies:
-    chalk "1.1.3"
-    github "9.2.0"
-    glob "7.1.1"
-    graceful-fs "4.1.11"
-    inquirer "3.0.6"
-    lodash "4.17.4"
-    minimist "1.2.0"
-    mkdirp "0.5.1"
-    p-retry "1.0.0"
-    parse-repo "1.0.1"
-    semver "5.3.0"
-    shelljs "0.7.7"
-    update-notifier "^2.3.0"
-    when "3.7.8"
 
 remark-parse@^6.0.0:
   version "6.0.3"
@@ -13703,14 +13284,6 @@ replace-homedir@^1.0.0:
     homedir-polyfill "^1.0.1"
     is-absolute "^1.0.0"
     remove-trailing-separator "^1.1.0"
-
-repo-path-parse@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/repo-path-parse/-/repo-path-parse-1.0.1.tgz#c510fbd5cd47eea04d81ca33cc5d4d533c8da60a"
-  integrity sha1-xRD71c1H7qBNgcozzF1NUzyNpgo=
-  dependencies:
-    dox "^0.6.1"
-    doxme "^1.8.1"
 
 repo-utils@^0.3.6, repo-utils@^0.3.7:
   version "0.3.7"
@@ -13898,14 +13471,6 @@ restore-cursor@^1.0.1:
     exit-hook "^1.0.0"
     onetime "^1.0.0"
 
-restore-cursor@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
-  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
-  dependencies:
-    onetime "^2.0.0"
-    signal-exit "^3.0.2"
-
 restore-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
@@ -13935,11 +13500,6 @@ retry@0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
-
-retry@^0.10.0:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
-  integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
 
 reusify@^1.0.4:
   version "1.0.4"
@@ -14070,7 +13630,7 @@ run-async@^0.1.0:
   dependencies:
     once "^1.3.0"
 
-run-async@^2.2.0, run-async@^2.4.0:
+run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
@@ -14085,7 +13645,7 @@ rx-lite@^4.0.7:
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
   integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
 
-rx@4.1.0, rx@^4.1.0:
+rx@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
   integrity sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=
@@ -14214,11 +13774,6 @@ semver-truncate@^1.1.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@5.3.0, semver@~5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-  integrity sha1-myzl094C0XxgEq0yaqa00M9U+U8=
-
 semver@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
@@ -14229,10 +13784,10 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@~5.0.1:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
-  integrity sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=
+semver@~5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+  integrity sha1-myzl094C0XxgEq0yaqa00M9U+U8=
 
 send@0.16.2:
   version "0.16.2"
@@ -14413,24 +13968,6 @@ shell-quote@^1.6.1:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
-
-shelljs@0.7.7:
-  version "0.7.7"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.7.tgz#b2f5c77ef97148f4b4f6e22682e10bba8667cff1"
-  integrity sha1-svXHfvlxSPS09uImguELuoZnz/E=
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
-shelljs@^0.7.0:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
-  integrity sha1-3svPh0sNHl+3LhSxZKloMEjprLM=
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
 
 shellwords@^0.1.1:
   version "0.1.1"
@@ -14667,14 +14204,6 @@ spawn-command@^0.0.2-1:
   resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
   integrity sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=
 
-spawn-sync@^1.0.15:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
-  integrity sha1-sAeZVX63+wyDdsKdROih6mfldHY=
-  dependencies:
-    concat-stream "^1.4.7"
-    os-shim "^0.1.2"
-
 spdx-correct@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.1.tgz#dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9"
@@ -14848,11 +14377,6 @@ stream-combiner@^0.2.2:
   dependencies:
     duplexer "~0.1.1"
     through "~2.3.4"
-
-stream-consume@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/stream-consume/-/stream-consume-0.1.1.tgz#d3bdb598c2bd0ae82b8cac7ac50b1107a7996c48"
-  integrity sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==
 
 stream-counter@^1.0.0:
   version "1.0.0"
@@ -15124,11 +14648,6 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-indent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
-  integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
-
 strip-indent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
@@ -15152,11 +14671,6 @@ strip-outer@^1.0.0:
   integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
   dependencies:
     escape-string-regexp "^1.0.2"
-
-striptags@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/striptags/-/striptags-2.2.1.tgz#4c450b708d41b8bf39cf24c49ff234fc6aabfd32"
-  integrity sha1-TEULcI1BuL85zyTEn/I0/Gqr/TI=
 
 striptags@^3.1.0:
   version "3.1.1"
@@ -15650,13 +15164,6 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tmp@^0.0.29:
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.29.tgz#f25125ff0dd9da3ccb0c2dd371ee1288bb9128c0"
-  integrity sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=
-  dependencies:
-    os-tmpdir "~1.0.1"
-
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -15811,11 +15318,6 @@ trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
   integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
-
-trim-newlines@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
-  integrity sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=
 
 trim-newlines@^3.0.0:
   version "3.0.0"
@@ -16168,7 +15670,7 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
-unquote@^1.1.0, unquote@~1.1.1:
+unquote@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz#8fded7324ec6e88a0ff8b905e7c098cdc086d544"
   integrity sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=
@@ -16630,11 +16132,6 @@ whatwg-url@^7.0.0:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
-
-when@3.7.8, when@^3.7.7:
-  version "3.7.8"
-  resolved "https://registry.yarnpkg.com/when/-/when-3.7.8.tgz#c7130b6a7ea04693e842cdc9e7a1f2aa39a39f82"
-  integrity sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I=
 
 which-module@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1062,11 +1062,6 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-1.1.0.tgz#7407d0accec0de8c542478f63e0a015ec9098877"
   integrity sha512-5nR77wCUngMfrBlPsM+nQJiOEh+I/DZWZiqO3cxZaOg9seanKBZnXMwyWnNAfx3ICzhJ3ejkMj2PSrAz2CxNYw==
 
-"@justeat/fozzie-colour-palette@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.1.0.tgz#3bbe51404025c5ef8c5e8bf8280a266e51d2a640"
-  integrity sha512-QWkVa0Hv1xQ6nqxY3S1V37fAQUdIaTO1RtAhCKIe5YmNKBKEegW0PbmFIcPk3ojBVnL6Q1hzUhs3wGvOLJAMbg==
-
 "@justeat/gulp-build-fozzie@10.2.1":
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/@justeat/gulp-build-fozzie/-/gulp-build-fozzie-10.2.1.tgz#ff79ce986dcb85d80608b634dcd8945679b79d15"
@@ -1153,6 +1148,15 @@
   integrity sha512-p+j8bK0ZcJ4wt1Uu2QPVzGhQJAkq8YaNFrSKKdeU61ps1hHg2L3nBENluIGGrH6wBKORQ1HDDWgFUBl/JFUO0A==
   dependencies:
     "@justeat/dom-buddy" "2.4.3"
+
+"@justeat/pie-design-tokens@0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@justeat/pie-design-tokens/-/pie-design-tokens-0.18.0.tgz#0f88859ddf31e6be05f86e42e0c0f7d7b39ed41b"
+  integrity sha512-vxUuc4mdSU8ojIjuE7TtotSmastITeZ5WlUWmvjVl1tvbXzHdr6cJCSJV1WaQ4N2hjjrEpL9FfPAV5kPzGKxwA==
+  dependencies:
+    jsonc-parser "2.2.0"
+    lodash.merge "4.6.2"
+    mkdirp "1.0.3"
 
 "@justeat/stylelint-config-fozzie@2.0.1":
   version "2.0.1"
@@ -3567,9 +3571,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001097:
-  version "1.0.30001109"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001109.tgz#a9f3f26a0c3753b063d7acbb48dfb9c0e46f2b19"
-  integrity sha512-4JIXRodHzdS3HdK8nSgIqXYLExOvG+D2/EenSvcub2Kp3QEADjo2v2oUn5g0n0D+UNwG9BtwKOyGcSq2qvQXvQ==
+  version "1.0.30001194"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001194.tgz"
+  integrity sha512-iDUOH+oFeBYk5XawYsPtsx/8fFpndAPUQJC7gBTfxHM8xw5nOZv7ceAD4frS1MKCLUac7QL5wdAJiFQlDRjXlA==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -3793,6 +3797,15 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 clone-buffer@^1.0.0:
   version "1.0.0"
@@ -4095,20 +4108,20 @@ concat-with-sourcemaps@*:
   dependencies:
     source-map "^0.6.1"
 
-concurrently@5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-5.3.0.tgz#7500de6410d043c912b2da27de3202cb489b1e7b"
-  integrity sha512-8MhqOB6PWlBfA2vJ8a0bSFKATOdWlHiQlk11IfmQBPaHVP8oP2gsh2MObE6UR3hqDHqvaIvLTyceNW6obVuFHQ==
+concurrently@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-6.0.0.tgz#c1a876dd99390979c71f8c6fe6796882f3a13199"
+  integrity sha512-Ik9Igqnef2ONLjN2o/OVx1Ow5tymVvvEwQeYCQdD/oV+CN9oWhxLk7ibcBdOtv0UzBqHCEKRwbKceYoTK8t3fQ==
   dependencies:
-    chalk "^2.4.2"
-    date-fns "^2.0.1"
-    lodash "^4.17.15"
-    read-pkg "^4.0.1"
-    rxjs "^6.5.2"
+    chalk "^4.1.0"
+    date-fns "^2.16.1"
+    lodash "^4.17.20"
+    read-pkg "^5.2.0"
+    rxjs "^6.6.3"
     spawn-command "^0.0.2-1"
-    supports-color "^6.1.0"
+    supports-color "^8.1.0"
     tree-kill "^1.2.2"
-    yargs "^13.3.0"
+    yargs "^16.2.0"
 
 config-chain@^1.1.11:
   version "1.1.12"
@@ -4562,10 +4575,10 @@ d@1, d@^1.0.1:
     es5-ext "^0.10.50"
     type "^1.0.1"
 
-danger@10.6.0:
-  version "10.6.0"
-  resolved "https://registry.yarnpkg.com/danger/-/danger-10.6.0.tgz#6fcb10753143aeb60c139065b952dbe783e8ed14"
-  integrity sha512-cN9skuxtkgfnV4CQpF20L3Yt3VhMlBvvWAoh2QashDepI420gwcxoCRpxdCF7GP3aVJuh5LuI9ObrDvAxpnCFA==
+danger@10.6.3:
+  version "10.6.3"
+  resolved "https://registry.yarnpkg.com/danger/-/danger-10.6.3.tgz#a312893991a7ceb3376b177a6643b1185a9cf34b"
+  integrity sha512-9aLh21tdJGb1CNuuk0xostg2jix8jFQ+CZuC4h38832Wbcaznj+hA8i7E1VPM5d797SIGURdemLvYBlLcgZ4YQ==
   dependencies:
     "@babel/polyfill" "^7.2.5"
     "@octokit/rest" "^16.43.1"
@@ -4644,10 +4657,10 @@ data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns@^2.0.1:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.15.0.tgz#424de6b3778e4e69d3ff27046ec136af58ae5d5f"
-  integrity sha512-ZCPzAMJZn3rNUvvQIMlXhDr4A+Ar07eLeGsGREoWU19a3Pqf5oYa+ccd+B3F6XVtQY6HANMFdOQ8A+ipFnvJdQ==
+date-fns@^2.16.1:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.17.0.tgz#afa55daea539239db0a64e236ce716ef3d681ba1"
+  integrity sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA==
 
 date.js@^0.3.1:
   version "0.3.3"
@@ -5503,6 +5516,11 @@ escalade@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.0.2.tgz#6a580d70edb87880f22b4c91d0d56078df6962c4"
   integrity sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==
+
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -6664,7 +6682,7 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -9464,6 +9482,11 @@ json5@^2.1.0, json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+jsonc-parser@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.2.0.tgz#f206f87f9d49d644b7502052c04e82dd6392e9ef"
+  integrity sha512-4fLQxW1j/5fWj6p78vAlAafoCKtuBm6ghv+Ij5W2DrDx0qE+ZdEl2c6Ko1mgJNF5ftX1iEWQQ4Ap7+3GlhjkOA==
+
 jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
@@ -10121,7 +10144,7 @@ lodash.memoize@~3.0.3:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
   integrity sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=
 
-lodash.merge@^4.4.0, lodash.merge@^4.6.0:
+lodash.merge@4.6.2, lodash.merge@^4.4.0, lodash.merge@^4.6.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
@@ -10236,6 +10259,11 @@ lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
+lodash@^4.17.20:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-driver@^1.2.7:
   version "1.2.7"
@@ -10843,6 +10871,11 @@ mkdirp@0.5.1:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mkdirp@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.3.tgz#4cf2e30ad45959dddea53ad97d518b6c8205e1ea"
+  integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
 
 "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.5"
@@ -12941,15 +12974,6 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-read-pkg@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
-  integrity sha1-ljYlN48+HE1IyFhytabsfV0JMjc=
-  dependencies:
-    normalize-package-data "^2.3.2"
-    parse-json "^4.0.0"
-    pify "^3.0.0"
-
 read-pkg@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
@@ -13657,10 +13681,17 @@ rxjs@^5.5.6:
   dependencies:
     symbol-observable "1.0.1"
 
-rxjs@^6.5.2, rxjs@^6.6.0:
+rxjs@^6.6.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.0.tgz#af2901eedf02e3a83ffa7f886240ff9018bbec84"
   integrity sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.6.3:
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -14798,6 +14829,13 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^8.1.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
 
@@ -16224,6 +16262,15 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -16337,6 +16384,11 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
+y18n@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
+  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -16378,6 +16430,11 @@ yargs-parser@^2.4.0:
   dependencies:
     camelcase "^3.0.0"
     lodash.assign "^4.0.6"
+
+yargs-parser@^20.2.2:
+  version "20.2.6"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.6.tgz#69f920addf61aafc0b8b89002f5d66e28f2d8b20"
+  integrity sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==
 
 yargs-parser@^4.1.0, yargs-parser@^4.2.0:
   version "4.2.1"
@@ -16425,7 +16482,7 @@ yargs@6.6.0:
     y18n "^3.2.1"
     yargs-parser "^4.2.0"
 
-yargs@^13.3.0, yargs@^13.3.2:
+yargs@^13.3.2:
   version "13.3.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
   integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
@@ -16457,6 +16514,19 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yargs@^7.1.0:
   version "7.1.1"


### PR DESCRIPTION
v5.0.0
------------------------------
*August 23, 2021*

## Main changes:
- Colour and typography variables updated to use `pie-design-tokens` repo instead of `fozzie-colour-palette`. 
- When importing v5 fozzie, consuming applications only get included variables, functions and mixins (no classes). Component styles for buttons, form-fields etc are being deprecated as we move our components over to versionable packages, but can still be included via optional mixins applications that still need this as part of the transition.
- Two optional variables can be used to include a base set of styles (similar to v4). These are `$includeBaseFramework` and `$includeMinimalFramework`. Check out the `_templates.scss` file to see what styles are included when these are set to true.

### Changed
- Eyeglass version bumped to v3.
- Made all styles and components optional (wrapped in a mixin).
- Lots of colour variables moved over as part of using the new `pie-design-tokens` repo instead of `fozzie-colour-palette`.
- Updated type-map with new typography variables for font-size and line-height.

### Removed
- `/settings/glyphs` moved into badges, as it is the only place it is used.
- `/images` as not used.
- `kickoff-grid` dependency brought into fozzie, to remove external dependency (making it easier to change if needed).
- `$font-weight-bold` was removed as it now comes straight from `pie-design-tokens`.


** Full list of changes (including all colour variable changes) can be found in beta release CHANGELOGs (see full CHANGELOG entries) **


## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines
- [x] UI Documentation has been updated (more incoming shortly)
