### PR TITLE
v9.1.0 - Adding spacing utility classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Future Todo List
 - Update to use latest v2 PIE design tokens
 
 
+v9.1.0
+------------------------------
+*August 19, 2022*
+
+### Added
+- Utilities mixin module containing a new `spacing-map` variable and `spacing-classes` mixin which can be used to generate utility classes for each spacing variable.
+- Optional spacing trump module which generates margin & padding utility classes.
+
+
 v9.0.2
 ------------------------------
 *August 11, 2022*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ v9.1.0
 ### Added
 - Utilities mixin module containing a new `spacing-map` variable and `spacing-classes` mixin which can be used to generate utility classes for each spacing variable.
 - Optional spacing trump module which generates margin & padding utility classes.
+- `u-noBorder`, `u-noBackground`, `u-hover--cursor`, and `u-visuallyDisabled` utility classes.
 
 
 v9.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ v9.1.0
 ### Added
 - Utilities mixin module containing a new `spacing-map` variable and `spacing-classes` mixin which can be used to generate utility classes for each spacing variable.
 - Optional spacing trump module which generates margin & padding utility classes.
-- `u-noBorder`, `u-noBackground`, `u-hover--cursor`, and `u-visuallyDisabled` utility classes.
+- `u-noBorder`, `u-noBackground`, and `u-hover--cursor` utility classes.
 
 
 v9.0.2

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@justeat/fozzie",
   "title": "Fozzie – Just Eat UI Web Framework",
   "description": "UI Web Framework for the Just Eat Global Platform",
