### PR TITLE
v8.0.0 – Removing reliance on eyeglass for imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Future Todo List
 - Deprecate modal and orderCard component styles in next major version as unused.
 
 
+v8.0.0
+------------------------------
+*Feburary 15, 2022*
+
+### Changed
+- Removing reliance on eyeglass in favour of using sass-loader `includePaths` option to resolve imports to node_modules.
+  Downside to this will be we are tied to using either webpack or a tool that allows similar functionality through it's resolver options.
+
+
 v7.5.0
 ------------------------------
 *February 9, 2022*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Future Todo List
 
 v8.0.0
 ------------------------------
-*Feburary 15, 2022*
+*February 15, 2022*
 
 ### Changed
 - Removing reliance on eyeglass in favour of using sass-loader `includePaths` option to resolve imports to node_modules.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "7.5.0",
+  "version": "8.0.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -46,7 +46,6 @@
     "@justeat/eslint-config-fozzie": "4.0.0",
     "@justeat/f-dom": "1.1.0",
     "@justeat/f-logger": "0.8.1",
-    "fontfaceobserver": "2.1.0",
     "@justeat/js-test-buddy": "0.4.1",
     "@justeat/stylelint-config-fozzie": "2.2.0",
     "concurrently": "6.3.0",
@@ -54,7 +53,9 @@
     "danger": "10.7.0",
     "eslint": "7.21.0",
     "eslint-plugin-import": "2.25.2",
+    "fontfaceobserver": "2.1.0",
     "jest": "27.3.0",
+    "sass": "1.49.7",
     "stylelint": "13.13.1",
     "stylelint-scss": "3.21.0"
   },
@@ -62,15 +63,8 @@
     "babel-core": "7.0.0-bridge.0"
   },
   "keywords": [
-    "fozzie",
-    "eyeglass-module"
+    "fozzie"
   ],
-  "eyeglass": {
-    "name": "fozzie",
-    "sassDir": "src/scss",
-    "needs": "^3.0.2",
-    "exports": false
-  },
   "scripts": {
     "compile": "babel -d dist src --ignore \"src/**/*.test.js\"",
     "lint": "yarn run lint:css && yarn run lint:js",
@@ -78,6 +72,7 @@
     "lint:js": "eslint --ext .js .",
     "prepare": "concurrently -n \"lint,compile,test\" -c \"blue,yellow,green\" \"yarn lint\" \"yarn compile\" \"yarn test\" --kill-others-on-fail",
     "test": "jest",
+    "test:build": "sass --no-source-map --load-path=node_modules --style=compressed src/scss:dist/css",
     "test:cover": "jest --collect-coverage",
     "test:cover:CI": "cat coverage/lcov.info | coveralls"
   },

--- a/src/scss/_dependencies.scss
+++ b/src/scss/_dependencies.scss
@@ -15,18 +15,18 @@
 // See mixins/css3.scss for the full list
 
 // Including helper modules
-@import 'f-utils'; // imports Fozzie SCSS helper functions and mixins – https://github.com/justeat/f-utils
-@import 'include-media'; // Cleaner media query declarations – http://include-media.com
+@import '@justeat/f-utils/src/scss/'; // imports Fozzie SCSS helper functions and mixins – https://github.com/justeat/f-utils
+@import 'include-media/dist/_include-media'; // Cleaner media query declarations – http://include-media.com
 
 
 // =================================
 // Core variables
 // =================================
 // The colour variables are imported from https://www.npmjs.com/package/@justeat/pie-design-tokens
-@import 'pie-design-tokens';
+@import '@justeat/pie-design-tokens/dist/jet';
 
 @import 'settings/variables';
-@import 'f-utils/helpers/breakpoints'; // breakpoint helper – https://github.com/justeat/f-utils/blob/96508ae19809c4b8b83cebb55b9d74728d01c1a5/src/scss/helpers/_breakpoints.scss
+@import '@justeat/f-utils/src/scss/helpers/breakpoints'; // breakpoint helper – https://github.com/justeat/f-utils/blob/96508ae19809c4b8b83cebb55b9d74728d01c1a5/src/scss/helpers/_breakpoints.scss
 
 
 // CSS Normalise and then Reset

--- a/yarn.lock
+++ b/yarn.lock
@@ -2024,6 +2024,21 @@ character-reference-invalid@^1.0.0:
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
   integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
 
+"chokidar@>=3.0.0 <4.0.0":
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 chokidar@^3.4.0:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
@@ -3502,6 +3517,11 @@ ignore@^5.1.4, ignore@^5.1.8:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
+immutable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0.tgz#b86f78de6adef3608395efb269a91462797e2c23"
+  integrity sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -5826,6 +5846,15 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sass@1.49.7:
+  version "1.49.7"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.49.7.tgz#22a86a50552b9b11f71404dfad1b9ff44c6b0c49"
+  integrity sha512-13dml55EMIR2rS4d/RDHHP0sXMY3+30e1TKsyXaSz3iLWVoDWEoboY8WzJd5JMnxrRHffKO3wq2mpJ0jxRJiEQ==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+    immutable "^4.0.0"
+    source-map-js ">=0.6.2 <2.0.0"
+
 saxes@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
@@ -5956,6 +5985,11 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
+
+"source-map-js@>=0.6.2 <2.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 source-map-resolve@^0.5.0:
   version "0.5.3"


### PR DESCRIPTION
### Changed
- Attempting to remove reliance on eyeglass in favour of using sass-loader `includePaths` option to resolve imports to node_modules.
  
  Downside to this will be we are tied to using either webpack or a tool that allows similar functionality through it's resolver options.