### PR TITLE
v8.2.0 - Node 16 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Future Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 - Deprecate modal and orderCard component styles in next major version as unused.
 
+v8.2.0
+------------------------------
+*May 23, 2022*
+
+### Added
+- Node 16 to the `engines` property in `package.json`.
+
 v8.1.0
 ------------------------------
 *May 12, 2022*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",
@@ -30,7 +30,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14"
+    "node": "^12 || ^14 || ^16"
   },
   "dependencies": {
     "@justeat/pie-design-tokens": "1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,11 +1166,6 @@
   dependencies:
     window-or-global "^1.0.1"
 
-"@justeat/f-utils@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-3.5.0.tgz#7534c48dfdad30b25b76449a556fd023ab32f64b"
-  integrity sha512-f1bFB8K/yAWGlNJRfODykWt7omkesMAiz8CqwSmHnLA04FyS8BpGZedVdxKbAxZ6n8rrITAjwWBG076uzBe2+w==
-
 "@justeat/js-test-buddy@0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@justeat/js-test-buddy/-/js-test-buddy-0.4.1.tgz#5ab0f7bd0ebc160c275b7b5d2ad2a6282420e106"


### PR DESCRIPTION
This PR adds Node 16 to the engines property in package.json.

Doing this allows up to upgrade fozzie-components and other repos to Node 16.


Tested locally by switching to Node 16 and running `yarn` / `yarn compile`

Was able to successfully import this version into fozzie-components when using Node 16.