### PR TITLE
v9.0.0-beta.2 - update @use rules in _type.scss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Future Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 - Deprecate modal and orderCard component styles in next major version as unused.
 
+v9.0.0-beta.2
+------------------------------
+*June 15, 2022*
+
+### Changed
+- Use a `@use` rule for `line-height` function in `_type.scss`
+- Remove namespace aliases from `@use` rules in `_type.scss`
+
+
 v9.0.0-beta.1
 ------------------------------
 *June 07, 2022*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "9.0.0-beta.1",
+  "version": "9.0.0-beta.2",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/tools/mixins/_type.scss
+++ b/src/scss/tools/mixins/_type.scss
@@ -1,6 +1,6 @@
 @use '../../settings/variables' as v;
-@use '../functions/strip-units' as functions;
-@use '../functions/units' as units;
+@use '../functions/strip-units' as *;
+@use '../functions/units' as *;
 
 // ==========================================================================
 // Typography mixins
@@ -11,7 +11,7 @@
 @use 'sass:math';
 
 @mixin rem($property, $sizeValue: v.$font-size-base) {
-    $unitlessSizeValue: functions.strip-units($sizeValue);
+    $unitlessSizeValue: strip-units($sizeValue);
     $remValue: math.div($unitlessSizeValue, v.$font-size-base);
 
     #{$property}: ceil($unitlessSizeValue) + px;
@@ -21,7 +21,7 @@
 // EM
 // @include em(margin, $font-size-base);
 @mixin em($property, $sizeValue: v.$font-size-base) {
-    #{$property}: math.div(functions.strip-units($sizeValue), v.$font-size-base) + em;
+    #{$property}: math.div(strip-units($sizeValue), v.$font-size-base) + em;
 }
 
 @mixin font-size($key: 'body-s', $line-height: true, $scale: 'default', $relativeToParent: false) {
@@ -51,7 +51,7 @@
             @if length($font-list) > 1 and $line-height == true {
                 $line-height: nth($font-list, 2);
 
-                line-height: units.line-height($font-size, $line-height);
+                line-height: line-height($font-size, $line-height);
             }
         } @else {
             @if $relativeToParent == true {

--- a/src/scss/tools/mixins/_type.scss
+++ b/src/scss/tools/mixins/_type.scss
@@ -1,6 +1,6 @@
 @use '../../settings/variables' as v;
-@use '../functions/strip-units' as *;
-@use '../functions/units' as *;
+@use '../functions/strip-units';
+@use '../functions/units';
 
 // ==========================================================================
 // Typography mixins
@@ -11,7 +11,7 @@
 @use 'sass:math';
 
 @mixin rem($property, $sizeValue: v.$font-size-base) {
-    $unitlessSizeValue: strip-units($sizeValue);
+    $unitlessSizeValue: strip-units.strip-units($sizeValue);
     $remValue: math.div($unitlessSizeValue, v.$font-size-base);
 
     #{$property}: ceil($unitlessSizeValue) + px;
@@ -21,7 +21,7 @@
 // EM
 // @include em(margin, $font-size-base);
 @mixin em($property, $sizeValue: v.$font-size-base) {
-    #{$property}: math.div(strip-units($sizeValue), v.$font-size-base) + em;
+    #{$property}: math.div(strip-units.strip-units($sizeValue), v.$font-size-base) + em;
 }
 
 @mixin font-size($key: 'body-s', $line-height: true, $scale: 'default', $relativeToParent: false) {
@@ -51,7 +51,7 @@
             @if length($font-list) > 1 and $line-height == true {
                 $line-height: nth($font-list, 2);
 
-                line-height: line-height($font-size, $line-height);
+                line-height: units.line-height($font-size, $line-height);
             }
         } @else {
             @if $relativeToParent == true {

--- a/src/scss/tools/mixins/_type.scss
+++ b/src/scss/tools/mixins/_type.scss
@@ -1,5 +1,6 @@
 @use '../../settings/variables' as v;
 @use '../functions/strip-units' as functions;
+@use '../functions/units' as units;
 
 // ==========================================================================
 // Typography mixins
@@ -50,7 +51,7 @@
             @if length($font-list) > 1 and $line-height == true {
                 $line-height: nth($font-list, 2);
 
-                line-height: line-height($font-size, $line-height);
+                line-height: units.line-height($font-size, $line-height);
             }
         } @else {
             @if $relativeToParent == true {


### PR DESCRIPTION
v9.0.0-beta.2
------------------------------
*June 15, 2022*

### Changed
- Use a `@use` rule for `line-height` function in `_type.scss`
- Remove namespace aliases from `@use` rules in `_type.scss`