### PR TITLE
v6.0.0-beta.2 - more typography changes for ICING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Future Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v6.0.0-beta.2
+------------------------------
+*September 17, 2021*
+
+### Changed
+- `$font-size-base` to use `$font-paragraph-01`(16px) instead of  `$font-paragraph-02`(14px).
+- separate font-sizes for mobile and desktop screen sizes for `h3,.gamma,h4,.delta,h5,.epsilon`
+
+
 v6.0.0-beta.1
 ------------------------------
 *September 15, 2021*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -105,7 +105,11 @@
     .delta,
     h5,
     .epsilon {
-        @include font-size(heading-s);
+        @include font-size(heading-s, true, narrow);
+
+        @include media('>mid') {
+            @include font-size(heading-s);
+        }
     }
 
     h6,

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -9,7 +9,7 @@
 // Set this in pixels (but do not add px),
 // the font-size mixin will convert to REMS
 
-$font-size-base             : $font-paragraph-02;
+$font-size-base             : $font-paragraph-01;
 $font-size-base-px          : $font-size-base * 1px;
 
 // Type map – these are our global font-sizes and line-heights across the site


### PR DESCRIPTION
### Changed
- `$font-size-base` to use `$font-paragraph-01`(16px) instead of  `$font-paragraph-02`(14px).
- separate font-sizes for mobile and desktop screen sizes for `h3,.gamma,h4,.delta,h5,.epsilon` headings.