### PR TITLE
v6.0.0-beta.0 - new font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Future Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v6.0.0-beta.0
+------------------------------
+*August 20, 2021*
+
+### Updated
+- pie-design-tokens package to v1.0.0-beta.0 to include new font vars
+
+### Added
+- `$font-family-secondary` as a fallback font (Arial)
+
+### Changed
+- `$font-weight-headings` use `$font-weight-extrabold` font weight (800)
+
+
 v5.0.0
 ------------------------------
 *August 23, 2021*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0",
+  "version": "6.0.0-beta.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -36,7 +36,7 @@
     "@justeat/f-dom": "1.1.0",
     "@justeat/f-logger": "0.8.1",
     "@justeat/f-utils": "2.0.0",
-    "@justeat/pie-design-tokens": "0.19.0",
+    "@justeat/pie-design-tokens": "1.0.0-beta.0",
     "fontfaceobserver": "2.1.0",
     "include-media": "1.4.10",
     "normalize-scss": "7.0.1"

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -53,11 +53,11 @@ $type: (
     )
 ) !default;
 
-$font-weight-headings       : $font-weight-bold;
+$font-weight-headings       : $font-weight-extrabold;
 $line-height-base           : line-height();
 
 // Font stacks
-$font-family-base           : $font-family-primary, Arial, sans-serif;
+$font-family-base           : $font-family-primary, $font-family-secondary, sans-serif;
 $font-family-mono           : Menlo, Monaco, 'Courier New', monospace;
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,10 +1149,10 @@
   dependencies:
     "@justeat/dom-buddy" "2.4.3"
 
-"@justeat/pie-design-tokens@0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@justeat/pie-design-tokens/-/pie-design-tokens-0.19.0.tgz#5110e0a607eb215353de4313ba457dab7dd6d459"
-  integrity sha512-YfQ2GkKaq36ZzgShkcKxZx1tefAr2I/19RY0G1aUhf7meq5fSkzkViHWlhGQHFO5t9syLgJ1oCHiwk2LPdaWZw==
+"@justeat/pie-design-tokens@1.0.0-beta.0":
+  version "1.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@justeat/pie-design-tokens/-/pie-design-tokens-1.0.0-beta.0.tgz#272457e7f806ac931800935cd54b10801c45a589"
+  integrity sha512-egiGduhwftk8O9KSnTnK5rN3cP/FY1TurdvFiC12C3mkXEImEZnpLTbf/sZ/StV95m4E69y45jiaPB87FXzSVw==
   dependencies:
     jsonc-parser "2.2.0"
     lodash.merge "4.6.2"


### PR DESCRIPTION
### Updated
- pie-design-tokens package to v1.0.0-beta.0 to include new font vars

### Added
- `$font-family-secondary` as a fallback font (Arial)

### Changed
- `$font-weight-headings` use `$font-weight-extrabold` font weight (800)