### PR TITLE
v6.0.0-beta.14 - bump pie-design-tokens to the latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Future Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
 
+v6.0.0-beta.14
+------------------------------
+*October 25, 2021*
+
+### Updated
+- `pie-design-tokens` package to v1.0.0-beta.2 to include small changes to colour tokens.
+
+
 v6.0.0-beta.13
 ------------------------------
 *October 25, 2021*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "6.0.0-beta.13",
+  "version": "6.0.0-beta.14",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@justeat/f-utils": "2.0.0",
-    "@justeat/pie-design-tokens": "1.1.0",
+    "@justeat/pie-design-tokens": "1.2.0",
     "include-media": "1.4.10"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1178,10 +1178,10 @@
   dependencies:
     "@justeat/dom-buddy" "2.4.3"
 
-"@justeat/pie-design-tokens@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@justeat/pie-design-tokens/-/pie-design-tokens-1.1.0.tgz#d93ad0411cd0457522d8bd466de521382682e05d"
-  integrity sha512-YtiJ7Uq+JZgYAJAFYr0e0an+p8RRk9MimAtqNnk2MFI5au7eNMFt3lTugwfoRgk4jKQfNg2RwTZe0tuuzzc8nw==
+"@justeat/pie-design-tokens@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@justeat/pie-design-tokens/-/pie-design-tokens-1.2.0.tgz#379b9f25b481405c501afc1960b459fd06459b40"
+  integrity sha512-uMVpHVWM3RORK8DzdXWi2Rey9jPCq4sWt64JL9pqN+f+l4ck61b/rpRRf060WvWCcU0Cy/zihbSrJy1hNG1SQg==
   dependencies:
     jsonc-parser "2.2.0"
     lodash.merge "4.6.2"


### PR DESCRIPTION
### Updated
- `pie-design-tokens` package to v1.0.0-beta.2 to include small changes to colour tokens.