### PR TITLE
v6.0.0-beta.4 - new button styles for icing phase 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Future Todo List
 
 v6.0.0-beta.4
 ------------------------------
-*September 23, 2021*
+*September 27, 2021*
 
 ### Added
 - `o-btn--outline`, `o-btn--ghost`, `o-btn--fullWidth` modifiers.
@@ -19,7 +19,7 @@ v6.0.0-beta.4
 ### Removed
 - `o-btn--tertiary`. Use `o-btn--outline` instead.
 - `o-btn--block`. Use `o-btn--fullWidth` instead.
-- `o-btn--wide`. 
+- `o-btn--wide`.
 
 ### Changed
 - Button styles in line with icing phase 2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,16 @@ v6.0.0-beta.4
 
 ### Removed
 - `o-btn--tertiary`. Use `o-btn--outline` instead.
+- `o-btn--block`. Use `o-btn--fullWidth` instead.
+- `o-btn--wide`. 
 
 ### Changed
 - Button styles in line with icing phase 2.
+- renamed `o-btnLink` to `o-btn--link`.
 Now button modifiers are:
 - Btn Background Colour modifiers: `o-btn--primary`, `o-btn--secondary`, `o-btn--outline`, `o-btn--ghost`.
 - Btn Size Modifiers: `o-btn--sizeLarge`, `o-btn--sizeSmall`, `o-btn--sizeXSmall`.
-- Btn Layout Modifiers: `o-btn--block`, `o-btn--wide`, `o-btn--icon`, `o-btn--fullWidth`, `o-btn--disabled`.
+- Btn Layout Modifiers: `o-btn--icon`, `o-btn--fullWidth`, `o-btn--disabled`, `o-btn--link`.
 - Moved font-family declaration from the button component styles to typography styles.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Future Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v6.0.0-beta.4
+------------------------------
+*September 23, 2021*
+
+### Changed
+- Button styles in line with icing phase 2.
+Now button modifiers are:
+- Btn Background Colour modifiers: `o-btn--primary`, `o-btn--secondary`, `o-btn--outline`, `o-btn--ghost`.
+- Btn Size Modifiers: `o-btn--sizeLarge`, `o-btn--sizeSmall`, `o-btn--sizeXSmall`.
+- Btn Layout Modifiers: `o-btn--block`, `o-btn--wide`, `o-btn--icon`, `o-btn--fullWidth`, `o-btn--disabled`.
+- Moved font-family declaration from the button component styles to typography styles.
+
+
 v6.0.0-beta.3
 ------------------------------
 *September 22, 2021*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ v6.0.0-beta.4
 ------------------------------
 *September 23, 2021*
 
+### Added
+- `o-btn--outline`, `o-btn--ghost`, `o-btn--fullWidth` modifiers.
+- `o-btn--sizeLarge`, `o-btn--sizeSmall`, `o-btn--sizeXSmall` size modifiers.
+
+### Removed
+- `o-btn--tertiary`. Use `o-btn--outline` instead.
+
 ### Changed
 - Button styles in line with icing phase 2.
 Now button modifiers are:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "6.0.0-beta.3",
+  "version": "6.0.0-beta.4",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -179,6 +179,13 @@
         }
     }
 
