### PR TITLE
V7.0.0 update tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Future Todo List
 ------------------------------
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
+v7.0.0
+------------------------------
+*January 25, 2022*
+
+### Changed
+- **Breaking** Type map for $spacing to reference pie design tokens.
+  - If you are using the below mapping values please note they have changed or been removed:
+    $spacing x 6 = spacing(h) instead of spacing(x6) - Note the size change has gone from 48px > 56px in the new mapping.
+    $spacing x 9 - Has been removed.
+
 
 v6.2.0
 ------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,22 @@ v7.0.0
 - **Breaking** Type map for $spacing to reference pie design tokens.
   - If you are using the below mapping values please note they have changed or been removed:
     $spacing x 6 = spacing(h) instead of spacing(x6) - Note the size change has gone from 48px > 56px.
-    $spacing x 9 - Has been removed.
+    $spacing x 9 - Has been removed - Please map to the next value up or down e.g spacing(j) or spacing(i).
+
+| Old map usage | New map usage |
+| ----- | ----- |
+| spacing(x0.5) | $spacing(a) |
+| spacing(base) | $spacing(b) |
+| spacing(x1.5) | $spacing(c) |
+| spacing(x2) | $spacing(d) |
+| spacing(x3) | $spacing(e) |
+| spacing(x4) | $spacing(f) |
+| spacing(x5) | $spacing(g) |
+| spacing(x6) | $spacing(h) |
+| spacing(x7) | $spacing(h) |
+| spacing(x8) | $spacing(i) |
+| spacing(x9) | Removed, replace with closet size up or down |
+| spacing(x10) | $spacing(j) |
 
 - `pie-design-tokens` package.json version to bring in new elevation changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ v7.0.0
 ### Changed
 - **Breaking** Type map for $spacing to reference pie design tokens.
   - If you are using the below mapping values please note they have changed or been removed:
-    $spacing x 6 = spacing(h) instead of spacing(x6) - Note the size change has gone from 48px > 56px in the new mapping.
+    $spacing x 6 = spacing(h) instead of spacing(x6) - Note the size change has gone from 48px > 56px.
     $spacing x 9 - Has been removed.
 
+- `pie-design-tokens` package.json version to bring in new elevation changes.
 
 v6.2.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "6.2.0",
+  "version": "7.0.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@justeat/f-utils": "2.0.0",
-    "@justeat/pie-design-tokens": "1.2.0",
+    "@justeat/pie-design-tokens": "1.4.0",
     "include-media": "1.4.10"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "@justeat/f-utils": "2.0.0",
+    "@justeat/f-utils": "3.1.0",
     "@justeat/pie-design-tokens": "1.4.0",
     "include-media": "1.4.10"
   },

--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -63,14 +63,14 @@
     }
 
     .l-innerContainer--verticalSpacing {
-        margin: spacing(x4) 0;
+        margin: spacing(f) 0;
 
         @include media('>=mid') {
-            margin: spacing(x5) auto spacing(x6);
+            margin: spacing(g) auto spacing(h);
         }
 
         @include media('>=wide') {
-            margin: spacing(x8) auto;
+            margin: spacing(i) auto;
         }
     }
 
