### PR TITLE
v9.0.2 – Updating colour palette references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Future Todo List
 - Make typography and utility classes silent extenders (so that they can be extended by components without importing all utility classes).
 - Update to use latest v2 PIE design tokens
 
+
+v9.0.2
+------------------------------
+*August 11, 2022*
+
+### Fixed
+- Colour palette references now point to `pie-design-tokens`
+
+
 v9.0.1
 ------------------------------
 *August 10, 2022*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/settings/_color-palette.scss
+++ b/src/scss/settings/_color-palette.scss
@@ -3,10 +3,10 @@
 // =================================
 //
 // If you’re wondering where the base colour variables are, they’re actually imported
-// from the fozzie-colour-palette module.
+// from the @justeat/pie-design-tokens module.
 //
-// Repo: https://github.com/justeat/fozzie-colour-palette
-// NPM Module: https://www.npmjs.com/package/@justeat/fozzie-colour-palette
+// Repo: https://github.com/justeat/pie-design-tokens
+// NPM Module: https://www.npmjs.com/package/@justeat/pie-design-tokens
 //
 // List of available colour variables:
-// https://github.com/justeat/fozzie-colour-palette/blob/master/src/scss/index.scss
+// https://unpkg.com/@justeat/pie-design-tokens/dist/jet.scss

--- a/src/scss/tools/mixins/_type.scss
+++ b/src/scss/tools/mixins/_type.scss
@@ -24,6 +24,12 @@
     #{$property}: math.div(strip-units.strip-units($sizeValue), v.$font-size-base) + em;
 }
 
+/**
+ * @param {String} $key – The type key you would like to reference. These are mapped to the PIE type definitions.
+ * @param {Boolean} $line-height – Specifies whether the relevant `line-height` is output alongside the `font-size` declaration.
+ * @param {String} $scale – Defines which sub-type scale definition to output from the Sass type-map.
+ * @param {Boolean} $relativeToParent – When set to true, the mixin will output the `font-size` as `em`s rather than `rem`s. By default, the `font-size` is defined relative to the root element.
+ */
 @mixin font-size($key: 'body-l', $line-height: true, $scale: 'default', $relativeToParent: false) {
     // if the $key passed in is actually just a font-size
     // then output it (may want to instead force a sass error saying to use the type map?)


### PR DESCRIPTION
### Fixed
- Colour palette references now point to `pie-design-tokens`