### PR TITLE
v6.0.0-beta.7 - Component style updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ Future Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v6.0.0-beta.7
+------------------------------
+*October 4, 2021*
+
+### Added
+- `c-card--info` component modifier.
+- `c-rating-description` component modifier.
+
+### Changed
+- Set default paragraph size to match base font-size.
+- Card border colour matches PIE designs.
+- `c-mediaElement--fullstack--negativeTop` modifier top margin updated.
+- Badge component font-size explicitly set.
+- `c-badge--indicator` modifier colours updated.
+
+### Fixed
+- Breadcrumb icon size.
+
+
 v6.0.0-beta.6
 ------------------------------
 *October 4, 2021*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "6.0.0-beta.6",
+  "version": "6.0.0-beta.7",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -43,7 +43,7 @@
     * Paragraphs
     */
     p {
-        @include font-size(body-s);
+        @include font-size(body-l);
         margin-top: $baseline;
         margin-bottom: 0;
     }

--- a/src/scss/components/_breadcrumbs.scss
+++ b/src/scss/components/_breadcrumbs.scss
@@ -146,7 +146,7 @@
             }
 
             svg {
-                height: 8px;
+                height: 6px;
                 transform: rotate(-90deg);
                 width: 12px;
 

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -17,7 +17,8 @@
     $card-arrow-bottom-position                     : 0;
     $card-padding                                   : spacing(x2);
     $card-radius                                    : $radius-rounded-c;
-    $card-borderColor                               : $color-border-strong;
+    $card-borderColor                               : $color-border-default;
+    $card-info-bgColor--active                      : $color-support-warning-02;
     $card-section-margin                            : spacing(x4);
     $card-section-margin--large                     : spacing(x8);
     $card-section-highlight-backgroundColor         : $color-support-brand-02;
@@ -36,6 +37,10 @@
         @include media('>=mid') {
             margin-bottom: 0;
         }
+    }
+
+    .c-card--info {
+        background-color: $card-info-bgColor--active;
     }
 
         //

--- a/src/scss/components/_media-element.scss
+++ b/src/scss/components/_media-element.scss
@@ -134,7 +134,7 @@
 
             .c-mediaElement--fullstack--negativeTop & {
                 flex: auto;
-                margin-top: -#{spacing(x2)};
+                margin-top: spacing(x4);
             }
 
             // some content uses br for content shaping – get rid of it on mobile devices

--- a/src/scss/components/optional/_badges.scss
+++ b/src/scss/components/optional/_badges.scss
@@ -22,14 +22,14 @@
     $badge-successAlt-bgColor       : $color-support-positive;
     $badge-warning-color            : $color-content-brand;
     $badge-alert-color              : $color-content-error;
-    $badge-important-color          : $color-content-subdued;
+    $badge-important-color          : $color-content-default;
     $badge-important-bgColor        : $color-support-brand-02;
     $badge-award-color              : $color-external-bta-text;
     $badge-award-bgColor            : $color-external-bta-background;
     $badge-dark-color               : $color-content-inverse;
     $badge-dark-bgColor             : $color-grey;
-    $badge-indicator-color          : $color-support-info;
-    $badge-indicator-bgColor        : $color-white;
+    $badge-indicator-color          : $color-content-interactive-brand;
+    $badge-indicator-bgColor        : $color-interactive-light;
     $badge-padding                  : 1px 5px;
     $badge-rounded-radius           : $radius-rounded-d;
     $badge-rounded-padding          : spacing(x0.5) spacing(x2);
@@ -40,6 +40,7 @@
 
     .c-badge {
         background-color: $badge-bgColor;
+        @include font-size(body-s);
         padding: $badge-padding;
         position: relative;
         white-space: nowrap;

--- a/src/scss/components/optional/_ratings.scss
+++ b/src/scss/components/optional/_ratings.scss
@@ -41,6 +41,10 @@
         }
     }
 
+    .c-rating-description {
+        @include font-size(body-s);
+    }
+
     .c-rating--small {
 
         height: $star-size--small;


### PR DESCRIPTION
### Added
- `c-card--info` component modifier.
- `c-rating-description` component modifier.

### Changed
- Set default paragraph size to match base font-size.
- Card border colour matches PIE designs.
- `c-mediaElement--fullstack--negativeTop` modifier top margin updated.
- Badge component font-size explicitly set.
- `c-badge--indicator` modifier colours updated.

### Fixed
- Breadcrumb icon size.