### PR TITLE
#trivial fozzie@v6.0.0-beta.8 - Version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "6.0.0-beta.7",
+  "version": "6.0.0-beta.8",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",


### PR DESCRIPTION
I messed up the npm publish for `v6.0.0-beta.7` by merging the last PR into `master` on my machine instead of `v6.0.0-icing` and then pushing to npm 🙈 

Bumping the version to push the correct changes to npm.

Note that if referencing `v6.0.0-beta.7` you'll likely see errors with variables not being found. 