### PR TITLE
v9.0.0-beta.8 - Remove tilde import.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Future Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 - Deprecate modal and orderCard component styles in next major version as unused.
 
+v9.0.0-beta.8
+------------------------------
+*July 27, 2022*
+
+### Removed
+- `~` Tilde from imports.
+- `importer` method from `scss-setup.spec.js` file.
+
 
 v9.0.0-beta.7
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "9.0.0-beta.7",
+  "version": "9.0.0-beta.8",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/_dependencies.scss
+++ b/src/scss/_dependencies.scss
@@ -21,7 +21,7 @@
 // Core variables
 // =================================
 // The colour variables are imported from https://www.npmjs.com/package/@justeat/pie-design-tokens
-@forward '~@justeat/pie-design-tokens/dist/jet';
+@forward '@justeat/pie-design-tokens/dist/jet';
 @forward 'settings/variables';
 @forward 'settings/include-media';
 @forward 'tools/helpers/breakpoints'; // breakpoint helper

--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../settings/variables' as v;
 @use '../settings/include-media' as *;
 @use '../tools/mixins/type';

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -1,5 +1,5 @@
 @use '../settings/variables' as v;
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../tools/mixins/type';
 @use '../settings/include-media' as *;
 

--- a/src/scss/components/_alerts.scss
+++ b/src/scss/components/_alerts.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../tools/mixins/alerts';
 
 @mixin alerts() {

--- a/src/scss/components/_breadcrumbs.scss
+++ b/src/scss/components/_breadcrumbs.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../settings/include-media' as *;
 @use '../tools/mixins/type';
 

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../settings/include-media' as *;
 @use '../tools/mixins/truncate';
 

--- a/src/scss/components/_media-element.scss
+++ b/src/scss/components/_media-element.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../tools/mixins/type';
 @use '../settings/include-media' as *;
 

--- a/src/scss/components/optional/_content-header.scss
+++ b/src/scss/components/optional/_content-header.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../../tools/mixins/type';
 @use '../../settings/include-media' as *;
 

--- a/src/scss/components/optional/_content-title.scss
+++ b/src/scss/components/optional/_content-title.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../../settings/variables' as v;
 @use '../../tools/mixins/type';
 

--- a/src/scss/components/optional/_cookie-warning.scss
+++ b/src/scss/components/optional/_cookie-warning.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../../tools/mixins/type';
 
 @mixin cookieWarning() {

--- a/src/scss/components/optional/_cuisines-widget.scss
+++ b/src/scss/components/optional/_cuisines-widget.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../../tools/mixins/type';
 @use '../../settings/include-media' as *;
 

--- a/src/scss/components/optional/_fullscreen-pop-over.scss
+++ b/src/scss/components/optional/_fullscreen-pop-over.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../../settings/include-media' as *;
 
 @mixin fullScreenPopOver() {

--- a/src/scss/components/optional/_listings-skeleton.scss
+++ b/src/scss/components/optional/_listings-skeleton.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../../settings/include-media' as *;
 
 @mixin listingSkeleton() {

--- a/src/scss/components/optional/_listings.scss
+++ b/src/scss/components/optional/_listings.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../../settings/include-media' as *;
 @use '../../tools/mixins/type';
 

--- a/src/scss/components/optional/_loading-indicator.scss
+++ b/src/scss/components/optional/_loading-indicator.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 
 /**
 * Components > Spinner Indicator

--- a/src/scss/components/optional/_menu.scss
+++ b/src/scss/components/optional/_menu.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../../tools/mixins/type';
 @use '../../settings/include-media' as *;
 @use '../../tools/mixins/truncate';

--- a/src/scss/components/optional/_modal.scss
+++ b/src/scss/components/optional/_modal.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../../settings/include-media' as *;
 @use '../../tools/mixins/type';
 

--- a/src/scss/components/optional/_order-card.scss
+++ b/src/scss/components/optional/_order-card.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../../settings/include-media' as *;
 @use '../../tools/mixins/type';
 @use '../../settings/variables' as v;

--- a/src/scss/components/optional/_page-banner.scss
+++ b/src/scss/components/optional/_page-banner.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../../settings/variables' as v;
 @use '../../settings/include-media' as *;
 

--- a/src/scss/components/optional/_tag.scss
+++ b/src/scss/components/optional/_tag.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../../tools/mixins/type';
 
 @mixin tag() {

--- a/src/scss/components/optional/_toast.scss
+++ b/src/scss/components/optional/_toast.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../../settings/include-media' as *;
 
 @mixin toast() {

--- a/src/scss/components/optional/_user-message.scss
+++ b/src/scss/components/optional/_user-message.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../../settings/include-media' as *;
 
 @mixin userMessage() {

--- a/src/scss/objects/_body.scss
+++ b/src/scss/objects/_body.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../settings/include-media' as *;
 
 @mixin bodyStyles() {

--- a/src/scss/objects/_buttons.scss
+++ b/src/scss/objects/_buttons.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../components/optional/loading-indicator';
 @use '../tools/mixins/type';
 @use '../settings/include-media' as *;

--- a/src/scss/objects/_form-controls.scss
+++ b/src/scss/objects/_form-controls.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../settings/include-media' as *;
 
 @mixin formControls() {

--- a/src/scss/objects/_form-toggle.scss
+++ b/src/scss/objects/_form-toggle.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../settings/include-media' as *;
 @use '../tools/functions/spacing';
 @use 'sass:math';

--- a/src/scss/objects/_links.scss
+++ b/src/scss/objects/_links.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 
 @mixin links() {
     /**

--- a/src/scss/objects/_lists.scss
+++ b/src/scss/objects/_lists.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../tools/mixins/type';
 
 @mixin lists() {

--- a/src/scss/objects/_tables.scss
+++ b/src/scss/objects/_tables.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../settings/variables' as v;
 @use '../tools/functions/units';
 

--- a/src/scss/settings/_variables.scss
+++ b/src/scss/settings/_variables.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 
 /* stylelint-disable indentation */
 // =================================

--- a/src/scss/tools/mixins/_border.scss
+++ b/src/scss/tools/mixins/_border.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../../settings/variables' as v;
 @use '../functions/spacing';
 

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -1,4 +1,4 @@
-@use '~@justeat/pie-design-tokens/dist/jet' as dt;
+@use '@justeat/pie-design-tokens/dist/jet' as dt;
 @use '../settings/include-media' as *;
 @use '../tools/mixins/border';
 @use '../tools/mixins/truncate';

--- a/src/test/scss/scss-setup.spec.js
+++ b/src/test/scss/scss-setup.spec.js
@@ -10,23 +10,6 @@ const path = require('path');
 const sassTrue = require('sass-true');
 const glob = require('glob');
 
-/**
- * Tells runSass how to handle Webpack’s tilde notation for cases such as `@use '~@justeat/pie-design-tokens/dist/jet' as dt;`
- * reference: https://www.oddbird.net/true/docs/
- * @param {string} filePath - the absolute path to an scss unit test file
- * @returns {object} an options object containing an amended filePath
- */
-function importer (filePath) {
-    let filePathCopy = filePath;
-
-    if (filePathCopy[0] === '~') {
-        filePathCopy = path.resolve('node_modules', filePathCopy.substr(1));
-    }
-
-    return { file: filePathCopy };
-}
-
-
 describe('Sass', () => {
     // All Scss unit tests should follow this naming convention
     const testFileGlob = '**/*.spec.scss';
@@ -36,5 +19,5 @@ describe('Sass', () => {
     const scssTestFiles = glob.sync(testFilePathGlob);
 
     // Run True on every file found with the describe and it methods provided
-    scssTestFiles.forEach(file => sassTrue.runSass({ file, importer }, { describe, it }));
+    scssTestFiles.forEach(file => sassTrue.runSass({ file, includePaths: ['node_modules'] }, { describe, it }));
 });


### PR DESCRIPTION
### Removed
- `~` Tilde from imports.
- `importer` method from `scss-setup.spec.js` file.