### PR TITLE
6.0.0 beta.13 - Fix loading indicator colour mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Future Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v6.0.0-beta.13
+------------------------------
+*October 25, 2021*
+
+### Fixed
+- `spinnerColor` mixin in `loading-indicator` to allow default colours to be displayed.
+
+
 v6.0.0-beta.12
 ------------------------------
 *October 21, 2021*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "6.0.0-beta.12",
+  "version": "6.0.0-beta.13",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_loading-indicator.scss
+++ b/src/scss/components/optional/_loading-indicator.scss
@@ -5,7 +5,8 @@
 * Example: f-searchbox -  Loqate feature enabled (Full address capture)
 *
 * If you'd like to use it in your project you can include it by adding `@include loadingIndicator();` into your SCSS dependencies file.
-*
+* Then add `<span class=“c-spinner” />` to your html;
+* If you’d like to change spinner colour add `@include spinnerColor(mainColourVar, opaqueColourVar);` to the parent element of the spinner styles.
 */
 
 $loading-indicator-size-medium: 20px;
@@ -23,7 +24,7 @@ $loading-indicator-spacing: 20px;
   }
 }
 
-@mixin loadingIndicator($loading-indicator-size: 'medium', $loading-indicator-color: $loading-indicator-color-default, $loading-indicator-borderColorOpaque: $loading-indicator-borderColorOpaque-default) {
+@mixin loadingIndicator($loading-indicator-size: 'medium') {
   @keyframes spin {
     from {
       transform: rotate(0);
@@ -39,12 +40,14 @@ $loading-indicator-spacing: 20px;
     right: 0;
   }
 
+
+  @include spinnerColor();
+
   .c-spinner {
     margin-right: $loading-indicator-spacing;
     border-radius: 50%;
     animation: spin 1s linear 0s infinite;
 
-    @include spinnerColor();
 
     @if $loading-indicator-size=='large' {
       width: $loading-indicator-size-large;


### PR DESCRIPTION
### Fixed
- `spinnerColor` mixin in `loading-indicator` to allow default colours to be displayed.