@@ -78,18 +78,18 @@
     * Layout class for containers that contain content (such as T&cs and Privacy pages)
     */
     .l-content {
-        padding-top: spacing(x2);
+        padding-top: spacing(d);
 
         @include media('>mid') {
-            padding-top: spacing(x4);
+            padding-top: spacing(f);
         }
     }
 
         .l-content-header {
-            margin: 0 0 spacing(x2);
+            margin: 0 0 spacing(d);
 
             @include media('>mid') {
-                margin: spacing(x2) 0 spacing(x4);
+                margin: spacing(d) 0 spacing(f);
             }
 
             > h1 {

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -78,7 +78,7 @@
     h1,
     .alpha {
         @include font-size(heading-xl, true, narrow);
-        margin-top: spacing(d) * 2;
+        margin-top: spacing(f);
         margin-bottom: spacing(d);
 
         @include media('>mid') {
@@ -120,7 +120,7 @@
     // Only give these headings a margin-top if they are after other elements
     * + h2,
     * + .beta {
-        margin-top: spacing(d) * 2;
+        margin-top: spacing(f);
     }
 
     * + h3,

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -44,7 +44,7 @@
     */
     p {
         @include font-size(body-l);
-        margin-top: $baseline;
+        margin-top: spacing(d);
         margin-bottom: 0;
     }
 
@@ -78,8 +78,8 @@
     h1,
     .alpha {
         @include font-size(heading-xl, true, narrow);
-        margin-top: $baseline * 2;
-        margin-bottom: $baseline;
+        margin-top: spacing(d) * 2;
+        margin-bottom: spacing(d);
 
         @include media('>mid') {
             @include font-size(heading-xl);
@@ -120,14 +120,14 @@
     // Only give these headings a margin-top if they are after other elements
     * + h2,
     * + .beta {
-        margin-top: $baseline * 2;
+        margin-top: spacing(d) * 2;
     }
 
     * + h3,
     * + .gamma,
     * + h4,
     * + .delta {
-        margin-top: $baseline;
+        margin-top: spacing(d);
     }
 
     small {
@@ -160,7 +160,7 @@
     */
     blockquote {
         padding-left: 10px;
-        margin: $baseline;
+        margin: spacing(d);
         border-left: 4px solid lighten(#000, 80%);
 
         p {
@@ -212,7 +212,7 @@
 
     address {
         font-style: normal;
-        margin-top: $baseline;
+        margin-top: spacing(d);
         margin-bottom: 0;
     }
 
@@ -235,7 +235,7 @@
 
     // Horizontal rules
     hr {
-        margin: ($baseline) 0;
+        margin: spacing(d) 0;
         border: 0;
         border-top: 1px solid $color-divider-default;
     }

--- a/src/scss/components/_alerts.scss
+++ b/src/scss/components/_alerts.scss
@@ -20,7 +20,7 @@
 
     .c-alert {
         padding: spacing();
-        margin-top: spacing(x2);
+        margin-top: spacing(d);
         border: 1px solid transparent;
         border-radius: $alert-border-radius;
 
@@ -29,7 +29,7 @@
         }
 
         & + * {
-            margin-top: spacing(x2);
+            margin-top: spacing(d);
         }
     }
 

--- a/src/scss/components/_breadcrumbs.scss
+++ b/src/scss/components/_breadcrumbs.scss
@@ -96,7 +96,7 @@
                 background-color: $breadcrumb--compact-background;
                 border-radius: $breadcrumb-border-radius;
                 line-height: 2;
-                padding-right: $baseline;
+                padding-right: spacing(d);
 
                 .c-breadcrumb-item-icon {
                     float: left;

--- a/src/scss/components/_breadcrumbs.scss
+++ b/src/scss/components/_breadcrumbs.scss
@@ -65,7 +65,7 @@
     }
 
     .c-breadcrumb-item-icon {
-        margin: 0 spacing(base);
+        margin: 0 spacing(b);
     }
 
     .c-breadcrumb--transparent {

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -15,12 +15,12 @@
     $card-bgColor--disabled                         : $color-container-subtle;
     $card-tooltip-width                             : 10px;
     $card-arrow-bottom-position                     : 0;
-    $card-padding                                   : spacing(x2);
+    $card-padding                                   : spacing(d);
     $card-radius                                    : $radius-rounded-c;
     $card-borderColor                               : $color-border-default;
     $card-info-bgColor--active                      : $color-support-warning-02;
-    $card-section-margin                            : spacing(x4);
-    $card-section-margin--large                     : spacing(x8);
+    $card-section-margin                            : spacing(f);
+    $card-section-margin--large                     : spacing(i);
     $card-section-highlight-backgroundColor         : $color-support-brand-02;
     $card-section-highlight-color                   : $color-content-default;
     $card-section-collapsible-paddingRight          : 60px;
@@ -68,22 +68,22 @@
 
             .c-card--padBottom--belowMid {
                 @include media('<mid') {
-                    padding-bottom: spacing(x4);
+                    padding-bottom: spacing(f);
                 }
             }
 
         // stretches the card contents outside of their container
         .c-card--negativeSpacing {
-            margin-left: -#{spacing(x2)};
-            margin-right: -#{spacing(x2)};
-            padding-left: spacing(x2);
-            padding-right: spacing(x2);
+            margin-left: -#{spacing(d)};
+            margin-right: -#{spacing(d)};
+            padding-left: spacing(d);
+            padding-right: spacing(d);
         }
 
             .c-card--negativeSpacing--belowMid {
                 @include media('<mid') {
-                    margin-left: -#{spacing(x2)};
-                    margin-right: -#{spacing(x2)};
+                    margin-left: -#{spacing(d)};
+                    margin-right: -#{spacing(d)};
                 }
             }
 
@@ -149,14 +149,14 @@
 
         // creates a section which is separated off by a border on larger screens
         .c-card-section {
-            margin-left: -#{spacing(x2)};
-            padding-left: spacing(x2);
+            margin-left: -#{spacing(d)};
+            padding-left: spacing(d);
             width: calc(100% + #{$card-section-margin});
 
             @include media('>=mid') {
                 border-top: solid 1px $card-borderColor;
-                margin-left: -#{spacing(x2)};
-                padding-left: spacing(x3);
+                margin-left: -#{spacing(d)};
+                padding-left: spacing(e);
             }
         }
 
@@ -165,8 +165,8 @@
                 background-color: $card-section-highlight-backgroundColor;
                 border-top: none;
                 color: $card-section-highlight-color;
-                margin-top: spacing(x2);
-                padding: spacing(x0.5) spacing();
+                margin-top: spacing(d);
+                padding: spacing(a) spacing();
 
                 + .c-card-section--highlight {
                     margin-top: 1px;
@@ -185,7 +185,7 @@
 
             .c-card-section--collapsible {
                 overflow: hidden;
-                padding-bottom: spacing(x2);
+                padding-bottom: spacing(d);
                 padding-right: $card-section-collapsible-paddingRight;
                 position: relative;
                 user-select: none;
@@ -195,7 +195,7 @@
                     padding-right: $card-section-collapsible-paddingRight;
 
                     &.c-card-section {
-                        margin-bottom: spacing(x2);
+                        margin-bottom: spacing(d);
 
                         &.has-noSpacing {
                             margin-bottom: 0;
@@ -209,13 +209,13 @@
             }
 
             .c-card-section--collapsible--noPad {
-                margin-left: -#{spacing(x4)};
-                padding: 0 $card-section-collapsible-paddingRight 0 spacing(x2);
+                margin-left: -#{spacing(f)};
+                padding: 0 $card-section-collapsible-paddingRight 0 spacing(d);
                 width: calc(100% + #{$card-section-margin--large});
 
                 @include media('>=mid') {
-                    margin-left: -#{spacing(x2)};
-                    padding: 0 $card-section-collapsible-paddingRight 0 spacing(x3);
+                    margin-left: -#{spacing(d)};
+                    padding: 0 $card-section-collapsible-paddingRight 0 spacing(e);
                     width: calc(100% + #{$card-section-margin});
                 }
             }
@@ -238,7 +238,7 @@
                 height: 6px;
                 display: none;
                 position: absolute;
-                right: spacing(x2);
+                right: spacing(d);
                 top: 22px;
                 transform: rotate(180deg);
                 transition: transform 0.4s;
@@ -246,7 +246,7 @@
 
                 @include media('>=mid') {
                     height: 8px;
-                    right: spacing(x3);
+                    right: spacing(e);
                     width: 14px;
                 }
 
@@ -262,7 +262,7 @@
                     right: 21px;
 
                     @include media('>=mid') {
-                        right: spacing(x3);
+                        right: spacing(e);
                     }
                 }
             }

--- a/src/scss/components/_media-element.scss
+++ b/src/scss/components/_media-element.scss
@@ -18,7 +18,7 @@
     $mediaElement-img-borderRadius  : $radius-rounded-c;
     $mediaElement-infoLinkColor     : $color-content-link-distinct;
     $mediaElement-fontSize          : body-l;
-    $mediaElement-spacing           : spacing(x2);
+    $mediaElement-spacing           : spacing(d);
 
 
     // mediaElement module
@@ -30,7 +30,7 @@
 
         & > :not(:last-child) {
             @include media('>=mid') {
-                margin-right: spacing(base);
+                margin-right: spacing(b);
             }
         }
     }
@@ -88,7 +88,7 @@
                 }
 
                 @include media('>=mid') {
-                    margin-top: spacing(base) / 4;
+                    margin-top: spacing(b) / 4;
                 }
 
                 @include media('>=wide') {
@@ -120,7 +120,7 @@
         }
 
         .c-mediaElement-heading {
-            margin: spacing(x6) 0 spacing(x2);
+            margin: spacing(h) 0 spacing(d);
         }
 
         .c-mediaElement-content {
@@ -129,12 +129,12 @@
 
             .c-mediaElement--fullstack & {
                 flex: auto;
-                margin-top: spacing(x0.5);
+                margin-top: spacing(a);
             }
 
             .c-mediaElement--fullstack--negativeTop & {
                 flex: auto;
-                margin-top: spacing(x4);
+                margin-top: spacing(f);
             }
 
             // some content uses br for content shaping – get rid of it on mobile devices
@@ -166,8 +166,8 @@
             top: $mediaElement-spacing;
 
             @include media('<mid') {
-                right: spacing(x2);
-                top: spacing(x2);
+                right: spacing(d);
+                top: spacing(d);
             }
 
             &:hover {

--- a/src/scss/components/optional/_apps-banner.scss
+++ b/src/scss/components/optional/_apps-banner.scss
@@ -45,7 +45,7 @@
             .c-appsBanner-image {
                 overflow: hidden;
                 max-width: 120px;
-                margin-top: spacing(x2);
+                margin-top: spacing(d);
                 grid-column: 1;
                 grid-row: 2;
 
@@ -62,7 +62,7 @@
             }
 
             .c-appsBanner-content {
-                margin-left: spacing(x2);
+                margin-left: spacing(d);
                 grid-column: 2;
                 grid-row: 2;
 
@@ -75,7 +75,7 @@
                 }
 
                 p {
-                    margin-top: spacing(x2);
+                    margin-top: spacing(d);
 
                     @include media('>=mid') {
                         margin-top: spacing();
@@ -85,7 +85,7 @@
         }
 
         .c-appsBanner-buttons {
-            margin-top: spacing(x3);
+            margin-top: spacing(e);
         }
 
         .c-appsBanner-appBtn {

--- a/src/scss/components/optional/_content-header.scss
+++ b/src/scss/components/optional/_content-header.scss
@@ -14,14 +14,14 @@
     */
 
     .c-contentHeader {
-        padding-top: spacing(x2);
+        padding-top: spacing(d);
         padding-bottom: spacing();
     }
 
         .c-contentHeader-title {
             padding: 0;
             display: inline-block;
-            margin: 0 spacing(x2) 0 0;
+            margin: 0 spacing(d) 0 0;
             font-weight: $font-weight-regular;
             @include font-size(body-l, false); // TODO – this should be updated with a more semantic font alias when it's ported to fozzie-components repo
         }

--- a/src/scss/components/optional/_content-title.scss
+++ b/src/scss/components/optional/_content-title.scss
@@ -17,7 +17,7 @@
         width: 100%;
         display: flex;
         align-items: center;
-        margin: spacing(x2) 0;
+        margin: spacing(d) 0;
     }
 
         .c-contentTitle-icon {

--- a/src/scss/components/optional/_cookie-warning.scss
+++ b/src/scss/components/optional/_cookie-warning.scss
@@ -27,7 +27,7 @@
     .c-cookieWarning-inner {
         margin: 0 auto;
         padding: spacing();
-        padding-right: spacing(x3);
+        padding-right: spacing(e);
         overflow: hidden;
     }
 

--- a/src/scss/components/optional/_cuisines-widget.scss
+++ b/src/scss/components/optional/_cuisines-widget.scss
@@ -48,14 +48,14 @@
             bottom: 0;
             left: 0;
             width: 100%;
-            padding: spacing(x2) spacing(x2) spacing();
+            padding: spacing(d) spacing(d) spacing();
             color: $cuisinesWidget-titleColour;
             text-align: center;
             background-image: $cuisinesWidget-gradient;
 
             @include media('>=mid-wide') {
                 @include font-size(heading-m, false);
-                padding: spacing(x2);
+                padding: spacing(d);
             }
         }
 

--- a/src/scss/components/optional/_fullscreen-pop-over.scss
+++ b/src/scss/components/optional/_fullscreen-pop-over.scss
@@ -15,7 +15,7 @@
 
     $fullScreenPopOver-background        : $color-grey-10;
     $fullScreenPopOver-action-background : $color-white;
-    $fullScreenPopOver-padding           : spacing(x2);
+    $fullScreenPopOver-padding           : spacing(d);
     $fullScreenPopOver-border-color      : $color-grey-30;
     $fullScreenPopOver-shadow-color      : rgba($color-black, 0.12);
 
@@ -117,7 +117,7 @@
                 height: 100%;
                 overflow-x: hidden;
                 overflow-y: scroll;
-                padding: spacing(x2) 0;
+                padding: spacing(d) 0;
                 -webkit-overflow-scrolling: touch;
             }
         }

--- a/src/scss/components/optional/_listings-skeleton.scss
+++ b/src/scss/components/optional/_listings-skeleton.scss
@@ -17,8 +17,8 @@
         position: relative;
         background: $color-container-default;
         border-radius: $radius-rounded-c;
-        padding: 85px spacing(x2) spacing(x2);
-        margin-bottom: spacing(x2);
+        padding: 85px spacing(d) spacing(d);
+        margin-bottom: spacing(d);
 
         @include media('>mid') {
             padding-top: 73px;
@@ -30,13 +30,13 @@
         &:after {
             content: '';
             position: absolute;
-            top: spacing(x2);
+            top: spacing(d);
             @include anim();
         }
 
         //Skeleton image
         &:before {
-            left: spacing(x2);
+            left: spacing(d);
             height: 55px;
             width: 55px;
         }
@@ -154,8 +154,8 @@
         @include media('>mid') {
             width: 360px;
             position: absolute;
-            top: spacing(x2);
-            right: spacing(x2);
+            top: spacing(d);
+            right: spacing(d);
         }
     }
 }

--- a/src/scss/components/optional/_listings.scss
+++ b/src/scss/components/optional/_listings.scss
@@ -54,12 +54,12 @@
     // Inactive listing is styling used for searchWeb offline
     .c-listing--subsequent,
     .c-listing--inactive {
-        margin-top: spacing(x3);
+        margin-top: spacing(e);
     }
 
     .c-listing--subsequent {
         overflow: hidden;
-        padding: 0 spacing(x2) spacing(x2);
+        padding: 0 spacing(d) spacing(d);
         background: $listing--subsequent-bg;
     }
 
@@ -76,13 +76,13 @@
         }
 
         .c-listing-item {
-            margin-bottom: spacing(x2);
+            margin-bottom: spacing(d);
             box-shadow: 0 2px 4px 0 rgba($color-black, 0.1);
             padding-bottom: spacing();
 
             @include media('>mid') {
                 min-height: 96px;
-                padding: spacing(x0.5);
+                padding: spacing(a);
             }
 
             &.is-active {
@@ -100,7 +100,7 @@
         .c-listing-item--withHeader {
             overflow: hidden;
             // Specific padding top % is based on an image size of 288x104 and maintaining an aspect ratio of 36 : 13
-            padding-top: calc(37.69% + #{spacing(x0.5)});
+            padding-top: calc(37.69% + #{spacing(a)});
 
             @include media('>mid') {
                 padding-top: spacing();
@@ -119,8 +119,8 @@
                     width: 87px;
                     height: 87px;
                     padding-top: 0;
-                    top: spacing(x0.5);
-                    left: spacing(x0.5);
+                    top: spacing(a);
+                    left: spacing(a);
                     border-radius: $listing-border-radius;
                 }
 
@@ -195,8 +195,8 @@
             .c-listing-item-img {
                 width: 55px;
                 height: 55px;
-                top: spacing(x2);
-                left: spacing(x2);
+                top: spacing(d);
+                left: spacing(d);
                 position: absolute;
                 border: 1px solid $color-border-subtle;
                 border-radius: $listing-border-radius;
@@ -217,7 +217,7 @@
                         transform: none;
                     }
                     @include media('>=wide') {
-                        top: spacing(x2);
+                        top: spacing(d);
                         left: calc(17.5% - 33px);
                     }
                 }
@@ -265,8 +265,8 @@
                 @include font-size(body-l, false);
 
                 @include media('>mid') {
-                    margin: spacing(x0.5) 0;
-                    padding-right: spacing(x2);
+                    margin: spacing(a) 0;
+                    padding-right: spacing(d);
                 }
             }
 
@@ -274,7 +274,7 @@
                 top: -4px;
                 color: $color-content-positive;
                 position: relative;
-                margin-right: spacing(x0.5);
+                margin-right: spacing(a);
             }
 
             .c-listing-item-details {
@@ -284,7 +284,7 @@
                 @include media('>mid') {
                     width: 45%;
                     margin-top: auto;
-                    padding: spacing() spacing() 0 spacing(x2);
+                    padding: spacing() spacing() 0 spacing(d);
                 }
 
                 @include media('>=wide') {
@@ -295,7 +295,7 @@
             .c-listing-item-detailsRow {
                 display : flex;
                 align-items : center;
-                margin-bottom: spacing(x0.5);
+                margin-bottom: spacing(a);
             }
 
             .c-listing-item-detailsRow-icon {

--- a/src/scss/components/optional/_menu.scss
+++ b/src/scss/components/optional/_menu.scss
@@ -20,9 +20,9 @@
     $menu-border-width                      : 1px;
     $menu-border-width--active              : 2px;
     $menu-link-color                        : $color-content-default;
-    $menu-link-padding                      : spacing() spacing(x2);
-    $menu-positionTop                       : $menu-headerHeight + spacing(x2);
-    $menu--condensed-link-padding           : spacing(x0.5);
+    $menu-link-padding                      : spacing() spacing(d);
+    $menu-positionTop                       : $menu-headerHeight + spacing(d);
+    $menu--condensed-link-padding           : spacing(a);
     $menu--expandable-bgColor               : $color-white;
     $menu--expandable-borderBottom          : $color-border-strong;
     $menu--expandable-linkFontSize          : body-s;
@@ -68,8 +68,8 @@
         .c-menu-openBtnWrapper {
             display: flex;
             justify-content: center;
-            margin-bottom: spacing(x4);
-            margin-top: -#{spacing(x3)};
+            margin-bottom: spacing(f);
+            margin-top: -#{spacing(e)};
             position: sticky;
             top: $menu-positionTop;
             transition: 100ms top ease-in-out;
@@ -81,11 +81,11 @@
             align-items: center;
             border-radius: $radius-rounded-d;
             display: flex;
-            padding: spacing() spacing(x2);
+            padding: spacing() spacing(d);
         }
 
         .c-menu-closeBtn {
-            padding: spacing(x2);
+            padding: spacing(d);
             position: absolute;
             right: 0;
             top: 0;
@@ -104,7 +104,7 @@
                     align-items: center;
 
                     .c-menu-link {
-                        padding-right: spacing(x0.5);
+                        padding-right: spacing(a);
                     }
                 }
             }
@@ -172,7 +172,7 @@
                 @include media('<mid') {
                     max-height: 70vh;
                     overflow-y: scroll;
-                    padding-top: spacing(x2);
+                    padding-top: spacing(d);
 
                     .c-menu-link {
                         display: block;

--- a/src/scss/components/optional/_modal.scss
+++ b/src/scss/components/optional/_modal.scss
@@ -44,7 +44,7 @@
                 }
 
                     .c-modal-title--spacing {
-                        padding: spacing(x5) spacing(x7) spacing(x2);
+                        padding: spacing(g) spacing(h) spacing(d);
                     }
 
                 .c-modal-content {
@@ -86,8 +86,8 @@
     .c-modal-closeBtn {
         padding: spacing();
         position: absolute;
-        right: spacing(x2);
-        top: spacing(x1.5);
+        right: spacing(d);
+        top: spacing(c);
         z-index: zIndex(high);
 
         @include media('>=mid') {
@@ -116,7 +116,7 @@
 
     .c-modal-title {
         @include font-size($modal-titleFontSize);
-        padding: 0 spacing(x3);
+        padding: 0 spacing(e);
 
         @include media('>=mid') {
             @include font-size(heading-m);
@@ -124,10 +124,10 @@
     }
 
         .c-modal-title--spacing {
-            padding: spacing(x3) spacing(x7);
+            padding: spacing(e) spacing(h);
 
             @include media('>=mid') {
-                padding: spacing(x5) spacing(x7) spacing(x2);
+                padding: spacing(g) spacing(h) spacing(d);
             }
         }
 
@@ -136,7 +136,7 @@
         border-radius: $modal-borderRadius;
         box-shadow: 0 3px 4px 0 rgba(0, 0, 0, 0.12);
         display: none;
-        padding: spacing(x3);
+        padding: spacing(e);
         position: fixed;
         right: 50%;
         text-align: center;
@@ -161,7 +161,7 @@
             max-height: 90vh;
             max-width: 600px;
             overflow: hidden;
-            padding: spacing(x5);
+            padding: spacing(g);
         }
     }
 
@@ -211,7 +211,7 @@
         background-color: $color-white;
         box-shadow: 0 -2px 4px 0 rgba(0, 0, 0, 0.12);
         bottom: 0;
-        padding: spacing(x3);
+        padding: spacing(e);
         position: sticky;
         width: 100%;
     }
@@ -219,7 +219,7 @@
     .c-modal-textSeparator {
         font-weight: $font-weight-bold;
         @include font-size(body-l);
-        margin: spacing(x3) 0 0;
+        margin: spacing(e) 0 0;
 
         @include media('>=narrow') {
             margin: 0;
@@ -227,6 +227,6 @@
     }
 
         .c-modal-textSeparator--spaceAround {
-            margin: spacing(x3) 0 spacing(x2);
+            margin: spacing(e) 0 spacing(d);
         }
 }

--- a/src/scss/components/optional/_order-card.scss
+++ b/src/scss/components/optional/_order-card.scss
@@ -119,7 +119,7 @@
         color: $color-blue;
         text-align: center;
         margin-top: spacing();
-        padding: 2px spacing(x1.5) spacing(x1.5);
+        padding: 2px spacing(c) spacing(c);
         border-top: 1px solid $color-grey-10;
     }
 
@@ -152,12 +152,12 @@
 
     .c-orderCard-orderTotal {
         margin-right: spacing();
-        margin-left: spacing(x3);
+        margin-left: spacing(e);
         align-self: flex-end;
     }
 
     .c-orderCard-content {
-        padding: spacing() spacing(x2) 0;
+        padding: spacing() spacing(d) 0;
         color: $color-grey;
         flex: 1 0 auto;
         display: flex;
@@ -165,11 +165,11 @@
     }
 
     .c-orderCard-yourFavourites-content {
-        padding: spacing() spacing(x2);
+        padding: spacing() spacing(d);
     }
 
     .c-orderCard-content--defaultMessage {
-        padding: 0 spacing(x2);
+        padding: 0 spacing(d);
         @include font-size(body-l, false);
     }
 
@@ -186,22 +186,22 @@
     }
 
     .c-orderCard--inactive {
-        margin-left: spacing(x4);
+        margin-left: spacing(f);
     }
 
     .c-orderCard-header {
         flex-direction: row;
         align-items: baseline;
         display: flex;
-        margin-left: spacing(x2);
+        margin-left: spacing(d);
 
         @include media('>mid') {
-            margin-left: spacing(x4);
+            margin-left: spacing(f);
         }
     }
 
     .c-orderCard-seeAllText {
         width: fit-content;
-        margin-left: spacing(x2);
+        margin-left: spacing(d);
     }
 }

--- a/src/scss/components/optional/_overflow-carousel.scss
+++ b/src/scss/components/optional/_overflow-carousel.scss
@@ -15,7 +15,7 @@
 
     .c-overflowCarousel {
         @include media('<mid') {
-            margin: 0 (spacing(x2) * -1);
+            margin: 0 (spacing(d) * -1);
         }
     }
 
@@ -56,18 +56,18 @@
         display: flex;
         flex-wrap: nowrap;
         overflow-x: auto;
-        padding: spacing() spacing(x2);
+        padding: spacing() spacing(d);
         -webkit-overflow-scrolling: touch;
         -ms-overflow-style: none;
 
         //add spacing after the last element
         &:after {
             content: '';
-            flex: 0 0 spacing(x2);
+            flex: 0 0 spacing(d);
         }
 
         @include media('>mid') {
-            padding: spacing(x2) spacing(x4) spacing();
+            padding: spacing(d) spacing(f) spacing();
         }
 
         .c-overflowCarousel-item {
@@ -75,7 +75,7 @@
             margin-right: spacing();
 
             @include media('>=mid') {
-                margin-right: spacing(x2);
+                margin-right: spacing(d);
             }
         }
     }
@@ -102,6 +102,6 @@
 @mixin overflowCarouselContent() {
     display: inline-flex;
     white-space: nowrap;
-    padding-left: spacing(x2);
-    padding-right: spacing(x2);
+    padding-left: spacing(d);
+    padding-right: spacing(d);
 }

--- a/src/scss/components/optional/_user-message.scss
+++ b/src/scss/components/optional/_user-message.scss
@@ -12,13 +12,13 @@
         color: $color-white;
         background-color: $color-orange;
         max-width: 100%;
-        margin-top: spacing(x2);
+        margin-top: spacing(d);
     }
 
     .c-userMessageContainer {
         max-width: 350px;
         margin: 0 auto;
-        padding: spacing(x2) 0;
+        padding: spacing(d) 0;
         display: flex;
 
         @include media('>=narrow') {
@@ -42,7 +42,7 @@
     }
 
     .c-userMessageText {
-        margin-left: spacing(x2);
+        margin-left: spacing(d);
         margin-top: 0;
 
         @include media('>=mid') {

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -13,7 +13,7 @@
     $btn-default-borderRadius              : $radius-rounded-e;
     $btn-default-font-size                 : 'heading-s';
     $btn-default-weight                    : $font-weight-bold;
-    $btn-default-padding                   : 10px spacing(x3);
+    $btn-default-padding                   : 10px spacing(e);
     $btn-default-outline-color             : $color-focus;
 
     $btn-default-bgColor                   : $color-interactive-brand;
@@ -58,11 +58,11 @@
     $btn-disabled-bgColor                  : $color-disabled-01;
     $btn-disabled-textColor                : $color-content-disabled;
 
-    $btn-sizeLarge-padding                 : 14px spacing(x3);
+    $btn-sizeLarge-padding                 : 14px spacing(e);
     $btn-sizeLarge-loading-color           : $color-content-interactive-light;
 
     $btn-sizeSmall-font-size               : 'body-l';
-    $btn-sizeSmall-padding                 : spacing() spacing(x2);
+    $btn-sizeSmall-padding                 : spacing() spacing(d);
 
     $btn-sizeXSmall-font-size              : 'body-s';
     $btn-sizeXSmall-padding                : 6px spacing();
@@ -130,7 +130,7 @@
         }
 
         p + & {
-            margin-top: spacing(x2);
+            margin-top: spacing(d);
         }
 
         & .note {
@@ -141,7 +141,7 @@
             }
         }
         &[type='submit'] {
-            margin-top: spacing(x2);
+            margin-top: spacing(d);
         }
     }
 

--- a/src/scss/objects/_form-controls.scss
+++ b/src/scss/objects/_form-controls.scss
@@ -40,7 +40,7 @@
     $formControl-color--hover       : darken($color-orange, $color-hover-01);
     $formControl-background-color   : $color-background-default;
     $formControl-margin-left        : 0;
-    $formControl-padding-left       : spacing(x4);
+    $formControl-padding-left       : spacing(f);
     $formControl-width              : 24px;
     $formControl-width--wide        : 20px;
     $formControl-height             : 24px;
@@ -147,7 +147,7 @@
         .o-formControl-icon {
             background-position: center 0;
             left: spacing();
-            min-width: spacing(x1.5);
+            min-width: spacing(c);
             position: absolute;
         }
 

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -42,7 +42,7 @@ $formToggle-text--checked           : $color-green;
     }
 
         .o-formToggle--button {
-            padding-left: spacing(x4);
+            padding-left: spacing(f);
             color: $formToggle-button-color;
             background: $formToggle-button-background;
             border-color: $formToggle-button-background;
@@ -59,7 +59,7 @@ $formToggle-text--checked           : $color-green;
         //Used alongside the default styles but for a larger tap area (min 44px) on narrow screens
         .o-formToggle--largeTouchArea {
             @include media('<mid') {
-                margin: spacing() 0 spacing() spacing(x0.5);
+                margin: spacing() 0 spacing() spacing(a);
             }
         }
 

--- a/src/scss/objects/_lists.scss
+++ b/src/scss/objects/_lists.scss
@@ -17,7 +17,7 @@
     ul,
     ol {
         padding: 0;
-        margin: spacing(x2) 0 0 spacing(x2);
+        margin: spacing(d) 0 0 spacing(d);
 
         li {
             margin-bottom: spacing();
@@ -56,7 +56,7 @@
         > li {
             font-weight: $font-weight-bold;
             @include font-size(heading-s); // TODO – this should be updated with a more semantic font alias specific to lists
-            margin-bottom: spacing(x4);
+            margin-bottom: spacing(f);
 
             > div {
                 font-weight: $font-weight-regular;

--- a/src/scss/objects/_tables.scss
+++ b/src/scss/objects/_tables.scss
@@ -36,8 +36,8 @@
     .table {
         width: 100%;
         max-width: 100%;
-        margin-top: spacing(x4);
-        margin-bottom: spacing(x4);
+        margin-top: spacing(f);
+        margin-bottom: spacing(f);
         border-spacing: 0;
         background-color: $table-bgColor;
         border: $table-border--width solid $table-border--color;

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -100,19 +100,17 @@ $use-legacy-grid              : true !default;
 // spacing map
 // Can access levels by using the spacing function > spacing() or spacing(a) for example
 $spacing: (
-    a    : $spacing-a,
-    b    : $spacing-b,
-    c    : $spacing-c,
-    d    : $spacing-d,
-    e    : $spacing-e,
-    f    : $spacing-f,
-    g    : $spacing-g,
-    h    : $spacing-h,
-    i    : $spacing-i,
-    j    : $spacing-j
+    a    : $spacing-a, // 4px
+    b    : $spacing-b, // 8px
+    c    : $spacing-c, // 12px
+    d    : $spacing-d, // 16px
+    e    : $spacing-e, // 24px
+    f    : $spacing-f, // 32px
+    g    : $spacing-g, // 40px
+    h    : $spacing-h, // 56px
+    i    : $spacing-i, // 64px
+    j    : $spacing-j  // 80px
 );
-
-$baseline: spacing(d); // default spacing between blocks
 
 $border-radius: $radius-rounded-a; // the smallest of pie border tokens
 

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -97,28 +97,22 @@ $responsive-gutters           : true !default; // Disable this if you don't want
 $use-legacy-grid              : true !default;
 
 
-// Spacing (Vertical / Horizontal)
-// ==========================================================================
-$spacing: 8px; // only for use in map below – not for in components
-
 // spacing map
 // Can access levels by using the spacing function > spacing() or spacing(x5) for example
 $spacing: (
-    x0.5 : $spacing / 2,
-    base : $spacing,
-    x1.5 : $spacing * 1.5,
-    x2   : $spacing * 2,
-    x3   : $spacing * 3,
-    x4   : $spacing * 4,
-    x5   : $spacing * 5,
-    x6   : $spacing * 6,
-    x7   : $spacing * 7,
-    x8   : $spacing * 8,
-    x9   : $spacing * 9,
-    x10   : $spacing * 10
+    a    : $spacing-a,
+    b    : $spacing-b,
+    c    : $spacing-c,
+    d    : $spacing-d,
+    e    : $spacing-e,
+    f    : $spacing-f,
+    g    : $spacing-g,
+    h    : $spacing-h,
+    i    : $spacing-i,
+    j    : $spacing-j
 );
 
-$baseline: spacing(x2); // default spacing between blocks
+$baseline: spacing(d); // default spacing between blocks
 
 $border-radius: $radius-rounded-a; // the smallest of pie border tokens
 

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -98,7 +98,7 @@ $use-legacy-grid              : true !default;
 
 
 // spacing map
-// Can access levels by using the spacing function > spacing() or spacing(x5) for example
+// Can access levels by using the spacing function > spacing() or spacing(a) for example
 $spacing: (
     a    : $spacing-a,
     b    : $spacing-b,

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -98,7 +98,7 @@
 
     .u-sticky {
         position: sticky !important;
-        top: spacing(x2);
+        top: spacing(d);
     }
 
     .u-absolutelyCentered {
@@ -122,7 +122,7 @@
     }
 
     .u-textPad {
-        padding-left: spacing(x4) !important;
+        padding-left: spacing(f) !important;
     }
 
     .u-text-truncate {
@@ -161,7 +161,7 @@
     }
 
     .u-text-indent {
-        margin-left: spacing(x2);
+        margin-left: spacing(d);
     }
 
     //
@@ -215,11 +215,11 @@
     }
 
         .u-spacingTop--small {
-            margin-top: spacing(x0.5) !important;
+            margin-top: spacing(a) !important;
         }
 
         .u-spacingTop--large {
-            margin-top: spacing(x2) !important;
+            margin-top: spacing(d) !important;
         }
 
     .u-spacingRight {
@@ -231,12 +231,12 @@
     }
 
         .u-spacingBottom--large {
-            margin-bottom: spacing(x2) !important;
+            margin-bottom: spacing(d) !important;
         }
 
         .u-spacingBottom--large--aboveMid {
             @include media('>=mid') {
-                margin-bottom: spacing(x2);
+                margin-bottom: spacing(d);
             }
         }
 
@@ -257,12 +257,12 @@
     }
 
         .u-padTop--large {
-            padding-top: spacing(x2) !important;
+            padding-top: spacing(d) !important;
         }
 
         .u-padTop--large--aboveMid {
             @include media('>=mid') {
-                padding-top: spacing(x2) !important;
+                padding-top: spacing(d) !important;
             }
         }
 
@@ -392,7 +392,7 @@
     // Misc classes
     // ==========================================================================
     .u-shadowBottom--belowMid {
-        padding-bottom: spacing(x7);
+        padding-bottom: spacing(h);
 
         @include media('<mid') {
             &:after {
@@ -401,7 +401,7 @@
                 box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, 0.1);
                 content: '';
                 display: block;
-                height: spacing(x7);
+                height: spacing(h);
                 left: -#{spacing()};
                 position: absolute;
                 width: 100vw;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@
   dependencies:
     window-or-global "^1.0.1"
 
-"@justeat/f-utils@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-2.0.0.tgz#34e34870f20ec85b5d0aca8a87e2bc2225e2f597"
-  integrity sha512-fFkNH39Qe6sg6e2YZmbh4l4g4qegvpsaEKnj1grCDRspQQvzpmBQBifx6nkHsdaEhetZTJC3LqwOXybmlVJI/g==
+"@justeat/f-utils@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-3.1.0.tgz#6f2607171d6d957b038617174f0c922258e2864f"
+  integrity sha512-DmkHElVkfBaocFEaqtge0AbbNs0+EzCRpPHYfSzSw6K8N88Git/e/O281Ye1ToqqIzKsdynrG1zAYBIrpaS5OQ==
 
 "@justeat/js-test-buddy@0.4.1":
   version "0.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1178,10 +1178,10 @@
   dependencies:
     "@justeat/dom-buddy" "2.4.3"
 
-"@justeat/pie-design-tokens@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@justeat/pie-design-tokens/-/pie-design-tokens-1.2.0.tgz#379b9f25b481405c501afc1960b459fd06459b40"
-  integrity sha512-uMVpHVWM3RORK8DzdXWi2Rey9jPCq4sWt64JL9pqN+f+l4ck61b/rpRRf060WvWCcU0Cy/zihbSrJy1hNG1SQg==
+"@justeat/pie-design-tokens@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@justeat/pie-design-tokens/-/pie-design-tokens-1.4.0.tgz#adb4b3b7f5ed9ac9691e67e02b02264acd6dcfbf"
+  integrity sha512-V+lBWi4Q7WjYRYYTAm2rJfDqjePArhHrgC4pB8vsQXp4uPmEUG/6cJa4K8DArADxLA924QESE3Akmtn8nAe5dw==
   dependencies:
     jsonc-parser "2.2.0"
     lodash.merge "4.6.2"


### PR DESCRIPTION
### Changed
- **Breaking** Type map for $spacing to reference pie design tokens.
  - If you are using the below mapping values please note they have changed or been removed:
    $spacing x 6 = spacing(h) instead of spacing(x6) - Note the size change has gone from 48px > 56px.
    $spacing x 9 - Has been removed - Please map to the next value up or down e.g spacing(j) or spacing(i).

| Old map usage | New map usage |
| ----- | ----- |
| spacing(x0.5) | $spacing(a) |
| spacing(base) | $spacing(b) |
| spacing(x1.5) | $spacing(c) |
| spacing(x2) | $spacing(d) |
| spacing(x3) | $spacing(e) |
| spacing(x4) | $spacing(f) |
| spacing(x5) | $spacing(g) |
| spacing(x6) | $spacing(h) |
| spacing(x7) | $spacing(h) |
| spacing(x8) | $spacing(i) |
| spacing(x9) | Removed, replace with closet size up or down |
| spacing(x10) | $spacing(j) |

- `pie-design-tokens` package.json version to bring in new elevation changes.

