### PR TITLE
v7.3.0 - Bump f-utils package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Future Todo List
 ------------------------------
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 
+v7.3.0
+------------------------------
+*January 31, 2022*
+
+### Changed
+- f-utils version to fix `map.merge` lint error.
+
+
 v7.2.0
 ------------------------------
 *January 31, 2022*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -33,7 +33,7 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "@justeat/f-utils": "3.3.0",
+    "@justeat/f-utils": "3.4.0",
     "@justeat/pie-design-tokens": "1.4.0",
     "include-media": "1.4.10"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@
   dependencies:
     window-or-global "^1.0.1"
 
-"@justeat/f-utils@3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-3.3.0.tgz#0b1a97d4f9c30a4dfd81d8e63cb166c8af486ca1"
-  integrity sha512-gX4+Q8iy23QB2iiYfK99z6YFjR5VM0pqSTh3qbp8XSA6+kkoUHVwvBUa7aSJGy96gr12wpm2oVOoQbWps52qPw==
+"@justeat/f-utils@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-3.4.0.tgz#7c6b49ea0db15cf8ebada530d1485cf53fec507d"
+  integrity sha512-VWKLJ37x3hZdyjqs37dtYGDmDNXhBe99Ny6Tll4guj9g4m132GBpNOwfSpYgMCHnz81rZozKoIVZ83czyMliIA==
 
 "@justeat/js-test-buddy@0.4.1":
   version "0.4.1"


### PR DESCRIPTION
### Changed
- f-utils version to fix `map.merge` lint error.