### PR TITLE
v7.5.0 - elevation tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Future Todo List
 ------------------------------
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
+- Deprecate modal and orderCard component styles in next major version as unused.
+
+
+v7.5.0
+------------------------------
+*February 9, 2022*
+
+### Changed
+- box-shadow values now use pie-design-tokens `$elevation` tokens.
+- Deprecation warning to the `c-modal` and `orderCard` components.
+
+### Removed
+- box-shadow from hover state of cuisinesWidget component styles.
+- `.c-menu--expandable` and `.c-menu--expandable--expanded` classes from menu component styles.
+
 
 v7.4.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "7.4.0",
+  "version": "7.5.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/components/optional/_cuisines-widget.scss
+++ b/src/scss/components/optional/_cuisines-widget.scss
@@ -3,22 +3,14 @@
     * Components > Cuisines Widget
     * =================================
     *
-    * Example: Homepage – Popular cuisines.
+    * Example: Homepage – Popular cuisines image tiles.
     *
     * The `c-cuisinesWidget` component is an optional mixin within Fozzie.
     * If you'd like to use it in your project you can include it by adding `@include cuisinesWidget();` into your SCSS dependencies file.
     *
-    * Documentation:
-    * https://fozzie.just-eat.com/styleguide/ui-components/cuisines-widget
     */
 
-    //TODO: Improvement of this solution: WH-682 as suggested in https://github.com/justeat/fozzie/pull/188#issuecomment-442138750
-
-
-    $cuisinesWidget-titleColour: $color-white;
     $cuisinesWidget-defaultBackground: $color-grey-20;
-    $cuisinesWidget-boxShadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
-    $cuisinesWidget-hoverBoxShadow: 0 2px 8px 0 rgba(0, 0, 0, 0.16), -2px -2px 4px 0 rgba(0, 0, 0, 0.04);
     $cuisinesWidget-gradient: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0));
 
     @include media-context(('narrow-mid': 570px, 'mid-wide': 1240px)) {
@@ -29,14 +21,12 @@
             overflow: hidden;
             position: relative;
             background-color: $cuisinesWidget-defaultBackground;
-            box-shadow: $cuisinesWidget-boxShadow;
+            box-shadow: $elevation-01; // token values for cards
             margin-top: spacing();
             margin-bottom: spacing();
 
             &:hover,
             &:focus {
-                box-shadow: $cuisinesWidget-hoverBoxShadow;
-
                 .c-cuisinesWidget-name {
                     text-decoration: underline;
                 }
@@ -49,7 +39,7 @@
             left: 0;
             width: 100%;
             padding: spacing(d) spacing(d) spacing();
-            color: $cuisinesWidget-titleColour;
+            color: $color-container-default;
             text-align: center;
             background-image: $cuisinesWidget-gradient;
 

--- a/src/scss/components/optional/_fullscreen-pop-over.scss
+++ b/src/scss/components/optional/_fullscreen-pop-over.scss
@@ -77,7 +77,7 @@
         .c-fullScreenPopOver-header {
             top: 0;
             z-index: zIndex(high);
-            box-shadow: 0 3px 4px 0 $color-grey-30;
+            box-shadow: $elevation-03; // token value for sticky headers
         }
 
         .c-fullScreenPopOver-header-actionFirst,
@@ -109,7 +109,7 @@
 
         .c-fullScreenPopOver-footer {
             bottom: 0;
-            box-shadow: 0 -2px 2px 0 $color-grey-30;
+            box-shadow: $elevation-05; // token value for 'above elevation'
         }
 
         .c-fullScreenPopOver-content {

--- a/src/scss/components/optional/_listings.scss
+++ b/src/scss/components/optional/_listings.scss
@@ -77,7 +77,7 @@
 
         .c-listing-item {
             margin-bottom: spacing(d);
-            box-shadow: 0 2px 4px 0 rgba($color-black, 0.1);
+            box-shadow: $elevation-01; // token value for card default state
             padding-bottom: spacing();
 
             @include media('>mid') {

--- a/src/scss/components/optional/_menu.scss
+++ b/src/scss/components/optional/_menu.scss
@@ -23,10 +23,6 @@
     $menu-link-padding                      : spacing() spacing(d);
     $menu-positionTop                       : $menu-headerHeight + spacing(d);
     $menu--condensed-link-padding           : spacing(a);
-    $menu--expandable-bgColor               : $color-white;
-    $menu--expandable-borderBottom          : $color-border-strong;
-    $menu--expandable-linkFontSize          : body-s;
-    $menu--expandable-linkActiveFontSize    : body-l;
 
     .c-menu {
         @extend %u-unstyled;
@@ -137,46 +133,4 @@
         .c-menu-icon {
             flex-shrink: 0;
         }
-
-        .c-menu--expandable {
-            @include media('<mid') {
-                background-color: $menu--expandable-bgColor;
-                border-bottom: solid 1px $menu--expandable-borderBottom;
-                box-shadow: 0 3px 4px 0 rgba(0, 0, 0, 0.12);
-                height: auto;
-
-                .c-menu-link {
-                    display: none;
-                    @include font-size($menu--expandable-linkFontSize);
-                    margin-left: 0;
-                    text-align: center;
-
-                    &,
-                    &:active,
-                    &:focus,
-                    &:hover {
-                        border: 0;
-                        font-weight: $font-weight-regular;
-                    }
-                }
-
-                .c-menu-link--active {
-                    @include font-size($menu--expandable-linkActiveFontSize);
-                    text-decoration: underline;
-                    width: 100vw;
-                }
-            }
-        }
-
-            .c-menu--expandable--expanded {
-                @include media('<mid') {
-                    max-height: 70vh;
-                    overflow-y: scroll;
-                    padding-top: spacing(d);
-
-                    .c-menu-link {
-                        display: block;
-                    }
-                }
-            }
 }

--- a/src/scss/components/optional/_modal.scss
+++ b/src/scss/components/optional/_modal.scss
@@ -1,4 +1,5 @@
 @mixin modal() {
+    @warn 'The modal component styles will be deprecated in version 8 as unused, please contact Web Core team if you are still using them';
     /**
     * Components > Item Selector
     * =================================

--- a/src/scss/components/optional/_order-card.scss
+++ b/src/scss/components/optional/_order-card.scss
@@ -1,4 +1,5 @@
 @mixin orderCard() {
+    @warn 'The orderCard component styles will be deprecated in version 8 as unused, please contact Web Core team if you are still using them';
     /**
     * Components > Order Card
     * =================================

--- a/src/scss/components/optional/_toast.scss
+++ b/src/scss/components/optional/_toast.scss
@@ -56,7 +56,7 @@
         background-color: $toast-bgColor--default;
         border-top-left-radius: $toast-radius;
         border-top-right-radius: $toast-radius;
-        box-shadow: 0 -3px 4px 0 rgba(0, 0, 0, 0.12);
+        box-shadow: $elevation-05; // token value for 'above elevation'
         color: $toast-textColor;
         height: $toast-height;
         opacity: 0.9;

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -398,7 +398,7 @@
             &:after {
                 background-color: $color-grey-20;
                 border: 0;
-                box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, 0.1);
+                box-shadow: $elevation-01;
                 content: '';
                 display: block;
                 height: spacing(h);


### PR DESCRIPTION
### Changed
- box-shadow values now use pie-design-tokens `$elevation` tokens.
- Deprecation warning to the `c-modal` and `orderCard` components.

### Removed
- box-shadow from hover state of cuisinesWidget component styles.
- `.c-menu--expandable` and `.c-menu--expandable--expanded` classes from menu component styles.