-  "version": "9.0.2",
+  "version": "9.1.0",
   "main": "dist/js/index.js",
   "files": [
     "dist/js",

--- a/src/scss/_dependencies.scss
+++ b/src/scss/_dependencies.scss
@@ -98,6 +98,7 @@
  * These should always come last as they should 'trump' other properties
  */
 @forward 'trumps/utilities';
+@forward 'trumps/spacing';
 @forward 'trumps/rwd';
 
 /**

--- a/src/scss/tools/mixins/_index.scss
+++ b/src/scss/tools/mixins/_index.scss
@@ -9,3 +9,4 @@
 @forward 'alerts';
 @forward 'ratings';
 @forward 'border';
+@forward 'utilities';

--- a/src/scss/tools/mixins/_utilities.scss
+++ b/src/scss/tools/mixins/_utilities.scss
@@ -12,17 +12,39 @@ $spacing-map: map.merge((
     '': 0
 ), v.$spacing);
 
-
-/**
- * Generates spacing utility classes
- */
-@mixin spacing-classes($spacings, $prefix, $modifier: '') {
+//
+// ==========================================================================
+// Spacing classes mixin
+//
+// Generates spacing utility classes
+// ==========================================================================
+//
+// Usage:
+// @include utilities.spacing-classes(utilities.$spacing-map, 'pad', 'top') using ($spacingValue) {
+//     padding-top: spacing(#{$spacingValue});
+// }
+//
+// eg. the output of the above would generate the following
+//
+// .u-pad--top { padding-top: spacing(); }
+// .u-pad-a--top { padding-top: spacing(a); }
+// .u-pad-b--top { padding-top: spacing(b); }
+// .u-pad-c--top { padding-top: spacing(c); }
+// .u-pad-d--top { padding-top: spacing(d); }
+// .u-pad-e--top { padding-top: spacing(e); }
+// .u-pad-f--top { padding-top: spacing(f); }
+// .u-pad-g--top { padding-top: spacing(g); }
+// .u-pad-h--top { padding-top: spacing(h); }
+// .u-pad-i--top { padding-top: spacing(i); }
+// .u-pad-j--top { padding-top: spacing(j); }
+//
+@mixin spacing-classes($spacings, $name, $modifier: '') {
     @each $spacing-value, $value in $spacings {
-        $spacing-value-str: if($spacing-value == '', '', '-');
+        $separator: if($spacing-value == '', '', '-');
         $modifier-str: if($modifier == '', '', '--#{$modifier}');
-        $suffix: #{$spacing-value-str}#{$spacing-value}#{$modifier-str};
+        $suffix: #{$separator}#{$spacing-value}#{$modifier-str};
 
-        .u-#{$prefix}#{$suffix} {
+        .u-#{$name}#{$suffix} {
             @content($spacing-value);
         }
     }

--- a/src/scss/tools/mixins/_utilities.scss
+++ b/src/scss/tools/mixins/_utilities.scss
@@ -1,0 +1,29 @@
+@use '../../settings/variables' as v;
+@use 'sass:map';
+
+// ==========================================================================
+// Utilities Mixins
+// ==========================================================================
+
+/**
+ * Extends default $spacing map with an empty entry at the start
+ */
+$spacing-map: map.merge((
+    '': 0
+), v.$spacing);
+
+
+/**
+ * Generates spacing utility classes
+ */
+@mixin spacing-classes($spacings, $prefix, $modifier: '') {
+    @each $spacing-value, $value in $spacings {
+        $spacing-value-str: if($spacing-value == '', '', '-');
+        $modifier-str: if($modifier == '', '', '--#{$modifier}');
+        $suffix: #{$spacing-value-str}#{$spacing-value}#{$modifier-str};
+
+        .u-#{$prefix}#{$suffix} {
+            @content($spacing-value);
+        }
+    }
+}

--- a/src/scss/trumps/_spacing.scss
+++ b/src/scss/trumps/_spacing.scss
@@ -1,0 +1,73 @@
+@use '../tools/mixins/utilities';
+
+
+@mixin trumps-spacing() {
+    //
+    // Margin Utilities
+    // ==========================================================================
+
+    @include utilities.spacing-classes(utilities.$spacing-map, 'spacing') using ($spacingValue) {
+        margin: spacing(#{$spacingValue}) !important;
+    }
+
+    @include utilities.spacing-classes(utilities.$spacing-map, 'spacing', 'top') using ($spacingValue) {
+        margin-top: spacing(#{$spacingValue}) !important;
+    }
+
+    @include utilities.spacing-classes(utilities.$spacing-map, 'spacing', 'bottom') using ($spacingValue) {
+        margin-bottom: spacing(#{$spacingValue}) !important;
+    }
+
+    @include utilities.spacing-classes(utilities.$spacing-map, 'spacing', 'left') using ($spacingValue) {
+        margin-left: spacing(#{$spacingValue}) !important;
+    }
+
+    @include utilities.spacing-classes(utilities.$spacing-map, 'spacing', 'right') using ($spacingValue) {
+        margin-right: spacing(#{$spacingValue}) !important;
+    }
+
+    @include utilities.spacing-classes(utilities.$spacing-map, 'spacing', 'horizontal') using ($spacingValue) {
+        margin-left: spacing(#{$spacingValue}) !important;
+        margin-right: spacing(#{$spacingValue}) !important;
+    }
+
+    @include utilities.spacing-classes(utilities.$spacing-map, 'spacing', 'vertical') using ($spacingValue) {
+        margin-bottom: spacing(#{$spacingValue}) !important;
+        margin-top: spacing(#{$spacingValue}) !important;
+    }
+
+
+    //
+    // Padding Utilities
+    // ==========================================================================
+
+    @include utilities.spacing-classes(utilities.$spacing-map, 'pad') using ($spacingValue) {
+        padding: spacing(#{$spacingValue}) !important;
+    }
+
+    @include utilities.spacing-classes(utilities.$spacing-map, 'pad', 'top') using ($spacingValue) {
+        padding-top: spacing(#{$spacingValue}) !important;
+    }
+
+    @include utilities.spacing-classes(utilities.$spacing-map, 'pad', 'bottom') using ($spacingValue) {
+        padding-bottom: spacing(#{$spacingValue}) !important;
+    }
+
+    @include utilities.spacing-classes(utilities.$spacing-map, 'pad', 'left') using ($spacingValue) {
+        padding-left: spacing(#{$spacingValue}) !important;
+    }
+
+    @include utilities.spacing-classes(utilities.$spacing-map, 'pad', 'right') using ($spacingValue) {
+        padding-right: spacing(#{$spacingValue}) !important;
+    }
+
+    @include utilities.spacing-classes(utilities.$spacing-map, 'pad', 'horizontal') using ($spacingValue) {
+        padding-left: spacing(#{$spacingValue}) !important;
+        padding-right: spacing(#{$spacingValue}) !important;
+    }
+
+    @include utilities.spacing-classes(utilities.$spacing-map, 'pad', 'vertical') using ($spacingValue) {
+        padding-bottom: spacing(#{$spacingValue}) !important;
+        padding-top: spacing(#{$spacingValue}) !important;
+    }
+}

--- a/src/scss/trumps/_spacing.scss
+++ b/src/scss/trumps/_spacing.scss
@@ -2,6 +2,31 @@
 
 
 @mixin trumps-spacing() {
+    /**
+    * Spacing Trumps
+    * ===================================
+    *
+    * These can be helpful in situations where you need to apply some spacing and do not wish to create a new class name for an element.
+    * The classes generated include spacing for each of our spacing variables in all directions (left.right, top, bottom), including horizontal & vertical, for both padding & margin.
+    *
+    * The format of the generated classes is `.u-{name}--{modifier}`, modifier is an optional parameter.
+    *
+    * eg. a subset of the generated classes
+    *
+    * .u-spacing { margin: spacing(); }
+    * .u-spacing--top { margin-top: spacing(); }
+    * .u-spacing-a--top { margin-top: spacing(a); }
+    * .u-spacing-b--top { margin-top: spacing(b); }
+    *
+    * .u-pad { padding: spacing(); }
+    * .u-pad--top { padding-top: spacing(); }
+    * .u-pad-a--top { padding-top: spacing(a); }
+    * .u-pad-b--top { padding-top: spacing(b); }
+    *
+    * This is an optional component within Fozzie.
+    * If you'd like to use it in your project you can include it by adding `@include trumps-spacing();` into your SCSS dependencies file.
+    */
+
     //
     // Margin Utilities
     // ==========================================================================

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -462,22 +462,4 @@
             cursor: pointer;
         }
     }
-
-    .u-visuallyDisabled {
-        cursor: default;
-
-        &,
-        &:hover,
-        &:active,
-        &:focus {
-            background-color: $color-disabled-01;
-            border-color: $color-disabled-01;
-            color: $color-content-disabled;
-            cursor: pointer;
-
-            &.is-readable {
-                color: inherit;
-            }
-        }
-    }
 }

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -99,7 +99,7 @@
     // ==========================================================================
 
     .u-noBorder {
-        border: none;
+        border: none !important;
     }
 
     .u-bordered {
@@ -454,12 +454,12 @@
     }
 
     .u-noBackground {
-        background: none;
+        background: none !important;
     }
 
     .u-hover--cursor {
         &:hover {
-            cursor: pointer;
+            cursor: pointer !important;
         }
     }
 }

--- a/src/scss/trumps/_utilities.scss
+++ b/src/scss/trumps/_utilities.scss
@@ -94,6 +94,14 @@
         background-color: dt.$color-white;
     }
 
+    //
+    // Border Utilities
+    // ==========================================================================
+
+    .u-noBorder {
+        border: none;
+    }
+
     .u-bordered {
         @extend %u-bordered;
     }
@@ -441,6 +449,34 @@
                 left: -#{spacing()};
                 position: absolute;
                 width: 100vw;
+            }
+        }
+    }
+
+    .u-noBackground {
+        background: none;
+    }
+
+    .u-hover--cursor {
+        &:hover {
+            cursor: pointer;
+        }
+    }
+
+    .u-visuallyDisabled {
+        cursor: default;
+
+        &,
+        &:hover,
+        &:active,
+        &:focus {
+            background-color: $color-disabled-01;
+            border-color: $color-disabled-01;
+            color: $color-content-disabled;
+            cursor: pointer;
+
+            &.is-readable {
+                color: inherit;
             }
         }
     }


### PR DESCRIPTION
### Added
- Utilities mixin module containing a new `spacing-map` variable and `spacing-classes` mixin which can be used to generate utility classes for each spacing variable.
- Optional spacing trump module which generates margin & padding utility classes.
- `u-noBorder`, `u-noBackground`, and `u-hover--cursor` utility classes.

A bit more detail on the spacing utility classes — these can be included in a project via an optional mixin, similar to [the classes in the utilities module](https://github.com/justeat/fozzie/blob/cea5fac43e8cce521ae8d199a61d1fe5190745c3/src/scss/trumps/_utilities.scss#L273). The difference is that these new classes feed off of our spacing variables and include a class for each spacing e.g.

```css
.u-pad-a {}
.u-pad-b {}
...
.u-pad-a--top {}
.u-pad-b--top {}
...
.u-pad-a--bottom {}
.u-pad-b--bottom {}
...
.u-pad-a--left {}
.u-pad-b--left {}
...
.u-pad-a--right {}
.u-pad-b--right {}
...
.u-pad-a--horizontal {}
.u-pad-b--horizontal {}
...
.u-pad-a--vertical {}
.u-pad-b--vertical {}
```

These classes can be helpful in situations where you need to apply some spacing and do not wish to create a new class name for an element (naming is hard!).

Following the same style as the other utility classes, these also include the `!important` property so that they can override existing styles with higher specificity.

These changes have been tested in another project to prove that the classes are generated as expected. [Here is a Gist that was created on sassmeister.com](https://gist.github.com/DamianMullins/d9e3597d2674cf53b40af1dd17538fd6) containing the core code and the resulting output.