### PR TITLE
v8.3.0 - Add sass:map.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ v8.3.0
 *June 17, 2022*
 
 ### Added
-- `sass:map` to resolve `map-get` error when using `sass` in comsuming apps.
+- `sass:map` to resolve `map-get` error when using `sass` in consuming apps.
 
 
 v8.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Future Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 - Deprecate modal and orderCard component styles in next major version as unused.
 
+v8.3.0
+------------------------------
+*June 17, 2022*
+
+### Added
+- `sass:map` to resolve `map-get` error when using `sass` in comsuming apps.
+
+
 v8.2.0
 ------------------------------
 *May 23, 2022*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/tools/functions/_units.scss
+++ b/src/scss/tools/functions/_units.scss
@@ -10,13 +10,14 @@
 // Returns a unitless line-height value
 //
 @use 'sass:math';
+@use 'sass:map';
 
 @function line-height($font-size: 'body-s', $line-height: '20', $scale: 'default') {
     @if type-of($font-size) == 'number' {
         @return decimal-round(math.div($line-height, $font-size), 2);
     } @else if map-has-key($type, $font-size) { // else try and find the value in our type map
-        $key-map: map-get($type, $font-size);
-        $font-list: map-get($key-map, $scale);
+        $key-map: map.get($type, $font-size);
+        $font-list: map.get($key-map, $scale);
 
         @if type-of($font-list) == 'list' {
             @return line-height(nth($font-list, 1), nth($font-list, 2));


### PR DESCRIPTION
### Added
- `sass:map` to resolve `map-get` error when using `sass` in comsuming apps.