### PR TITLE
v5.1.0 - move normalize styles from base to optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Future Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v5.1.0
+------------------------------
+*September 13, 2021*
+
+### Changed
+- Move normalize styles from base to optional. We had to copy the styles straight into the project to be able to make them optional wrapping them into a mixin.
+!!Note: If you don't use `$includeBaseFramework` or `$includeMinimalFramework` vars and want to have normalize styles in you project, you need to `@include normalize()` mixin starting from this version. 
+
+
 v5.0.0
 ------------------------------
 *August 23, 2021*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -38,8 +38,7 @@
     "@justeat/f-utils": "2.0.0",
     "@justeat/pie-design-tokens": "0.19.0",
     "fontfaceobserver": "2.1.0",
-    "include-media": "1.4.10",
-    "normalize-scss": "7.0.1"
+    "include-media": "1.4.10"
   },
   "devDependencies": {
     "@justeat/browserslist-config-fozzie": "1.2.0",

--- a/src/scss/_dependencies.scss
+++ b/src/scss/_dependencies.scss
@@ -37,7 +37,7 @@
 
 
 // CSS Normalise and then Reset
-@import 'normalize/import-now'; // https://www.npmjs.com/package/normalize-scss
+@import 'base/normalize';
 @import 'base/reset';
 
 // Global typography styles

--- a/src/scss/_templates.scss
+++ b/src/scss/_templates.scss
@@ -3,6 +3,7 @@
  * as part of Fozzie v4 (useful for anyone upgrading that wants to keep things as-is)
 **/
 @if $includeBaseFramework {
+    @include normalize();
     @include reset();
     @include typography();
 
@@ -38,6 +39,7 @@
  * that provides styling for most use-cases (links, lists, buttons, grid)
  **/
 @if $includeMinimalFramework {
+    @include normalize();
     @include reset();
     @include typography();
 

--- a/src/scss/base/_normalize.scss
+++ b/src/scss/base/_normalize.scss
@@ -1,198 +1,351 @@
 @mixin normalize() {
-    /**
-    * Normalize Styles
-    * =================================
-    * We use normalize.css for the bulk of our 'reset' (https://www.npmjs.com/package/normalize-scss).
-    * We wrap it into a mixin to be able to make it optional.
-    *
-    * This is an optional component within Fozzie.
-    * If you'd like to use it in your project you can include it by adding `@include normalize();` into your SCSS dependencies file.
-    */
+/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
 
-    /*! normalize-scss | MIT/GPLv2 License | bit.ly/normalize-scss v7.0.1*/
-    html {
-        line-height: 1.15;
-        -ms-text-size-adjust: 100%;
-        -webkit-text-size-adjust: 100%;
-    }
-    body {
-        margin: 0;
-    }
-    article,
-    aside,
-    footer,
-    header,
-    nav,
-    section {
-        display: block;
-    }
-    h1 {
-        font-size: 2em;
-        margin: 0.67em 0;
-    }
-    figcaption,
-    figure {
-        display: block;
-    }
-    figure {
-        margin: 1em 40px;
-    }
-    hr {
-        box-sizing: content-box;
-        height: 0;
-        overflow: visible;
-    }
-    main {
-        display: block;
-    }
-    pre {
-        font-family: monospace;
-        font-size: 1em;
-    }
-    a {
-        background-color: transparent;
-        -webkit-text-decoration-skip: objects;
-    }
-    abbr[title] {
-        border-bottom: none;
-        -webkit-text-decoration: underline dotted;
-        text-decoration: underline dotted;
-    }
-    b, strong {
-        font-weight: inherit;
-        font-weight: bolder;
-    }
-    code,
-    kbd,
-    samp {
-        font-family: monospace;
-        font-size: 1em;
-    }
-    dfn {
-        font-style: italic;
-    }
-    mark {
-        background-color: #ff0;
-        color: #000;
-    }
-    small {
-        font-size: 80%;
-    }
-    sub,
-    sup {
-        font-size: 75%;
-        line-height: 0;
-        position: relative;
-        vertical-align: baseline;
-    }
-    sub {
-        bottom: -0.25em;
-    }
-    sup {
-        top: -0.5em;
-    }
-    audio,
-    video {
-        display: inline-block;
-    }
-    audio:not([controls]) {
-        display: none; height: 0;
-    }
-    img {
-        border-style: none;
-    }
-    svg:not(:root) {
-        overflow: hidden;
-    }
-    button,
-    input,
-    optgroup,
-    select,
-    textarea {
-        font-family: sans-serif;
-        font-size: 100%;
-        line-height: 1.15;
-        margin: 0;
-    }
-    button {
-        overflow: visible;
-    }
-    button,
-    select {
-        text-transform: none;
-    }
-    [type='reset'],
-    [type='submit'],
-    button,
-    html [type='button'] {
-        -webkit-appearance: button;
-    }
-    [type='button']::-moz-focus-inner,
-    [type='reset']::-moz-focus-inner,
-    [type='submit']::-moz-focus-inner,
-    button::-moz-focus-inner {
-        border-style: none; padding: 0;
-    }
-    [type='button']:-moz-focusring,
-    [type='reset']:-moz-focusring,
-    [type='submit']:-moz-focusring,
-    button:-moz-focusring {
-        outline: 1px dotted ButtonText;
-    }
-    input {
-        overflow: visible;
-    }
-    [type='checkbox'],
-    [type='radio'] {
-        box-sizing: border-box;
-        padding: 0;
-    }
-    [type='number']::-webkit-inner-spin-button,
-    [type='number']::-webkit-outer-spin-button {
-        height: auto;
-    }
-    [type='search'] {
-        -webkit-appearance: textfield; outline-offset: -2px;
-    }
-    [type='search']::-webkit-search-cancel-button,
-    [type='search']::-webkit-search-decoration {
-        -webkit-appearance: none;
-    }
-    ::-webkit-file-upload-button {
-        -webkit-appearance: button; font: inherit;
-    }
-    fieldset {
-        padding: 0.35em 0.75em 0.625em;
-    }
-    legend {
-        box-sizing: border-box;
-        display: table;
-        max-width: 100%;
-        padding: 0;
-        color: inherit;
-        white-space: normal;
-    }
-    progress {
-        display: inline-block;
-        vertical-align: baseline;
-    }
-    textarea {
-        overflow: auto;
-    }
-    details {
-        display: block;
-    }
-    summary {
-        display: list-item;
-    }
-    menu {
-        display: block;
-    }
-    canvas {
-        display: inline-block;
-    }
-    [hidden],
-    template {
-        display: none;
-    }
+/* Document
+   ========================================================================== */
+
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ */
+
+ html {
+    line-height: 1.15; /* 1 */
+    -webkit-text-size-adjust: 100%; /* 2 */
+  }
+
+  /* Sections
+     ========================================================================== */
+
+  /**
+   * Remove the margin in all browsers.
+   */
+
+  body {
+    margin: 0;
+  }
+
+  /**
+   * Render the `main` element consistently in IE.
+   */
+
+  main {
+    display: block;
+  }
+
+  /**
+   * Correct the font size and margin on `h1` elements within `section` and
+   * `article` contexts in Chrome, Firefox, and Safari.
+   */
+
+  h1 {
+    font-size: 2em;
+    margin: 0.67em 0;
+  }
+
+  /* Grouping content
+     ========================================================================== */
+
+  /**
+   * 1. Add the correct box sizing in Firefox.
+   * 2. Show the overflow in Edge and IE.
+   */
+
+  hr {
+    box-sizing: content-box; /* 1 */
+    height: 0; /* 1 */
+    overflow: visible; /* 2 */
+  }
+
+  /**
+   * 1. Correct the inheritance and scaling of font size in all browsers.
+   * 2. Correct the odd `em` font sizing in all browsers.
+   */
+
+  pre {
+    font-family: monospace; /* 1 */
+    font-size: 1em; /* 2 */
+  }
+
+  /* Text-level semantics
+     ========================================================================== */
+
+  /**
+   * Remove the gray background on active links in IE 10.
+   */
+
+  a {
+    background-color: transparent;
+  }
+
+  /**
+   * 1. Remove the bottom border in Chrome 57-
+   * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+   */
+
+  abbr[title] {
+    border-bottom: none; /* 1 */
+    text-decoration: underline; /* 2 */
+    text-decoration: underline dotted; /* 2 */
+  }
+
+  /**
+   * Add the correct font weight in Chrome, Edge, and Safari.
+   */
+
+  b,
+  strong {
+    font-weight: bolder;
+  }
+
+  /**
+   * 1. Correct the inheritance and scaling of font size in all browsers.
+   * 2. Correct the odd `em` font sizing in all browsers.
+   */
+
+  code,
+  kbd,
+  samp {
+    font-family: monospace; /* 1 */
+    font-size: 1em; /* 2 */
+  }
+
+  /**
+   * Add the correct font size in all browsers.
+   */
+
+  small {
+    font-size: 80%;
+  }
+
+  /**
+   * Prevent `sub` and `sup` elements from affecting the line height in
+   * all browsers.
+   */
+
+  sub,
+  sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  sub {
+    bottom: -0.25em;
+  }
+
+  sup {
+    top: -0.5em;
+  }
+
+  /* Embedded content
+     ========================================================================== */
+
+  /**
+   * Remove the border on images inside links in IE 10.
+   */
+
+  img {
+    border-style: none;
+  }
+
+  /* Forms
+     ========================================================================== */
+
+  /**
+   * 1. Change the font styles in all browsers.
+   * 2. Remove the margin in Firefox and Safari.
+   */
+
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    font-family: inherit; /* 1 */
+    font-size: 100%; /* 1 */
+    line-height: 1.15; /* 1 */
+    margin: 0; /* 2 */
+  }
+
+  /**
+   * Show the overflow in IE.
+   * 1. Show the overflow in Edge.
+   */
+
+  button,
+  input { /* 1 */
+    overflow: visible;
+  }
+
+  /**
+   * Remove the inheritance of text transform in Edge, Firefox, and IE.
+   * 1. Remove the inheritance of text transform in Firefox.
+   */
+
+  button,
+  select { /* 1 */
+    text-transform: none;
+  }
+
+  /**
+   * Correct the inability to style clickable types in iOS and Safari.
+   */
+
+  button,
+  [type='button'],
+  [type='reset'],
+  [type='submit'] {
+    -webkit-appearance: button;
+  }
+
+  /**
+   * Remove the inner border and padding in Firefox.
+   */
+
+  button::-moz-focus-inner,
+  [type='button']::-moz-focus-inner,
+  [type='reset']::-moz-focus-inner,
+  [type='submit']::-moz-focus-inner {
+    border-style: none;
+    padding: 0;
+  }
+
+  /**
+   * Restore the focus styles unset by the previous rule.
+   */
+
+  button:-moz-focusring,
+  [type='button']:-moz-focusring,
+  [type='reset']:-moz-focusring,
+  [type='submit']:-moz-focusring {
+    outline: 1px dotted ButtonText;
+  }
+
+  /**
+   * Correct the padding in Firefox.
+   */
+
+  fieldset {
+    padding: 0.35em 0.75em 0.625em;
+  }
+
+  /**
+   * 1. Correct the text wrapping in Edge and IE.
+   * 2. Correct the color inheritance from `fieldset` elements in IE.
+   * 3. Remove the padding so developers are not caught out when they zero out
+   *    `fieldset` elements in all browsers.
+   */
+
+  legend {
+    box-sizing: border-box; /* 1 */
+    color: inherit; /* 2 */
+    display: table; /* 1 */
+    max-width: 100%; /* 1 */
+    padding: 0; /* 3 */
+    white-space: normal; /* 1 */
+  }
+
+  /**
+   * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+   */
+
+  progress {
+    vertical-align: baseline;
+  }
+
+  /**
+   * Remove the default vertical scrollbar in IE 10+.
+   */
+
+  textarea {
+    overflow: auto;
+  }
+
+  /**
+   * 1. Add the correct box sizing in IE 10.
+   * 2. Remove the padding in IE 10.
+   */
+
+  [type='checkbox'],
+  [type='radio'] {
+    box-sizing: border-box; /* 1 */
+    padding: 0; /* 2 */
+  }
+
+  /**
+   * Correct the cursor style of increment and decrement buttons in Chrome.
+   */
+
+  [type='number']::-webkit-inner-spin-button,
+  [type='number']::-webkit-outer-spin-button {
+    height: auto;
+  }
+
+  /**
+   * 1. Correct the odd appearance in Chrome and Safari.
+   * 2. Correct the outline style in Safari.
+   */
+
+  [type='search'] {
+    -webkit-appearance: textfield; /* 1 */
+    outline-offset: -2px; /* 2 */
+  }
+
+  /**
+   * Remove the inner padding in Chrome and Safari on macOS.
+   */
+
+  [type='search']::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+
+  /**
+   * 1. Correct the inability to style clickable types in iOS and Safari.
+   * 2. Change font properties to `inherit` in Safari.
+   */
+
+  ::-webkit-file-upload-button {
+    -webkit-appearance: button; /* 1 */
+    font: inherit; /* 2 */
+  }
+
+  /* Interactive
+     ========================================================================== */
+
+  /*
+   * Add the correct display in Edge, IE 10+, and Firefox.
+   */
+
+  details {
+    display: block;
+  }
+
+  /*
+   * Add the correct display in all browsers.
+   */
+
+  summary {
+    display: list-item;
+  }
+
+  /* Misc
+     ========================================================================== */
+
+  /**
+   * Add the correct display in IE 10+.
+   */
+
+  template {
+    display: none;
+  }
+
+  /**
+   * Add the correct display in IE 10.
+   */
+
+  [hidden] {
+    display: none;
+  }
 }

--- a/src/scss/base/_normalize.scss
+++ b/src/scss/base/_normalize.scss
@@ -1,0 +1,198 @@
+@mixin normalize() {
+    /**
+    * Normalize Styles
+    * =================================
+    * We use normalize.css for the bulk of our 'reset' (https://www.npmjs.com/package/normalize-scss).
+    * We wrap it into a mixin to be able to make it optional.
+    *
+    * This is an optional component within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include normalize();` into your SCSS dependencies file.
+    */
+
+    /*! normalize-scss | MIT/GPLv2 License | bit.ly/normalize-scss v7.0.1*/
+    html {
+        line-height: 1.15;
+        -ms-text-size-adjust: 100%;
+        -webkit-text-size-adjust: 100%;
+    }
+    body {
+        margin: 0;
+    }
+    article,
+    aside,
+    footer,
+    header,
+    nav,
+    section {
+        display: block;
+    }
+    h1 {
+        font-size: 2em;
+        margin: 0.67em 0;
+    }
+    figcaption,
+    figure {
+        display: block;
+    }
+    figure {
+        margin: 1em 40px;
+    }
+    hr {
+        box-sizing: content-box;
+        height: 0;
+        overflow: visible;
+    }
+    main {
+        display: block;
+    }
+    pre {
+        font-family: monospace;
+        font-size: 1em;
+    }
+    a {
+        background-color: transparent;
+        -webkit-text-decoration-skip: objects;
+    }
+    abbr[title] {
+        border-bottom: none;
+        -webkit-text-decoration: underline dotted;
+        text-decoration: underline dotted;
+    }
+    b, strong {
+        font-weight: inherit;
+        font-weight: bolder;
+    }
+    code,
+    kbd,
+    samp {
+        font-family: monospace;
+        font-size: 1em;
+    }
+    dfn {
+        font-style: italic;
+    }
+    mark {
+        background-color: #ff0;
+        color: #000;
+    }
+    small {
+        font-size: 80%;
+    }
+    sub,
+    sup {
+        font-size: 75%;
+        line-height: 0;
+        position: relative;
+        vertical-align: baseline;
+    }
+    sub {
+        bottom: -0.25em;
+    }
+    sup {
+        top: -0.5em;
+    }
+    audio,
+    video {
+        display: inline-block;
+    }
+    audio:not([controls]) {
+        display: none; height: 0;
+    }
+    img {
+        border-style: none;
+    }
+    svg:not(:root) {
+        overflow: hidden;
+    }
+    button,
+    input,
+    optgroup,
+    select,
+    textarea {
+        font-family: sans-serif;
+        font-size: 100%;
+        line-height: 1.15;
+        margin: 0;
+    }
+    button {
+        overflow: visible;
+    }
+    button,
+    select {
+        text-transform: none;
+    }
+    [type='reset'],
+    [type='submit'],
+    button,
+    html [type='button'] {
+        -webkit-appearance: button;
+    }
+    [type='button']::-moz-focus-inner,
+    [type='reset']::-moz-focus-inner,
+    [type='submit']::-moz-focus-inner,
+    button::-moz-focus-inner {
+        border-style: none; padding: 0;
+    }
+    [type='button']:-moz-focusring,
+    [type='reset']:-moz-focusring,
+    [type='submit']:-moz-focusring,
+    button:-moz-focusring {
+        outline: 1px dotted ButtonText;
+    }
+    input {
+        overflow: visible;
+    }
+    [type='checkbox'],
+    [type='radio'] {
+        box-sizing: border-box;
+        padding: 0;
+    }
+    [type='number']::-webkit-inner-spin-button,
+    [type='number']::-webkit-outer-spin-button {
+        height: auto;
+    }
+    [type='search'] {
+        -webkit-appearance: textfield; outline-offset: -2px;
+    }
+    [type='search']::-webkit-search-cancel-button,
+    [type='search']::-webkit-search-decoration {
+        -webkit-appearance: none;
+    }
+    ::-webkit-file-upload-button {
+        -webkit-appearance: button; font: inherit;
+    }
+    fieldset {
+        padding: 0.35em 0.75em 0.625em;
+    }
+    legend {
+        box-sizing: border-box;
+        display: table;
+        max-width: 100%;
+        padding: 0;
+        color: inherit;
+        white-space: normal;
+    }
+    progress {
+        display: inline-block;
+        vertical-align: baseline;
+    }
+    textarea {
+        overflow: auto;
+    }
+    details {
+        display: block;
+    }
+    summary {
+        display: list-item;
+    }
+    menu {
+        display: block;
+    }
+    canvas {
+        display: inline-block;
+    }
+    [hidden],
+    template {
+        display: none;
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11195,11 +11195,6 @@ normalize-range@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
 
-normalize-scss@7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/normalize-scss/-/normalize-scss-7.0.1.tgz#74485e82bb5d0526371136422a09fdb868ffc1a4"
-  integrity sha512-qj16bWnYs+9/ac29IgGjySg4R5qQTp1lXfm7ApFOZNVBYFY8RZ3f8+XQNDDLHeDtI3Ba7Jj4+LuPgz9v/fne2A==
-
 normalize-selector@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/normalize-selector/-/normalize-selector-0.2.0.tgz#d0b145eb691189c63a78d201dc4fdb1293ef0c03"


### PR DESCRIPTION
### Changed
- Move normalize styles from base to optional. We had to copy the styles straight into the project to be able to make them optional wrapping them into a mixin.
!!Note: If you don't use `$includeBaseFramework` or `$includeMinimalFramework` vars and want to have normalize styles in you project, you need to `@include normalize()` mixin starting from this version. 