+    /**
+    * Buttons
+    */
+    button {
+        font-family: $font-family-base;
+    }
+
     // Quotes
     q,
     blockquote {

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -315,8 +315,8 @@
 
     .o-btn--disabled,
     .o-btn.disabled,
-    &.is-disabled,
-    &[disabled] {
+    .o-btn.is-disabled,
+    .o-btn[disabled] {
         cursor: not-allowed;
         color: $btn-disabled-textColor;
 

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -10,41 +10,51 @@
     * https://fozzie.just-eat.com/styleguide/ui-components/buttons
     */
 
-    $btn-default-bgColor                : $color-interactive-secondary;
-    $btn-default-weight                 : $font-weight-bold;
-    $btn-default-height                 : 2.6;
-    $btn-default-font-size              : 18;
-    $btn-default-font-family            : $font-family-base;
-    $btn-default-bgColor--hover         : darken($color-interactive-secondary, $color-hover-01);
-    $btn-default-bgColor--active        : darken($color-interactive-secondary, $color-active-01);
-    $btn-default-borderRadius           : $radius-rounded-e;
-    $btn-default-hozPadding             : 1em;
-    $btn-default-vertPadding            : 11px;
+    $btn-default-borderRadius              : $radius-rounded-e;
+    $btn-default-font-size                 : 'heading-s';
+    $btn-default-weight                    : $font-weight-bold;
+    $btn-default-padding                   : 10px spacing(x3);
+    $btn-default-outline-color             : $color-focus;
 
-    $btn-primary-bgColor                : $color-interactive-brand;
-    $btn-primary-bgColor--hover         : darken($color-interactive-brand, $color-hover-01);
-    $btn-primary-bgColor--focus         : darken($color-interactive-brand, $color-active-01);
-    $btn-primary-textColor              : $color-content-interactive-light;
+    $btn-default-bgColor                   : $color-interactive-brand;
+    $btn-default-color                     : $color-content-interactive-light;
+    $btn-default-bgColor--hover            : darken($color-interactive-brand, $color-hover-01);
+    $btn-default-bgColor--active           : darken($color-interactive-brand, $color-active-01);
 
-    $btn-secondary-bgColor              : $color-interactive-secondary;
-    $btn-secondary-bgColor--hover       : darken($color-interactive-secondary, $color-hover-01);
-    $btn-secondary-bgColor--active      : darken($color-interactive-secondary, $color-active-01);
-    $btn-secondary-textColor            : $color-content-interactive-secondary;
-    $btn-secondary-textColor--hover     : $color-content-interactive-secondary;
-    $btn-secondary-textColor--active    : $color-content-interactive-secondary;
+    $btn-primary-bgColor                   : $color-interactive-brand;
+    $btn-primary-bgColor--hover            : darken($color-interactive-brand, $color-hover-01);
+    $btn-primary-bgColor--active           : darken($color-interactive-brand, $color-active-01);
+    $btn-primary-textColor                 : $color-content-interactive-light;
 
-    $btn-tertiary-bgColor              : transparent;
-    $btn-tertiary-bgColor--hover       : darken($color-white, $color-hover-01);
-    $btn-tertiary-bgColor--active      : darken($color-white, $color-active-01);
-    $btn-tertiary-textColor            : $color-content-interactive-tertiary;
-    $btn-tertiary-textColor--hover     : $color-content-interactive-tertiary;
-    $btn-tertiary-textColor--active    : $color-content-interactive-tertiary;
-    $btn-tertiary-border-color         : $color-border-default;
+    $btn-secondary-bgColor                 : $color-interactive-secondary;
+    $btn-secondary-bgColor--hover          : darken($color-interactive-secondary, $color-hover-01);
+    $btn-secondary-bgColor--active         : darken($color-interactive-secondary, $color-active-01);
+    $btn-secondary-textColor               : $color-content-interactive-secondary;
 
-    $btn-wide-hozPadding                : 2em;
+    $btn-outline-bgColor                   : transparent;
+    $btn-outline-bgColor--hover            : darken($color-white, $color-hover-01);
+    $btn-outline-bgColor--active           : darken($color-white, $color-active-01);
+    $btn-outline-textColor                 : $color-content-interactive-tertiary;
+    $btn-outline-border-color              : $color-border-default;
 
-    $btn-disabled-bgColor               : $color-disabled-01;
+    $btn-ghost-bgColor                     : transparent;
+    $btn-ghost-bgColor--hover              : darken($color-white, $color-hover-01);
+    $btn-ghost-bgColor--active             : darken($color-white, $color-active-01);
+    $btn-ghost-textColor                   : $color-content-interactive-secondary;
 
+    $btn-disabled-bgColor                  : $color-disabled-01;
+    $btn-disabled-textColor                : $color-content-disabled;
+
+    $btn-sizeLarge-padding                 : 14px spacing(x3);
+    $btn-sizeLarge-loading-color           : $color-content-interactive-light;
+
+    $btn-sizeSmall-font-size               : 'body-l';
+    $btn-sizeSmall-padding                 : spacing() spacing(x2);
+
+    $btn-sizeXSmall-font-size              : 'body-s';
+    $btn-sizeXSmall-padding                : 6px spacing();
+
+    $btn-wide-hozPadding                   : 2em;
 
     /**
     * Base button styles – Based on csswizardry.com/beautons
@@ -54,48 +64,52 @@
     * 3. Make buttons inherit font styles.
     * 4. Force all elements using beautons to appear clickable.
     * 5. Normalise box model styles.
-    * 6. If the button’s text is 1em, and the button is (3 * font-size) tall, then
-    *    there is 1em of space above and below that text. We therefore apply 1em
-    *    of space to the left and right, as padding, to keep consistent spacing.
-    * 7. Fixes odd inner spacing in IE7.
+    * 6. Fixes odd inner spacing in IE7.
     */
 
+    // By deafult the button is Primary medium sized button
     .o-btn {
         display: inline-block;                      /* [1] */
         vertical-align: middle;                     /* [2] */
-        font-family: $btn-default-font-family;      /* [3] */
         @include font-size($btn-default-font-size); /* [3] */
         cursor: pointer;                            /* [4] */
         margin: 0;                                  /* [5] */
-        padding: $btn-default-vertPadding $btn-default-hozPadding; /* [5, 6] */
-        overflow: visible;                          /* [7] */
+        padding: $btn-default-padding;              /* [5] */
+        overflow: visible;                          /* [6] */
         text-align: center;
         font-weight: $btn-default-weight;
-        line-height: 1;
 
-        // You may want to change this
         background-color: $btn-default-bgColor;
         border-radius: $btn-default-borderRadius;
         border: 1px solid transparent;
         user-select: none;
-
-        color: $color-grey-50;
+        color: $btn-default-color;
         text-decoration: none;
 
-        &:hover,
-        &:focus {
-            background-color: $btn-default-bgColor--hover;
+        // Hide focus styles if they're not needed, for example, when an element receives focus via the mouse.
+        &:focus:not(:focus-visible) {
+            outline: 0;
+        }
 
-            &:not(.o-btnLink) {
-                outline: none; // no need as already has a focus/active state
-            }
+        // Show focus styles on keyboard focus.
+        &:focus-visible {
+            outline: 0;
+            box-shadow: 0 0 0 2px $btn-default-outline-color;
+        }
+
+        &:hover {
+            background-color: $btn-default-bgColor--hover;
         }
 
         &:active {
             background-color: $btn-default-bgColor--active;
+        }
 
+
+        &:hover,
+        &:active {
             &:not(.o-btnLink) {
-                outline: none; // no need as already has a focus/active state
+                outline: 0; // no need as already has a focus/active state
             }
         }
 
@@ -105,17 +119,6 @@
         &:focus,
         &:visited {
             text-decoration: none;
-        }
-
-        // Disabled state
-        &.disabled,
-        &[disabled] {
-            cursor: default;
-
-            &,
-            &:hover {
-                background-color: $btn-disabled-bgColor;
-            }
         }
 
         p + & {
@@ -165,11 +168,23 @@
             background-color: $btn-primary-bgColor--hover;
         }
 
-        &:active,
-        &:focus {
-            background-color: $btn-primary-bgColor--focus;
+        &:active {
+            background-color: $btn-primary-bgColor--active;
+        }
+
+        &.o-btn--sizeSmall,
+        &.o-btn--sizeXSmall {
+            background-color: $color-interactive-primary;
+
+            &:hover {
+                background-color: lighten($color-interactive-primary, $color-hover-02);
+            }
+            &:active {
+                background-color: lighten($color-interactive-primary, $color-active-02);
+            }
         }
     }
+
 
     /**
     * Modifier – .o-btn--secondary
@@ -183,39 +198,85 @@
 
         &:hover {
             background-color: $btn-secondary-bgColor--hover;
-            color: $btn-secondary-textColor--hover;
         }
 
-        &:active,
-        &:focus {
+        &:active {
             background-color: $btn-secondary-bgColor--active;
-            color: $btn-secondary-textColor--active;
-            outline: none;
         }
     }
 
+
     /**
-    * Modifier – .o-btn--tertiary
+    * Modifier – .o-btn--outline
+    *
+    * Accompanying button style
+    */
+
+    .o-btn--outline {
+        background-color: $btn-outline-bgColor;
+        color: $btn-outline-textColor;
+        border-color: $btn-outline-border-color;
+
+        &:hover,
+        &:active,
+        &:focus {
+            color: $btn-outline-textColor;
+        }
+
+        &:hover {
+            background-color: $btn-outline-bgColor--hover;
+        }
+
+        &:active {
+            background-color: $btn-outline-bgColor--active;
+        }
+    }
+
+
+    /**
+    * Modifier – .o-btn--ghost
     *
     * Accompanying button that can be used on solid background colours (such as grey)
     */
 
-    .o-btn--tertiary {
-        background-color: $btn-tertiary-bgColor;
-        color: $btn-tertiary-textColor;
-        border-color: $btn-tertiary-border-color;
+    .o-btn--ghost {
+        background-color: $btn-ghost-bgColor;
+        color: $btn-ghost-textColor;
 
-        &:hover {
-            background-color: $btn-tertiary-bgColor--hover;
-            color: $btn-tertiary-textColor--hover;
-        }
-
+        &:hover,
         &:active,
         &:focus {
-            background-color: $btn-tertiary-bgColor--active;
-            color: $btn-tertiary-textColor--active;
-            outline: none;
+            color: $btn-ghost-textColor;
         }
+
+        &:hover {
+            background-color: $btn-ghost-bgColor--hover;
+        }
+
+        &:active {
+            background-color: $btn-ghost-bgColor--active;
+        }
+    }
+
+
+    /**
+    * ==========================================================================
+    * Btn Size Modifiers
+    * ==========================================================================
+    */
+
+    .o-btn--sizeLarge {
+        padding: $btn-sizeLarge-padding;
+    }
+
+    .o-btn--sizeSmall {
+        @include font-size($btn-sizeSmall-font-size);
+        padding: $btn-sizeSmall-padding;
+    }
+
+    .o-btn--sizeXSmall {
+        @include font-size($btn-sizeXSmall-font-size);
+        padding: $btn-sizeXSmall-padding;
     }
 
 
@@ -268,22 +329,36 @@
         }
     }
 
+    .o-btn--fullWidth {
+        display: block;
+        width: 100%;
+
+        // Vertically space out multiple fullWidth buttons
+        // same as .o-btn--fullWidth + .o-btn--fullWidth
+        & + & {
+            margin-top: spacing();
+        }
+    }
+
 
     /**
     * Disabled button
     */
 
-    .o-btn--disabled {
-        cursor: default;
+    .o-btn--disabled,
+    .o-btn.disabled,
+    &.is-disabled,
+    &[disabled] {
+        cursor: not-allowed;
+        color: $btn-disabled-textColor;
 
         &,
-        &:hover,
-        &:active,
-        &:focus {
+        &:hover {
             background-color: $btn-disabled-bgColor;
-            color: inherit;
+            color: $btn-disabled-textColor;
         }
     }
+
 
     /**
     * Loading state
@@ -311,7 +386,7 @@
         padding: 0;
         margin: 0;
         color: $color-content-link;
-        font-weight: 500;
+        font-weight: $font-weight-bold;
         text-decoration: underline;
 
         &:hover {

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -81,15 +81,8 @@
         color: $btn-default-color;
         text-decoration: none;
 
-        // Hide focus styles if they're not needed, for example, when an element receives focus via the mouse.
-        &:focus:not(:focus-visible) {
-            outline: 0;
-        }
-
-        // Show focus styles on keyboard focus.
-        &:focus-visible {
-            outline: 0;
-            box-shadow: 0 0 0 2px $btn-default-outline-color;
+        &:focus {
+            border: 2px solid $btn-default-outline-color;
         }
 
         &:hover {
@@ -190,6 +183,12 @@
     .o-btn--secondary {
         background-color: $btn-secondary-bgColor;
         color: $btn-secondary-textColor;
+
+        &:hover,
+        &:active,
+        &:focus {
+            color: $btn-secondary-textColor;
+        }
 
         &:hover {
             background-color: $btn-secondary-bgColor--hover;

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -54,8 +54,6 @@
     $btn-sizeXSmall-font-size              : 'body-s';
     $btn-sizeXSmall-padding                : 6px spacing();
 
-    $btn-wide-hozPadding                   : 2em;
-
     /**
     * Base button styles – Based on csswizardry.com/beautons
     *
@@ -96,7 +94,7 @@
 
         &:hover,
         &:active {
-            &:not(.o-btnLink) {
+            &:not(.o-btn--link) {
                 outline: 0; // no need as already has a focus/active state
             }
         }
@@ -280,30 +278,6 @@
     * ==========================================================================
     */
 
-    /**
-    * Modifier – btn-block
-    *
-    * Makes the btn full width
-    */
-
-    .o-btn--block {
-        display: block;
-        width: 100%;
-        padding-left: 0;
-        padding-right: 0;
-
-        // Vertically space out multiple block buttons
-        // same as .o-btn--block + .o-btn--block
-        & + & {
-            margin-top: 10px;
-        }
-    }
-
-    .o-btn--wide {
-        padding-left: $btn-wide-hozPadding;
-        padding-right: $btn-wide-hozPadding;
-    }
-
     //remove uneeded styles (like colours) from a button when only an icon is on it (like a close button)
     .o-btn--icon {
         @extend %u-ir;
@@ -374,7 +348,7 @@
     * Should only be applied to buttons
     */
 
-    .o-btnLink {
+    .o-btn--link {
         border: 0;
         background-color: transparent;
         padding: 0;

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -61,21 +61,16 @@
     *
     * 1. Allow us to better style box model properties.
     * 2. Line different sized buttons up a little nicer.
-    * 3. Make buttons inherit font styles.
-    * 4. Force all elements using beautons to appear clickable.
-    * 5. Normalise box model styles.
-    * 6. Fixes odd inner spacing in IE7.
     */
 
     // By deafult the button is Primary medium sized button
     .o-btn {
         display: inline-block;                      /* [1] */
         vertical-align: middle;                     /* [2] */
-        @include font-size($btn-default-font-size); /* [3] */
-        cursor: pointer;                            /* [4] */
-        margin: 0;                                  /* [5] */
-        padding: $btn-default-padding;              /* [5] */
-        overflow: visible;                          /* [6] */
+        @include font-size($btn-default-font-size);
+        cursor: pointer;
+        margin: 0;
+        padding: $btn-default-padding;
         text-align: center;
         font-weight: $btn-default-weight;
 
@@ -209,7 +204,7 @@
     /**
     * Modifier – .o-btn--outline
     *
-    * Accompanying button style
+    * Accompanying outline style button
     */
 
     .o-btn--outline {
@@ -236,7 +231,7 @@
     /**
     * Modifier – .o-btn--ghost
     *
-    * Accompanying button that can be used on solid background colours (such as grey)
+    * Accompanying ghost style button
     */
 
     .o-btn--ghost {

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -80,7 +80,7 @@
         text-decoration: none;
 
         &:focus {
-            border: 2px solid $btn-default-outline-color;
+            box-shadow: 0 0 0 2px solid $btn-default-outline-color;
         }
 
         &:hover {


### PR DESCRIPTION
### Changed
- Button styles in line with icing phase 2.
Now button modifiers are:
- Btn Background Colour modifiers: `o-btn--primary`, `o-btn--secondary`, `o-btn--outline`, `o-btn--ghost`.
- Btn Size Modifiers: `o-btn--sizeLarge`, `o-btn--sizeSmall`, `o-btn--sizeXSmall`.
- Btn Layout Modifiers: `o-btn--block`, `o-btn--wide`, `o-btn--icon`, `o-btn--fullWidth`, `o-btn--disabled`.
- Moved font-family declaration from the button component styles to typography styles.